### PR TITLE
fix: suppress stack trace logging for invalid version errors

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -145,5 +145,5 @@ level = NOTSET
 formatter = generic
 
 [formatter_generic]
-format = %(levelname)-5.5s [%(name)s] %(message)s
+format = %(levelname)-7.7s [%(name)s] %(message)s
 datefmt = %H:%M:%S

--- a/chap_core/rest_api/v1/rest_api.py
+++ b/chap_core/rest_api/v1/rest_api.py
@@ -4,7 +4,7 @@ import traceback
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, ORJSONResponse
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel
 
 from chap_core.api_types import EvaluationResponse
@@ -52,11 +52,15 @@ def create_api():
     @app.exception_handler(Exception)
     async def global_exception_handler(request: Request, exc: Exception):
         """Catch all unhandled exceptions and log full traceback"""
-        logger.error(f"Unhandled exception on {request.method} {request.url.path}")
-        logger.error(f"Exception type: {type(exc).__name__}")
-        logger.error(f"Exception message: {str(exc)}")
-        logger.error("Full traceback:")
-        logger.error(traceback.format_exc())
+        # Handle InvalidVersion exceptions without full stack trace
+        if isinstance(exc, InvalidVersion):
+            logger.warning(f"Invalid version string on {request.method} {request.url.path}: {str(exc)}")
+        else:
+            logger.error(f"Unhandled exception on {request.method} {request.url.path}")
+            logger.error(f"Exception type: {type(exc).__name__}")
+            logger.error(f"Exception message: {str(exc)}")
+            logger.error("Full traceback:")
+            logger.error(traceback.format_exc())
 
         return JSONResponse(
             status_code=500, content={"detail": "Internal server error", "error": str(exc), "type": type(exc).__name__}

--- a/tests/integration/rest_api/test_is_compatible.py
+++ b/tests/integration/rest_api/test_is_compatible.py
@@ -1,0 +1,56 @@
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from chap_core.rest_api.v1.rest_api import app
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_is_compatible_with_valid_version():
+    """Test that a valid version returns the expected compatibility response"""
+    response = client.get("/is-compatible?modelling_app_version=3.0.0")
+    assert response.status_code == 200
+    data = response.json()
+    assert "compatible" in data
+    assert "description" in data
+    assert isinstance(data["compatible"], bool)
+
+
+def test_is_compatible_with_invalid_version_format(caplog):
+    """Test that an invalid version returns error without stack trace"""
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/is-compatible?modelling_app_version=999.99.9-remove-orgunits-lacking-geometry.1")
+
+    # Check response format
+    assert response.status_code == 500
+    data = response.json()
+    assert "detail" in data
+    assert "error" in data
+    assert "type" in data
+    assert data["type"] == "InvalidVersion"
+    assert "Invalid version" in data["error"]
+
+    # Verify only WARNING level logs, no ERROR with stack trace
+    assert any("Invalid version string" in record.message for record in caplog.records if record.levelname == "WARNING")
+    # Verify no ERROR logs with "Full traceback" or traceback content
+    assert not any("Full traceback" in record.message for record in caplog.records if record.levelname == "ERROR")
+
+
+def test_is_compatible_with_old_version():
+    """Test that an old version returns incompatible response"""
+    response = client.get("/is-compatible?modelling_app_version=1.0.0")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["compatible"] is False
+    assert "too old" in data["description"].lower()
+
+
+def test_is_compatible_with_newer_version():
+    """Test that a newer version returns compatible response"""
+    response = client.get("/is-compatible?modelling_app_version=999.0.0")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["compatible"] is True
+    assert "compatible" in data["description"].lower()


### PR DESCRIPTION
## Summary
- Modified the global exception handler to suppress full stack traces for InvalidVersion exceptions
- InvalidVersion errors now log a simple warning instead of verbose error logs
- Maintains the same JSON error response format for API clients
- Fixed log format to display "WARNING" in full instead of truncated "WARNI"
- Added comprehensive tests for the /is-compatible endpoint

## Test plan
- [x] Added 4 new tests in `test_is_compatible.py`
- [x] Test validates that invalid versions return proper error without stack trace
- [x] All existing tests pass (`make test`)
- [x] Code passes linting (`make lint`)

## Changes
**Modified:** `chap_core/rest_api/v1/rest_api.py:52-67`
- Added `InvalidVersion` to imports
- Added conditional check in global exception handler to detect InvalidVersion
- Logs warning instead of error with traceback for InvalidVersion

**Modified:** `alembic.ini:148`
- Changed log format from `%(levelname)-5.5s` to `%(levelname)-7.7s`
- Prevents "WARNING" from being truncated to "WARNI" in logs

**Added:** `tests/integration/rest_api/test_is_compatible.py`
- Test for valid version compatibility check
- Test for invalid version format (verifies no stack trace)
- Test for old version (incompatible)
- Test for newer version (compatible)