### PR TITLE
feat: use gunicorn for chap-core

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -24,7 +24,7 @@ services:
       - "8000:8000"
     expose:
       - "8000"
-    command: /app/.venv/bin/chap serve
+    # command: /app/.venv/bin/chap serve
     working_dir: /app
     networks:
       - chap-network

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ dependencies = [
     "virtualenv>=20.34.0",
     "pydantic-geojson>=0.2.0",
     "pandera>=0.26.1",
-    "numpy>=2.1.3",                 # held back because of gluonts
+    "numpy>=2.1.3", # held back because of gluonts
+    "gunicorn>=23.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ dependencies = [
     { name = "geopy" },
     { name = "gitpython" },
     { name = "gluonts" },
-    { name = "httpx" },
+    { name = "gunicorn" },
     { name = "jsonschema" },
     { name = "libpysal" },
     { name = "matplotlib" },
@@ -308,6 +308,7 @@ requires-dist = [
     { name = "geopy", specifier = ">=2.4.1" },
     { name = "gitpython", specifier = ">=3.1.45" },
     { name = "gluonts", specifier = ">=0.16.2" },
+    { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "jsonschema", specifier = ">=4.25.1" },
     { name = "libpysal", specifier = ">=4.13.0" },
     { name = "matplotlib", specifier = ">=3.10.6" },
@@ -1001,6 +1002,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
+]
+
+[[package]]
+name = "gunicorn"
+version = "23.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031, upload-time = "2024-08-10T20:25:27.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029, upload-time = "2024-08-10T20:25:24.996Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Instead of using `chap serve` (which uses a hardcoded `uvicorn` config) switch to using `gunicorn` with `uvicorn` worker class.

Also adds env variables to allow further customization in `docker compose`

```
ENV PORT=8000
ENV TIMEOUT=60
ENV GRACEFUL_TIMEOUT=30
ENV KEEPALIVE=5
ENV FORWARDED_ALLOW_IPS="*"
```