### PR TITLE
fix: update health endpoint message to 'healthy'

### DIFF
--- a/chap_core/rest_api/v1/rest_api.py
+++ b/chap_core/rest_api/v1/rest_api.py
@@ -197,7 +197,7 @@ async def health(worker_config=Depends(get_settings)) -> HealthResponse:
     #     wf.initialize_gee_client(usecwd=True, worker_config=worker_config)
     # except GEEError as e:
     #     return HealthResponse(status="failed", message="GEE authentication might not be set up properly: " + str(e))
-    return HealthResponse(status="success", message="GEE client initialized")
+    return HealthResponse(status="success", message="healthy")
 
 
 @app.get("/version")

--- a/tests/integration/rest_api/test_integration.py
+++ b/tests/integration/rest_api/test_integration.py
@@ -189,9 +189,9 @@ def test_health_check_success(dependency_overrides):
 
 def test_common_api_get_endpoints_do_not_fail(dependency_overrides):
     endpoints = [
-        'v1/crud/model-templates',
-        'v1/crud/configured-models',
-        'v1/crud/backtests',
+        "v1/crud/model-templates",
+        "v1/crud/configured-models",
+        "v1/crud/backtests",
     ]
     for endpoint in endpoints:
         response = client.get(f"/{endpoint}")


### PR DESCRIPTION
## Summary

Updated the REST API health endpoint message from "GEE client initialized" (which was outdated) to "healthy" for clarity.

## Test plan

- Ran `make lint` - passed
- Ran `make test` - all tests passed (177 passed, 62 skipped, 6 xfailed, 1 xpassed)