### PR TITLE
feat: add model update endpoint

### DIFF
--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -230,6 +230,7 @@ class SessionWrapper:
                 # combine model template with configuration name to make the name unique
                 configuration_display_name = configuration_stub.replace("_", " ").capitalize()
                 display_name = f"{template_display_name} [{configuration_display_name}]"
+                configured_data["configuration_name"] = configuration_display_name
             else:
                 # default configurations just use the display name of their model template
                 display_name = template_display_name

--- a/chap_core/database/model_spec_tables.py
+++ b/chap_core/database/model_spec_tables.py
@@ -37,7 +37,7 @@ class ModelSpecRead(ModelSpecBase):
     id: int
     covariates: List[FeatureType]
     target: FeatureType
-
+    configuration_name: Optional[str] = None
 
 target_type = FeatureType(name="disease_cases", display_name="Disease Cases", description="Disease Cases")
 


### PR DESCRIPTION
Summary:
- Introduced a new endpoint to update model names while preserving template prefixes.
- Added `configuration_name` attribute to the `ModelSpecRead` class.