### PR TITLE
chore: use uv cache for chap Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,20 @@
 # Use the official Python base image
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
 # Set the working directory in the container
 WORKDIR /app
+
+# Install the project's dependencies using the lockfile and settings
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --no-dev
 
 # Install the Python dependencies
 RUN apt-get update
@@ -14,6 +26,13 @@ RUN apt-get install -y git
 COPY ./chap_core ./chap_core
 COPY ./scripts/seed.py ./scripts/seed.py
 COPY ./pyproject.toml .
+COPY ./uv.lock .
 COPY ./README.md .
 
-RUN uv sync
+# Then, add the rest of the project source code and install it
+# Installing separately from its dependencies allows optimal layer caching
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"


### PR DESCRIPTION
## Description

Uses uv cache according to guides from:

https://docs.astral.sh/uv/guides/integration/docker/
https://github.com/astral-sh/uv-docker-example/blob/main/Dockerfile