### PR TITLE
feat: add yaml plotting and support monthly/daily data in peak_diff metrics

### DIFF
--- a/chap_core/assessment/backtest_plots/vega_lite_dash.py
+++ b/chap_core/assessment/backtest_plots/vega_lite_dash.py
@@ -23,7 +23,7 @@ def _compute_metric_df(metric_cls, flat_obs, flat_fc) -> pd.DataFrame:
 def _horizon_section(flat_obs: FlatObserved, flat_fc: FlatForecasts, geojson: Optional[dict]):
     # rmse_df = _compute_metric_df(DetailedRMSE, flat_obs, flat_fc)
     # peak_diff_df = _compute_metric_df(PeakValueDiffMetric, flat_obs, flat_fc)
-    # peak_lag_df = _compute_metric_df(PeakWeekLagMetric, flat_obs, flat_fc)
+    # peak_lag_df = _compute_metric_df(PeakPeriodLagMetric, flat_obs, flat_fc)
     above_truth_df = _compute_metric_df(RatioOfSamplesAboveTruth, flat_obs, flat_fc)
     print("Above truth df:", above_truth_df)
 
@@ -86,7 +86,7 @@ def _horizon_section(flat_obs: FlatObserved, flat_fc: FlatForecasts, geojson: Op
 def _time_section(flat_obs: FlatObserved, flat_fc: FlatForecasts):
     # rmse_df = _compute_metric_df(DetailedRMSE, flat_obs, flat_fc)
     # peak_diff_df = _compute_metric_df(PeakValueDiffMetric, flat_obs, flat_fc)
-    # peak_lag_df = _compute_metric_df(PeakWeekLagMetric, flat_obs, flat_fc)
+    # peak_lag_df = _compute_metric_df(PeakPeriodLagMetric, flat_obs, flat_fc)
     above_truth_df = _compute_metric_df(RatioOfSamplesAboveTruth, flat_obs, flat_fc)
 
     # Ensure columns needed for grouping exist

--- a/chap_core/assessment/metrics/__init__.py
+++ b/chap_core/assessment/metrics/__init__.py
@@ -12,7 +12,7 @@ from chap_core.assessment.metrics.rmse import RMSE, RMSEAggregate, DetailedRMSE
 from chap_core.assessment.metrics.mae import MAE, MAEAggregate
 from chap_core.assessment.metrics.crps import CRPS, CRPSPerLocation, DetailedCRPS
 from chap_core.assessment.metrics.crps_norm import CRPSNorm, DetailedCRPSNorm
-from chap_core.assessment.metrics.peak_diff import PeakValueDiffMetric, PeakWeekLagMetric
+from chap_core.assessment.metrics.peak_diff import PeakValueDiffMetric, PeakPeriodLagMetric
 from chap_core.assessment.metrics.above_truth import SamplesAboveTruth
 from chap_core.assessment.metrics.percentile_coverage import (
     IsWithin10th90thDetailed,
@@ -41,7 +41,7 @@ __all__ = [
     "CRPSNorm",
     "DetailedCRPSNorm",
     "PeakValueDiffMetric",
-    "PeakWeekLagMetric",
+    "PeakPeriodLagMetric",
     "SamplesAboveTruth",
     "IsWithin10th90thDetailed",
     "IsWithin25th75thDetailed",
@@ -67,7 +67,7 @@ available_metrics = {
     "detailed_crps_norm": DetailedCRPSNorm,
     "crps_norm": CRPSNorm,
     #    "peak_value_diff": PeakValueDiffMetric,
-    #    "peak_week_lag": PeakWeekLagMetric,
+    #    "peak_period_lag": PeakPeriodLagMetric,
     "samples_above_truth": SamplesAboveTruth,
     "is_within_10th_90th_detailed": IsWithin10th90thDetailed,
     "is_within_25th_75th_detailed": IsWithin25th75thDetailed,

--- a/chap_core/plotting/produce_plots_from_yaml.py
+++ b/chap_core/plotting/produce_plots_from_yaml.py
@@ -1,0 +1,305 @@
+# --- dependencies you already use ---
+import altair as alt
+import pandas as pd
+import numpy as np
+import textwrap
+import yaml
+from collections.abc import Mapping
+from datetime import datetime
+from chap_core.assessment.metrics import available_metrics
+from chap_core.assessment.evaluation import Evaluation
+from chap_core.plotting.evaluation_plot import (
+    MetricByHorizonV2Mean,
+    MetricByHorizonV2Sum,
+    MetricByHorizonAndLocationMean,
+    MetricByTimePeriodV2Mean,
+    MetricByTimePeriodV2Sum,
+    MetricByTimePeriodAndLocationV2Mean,
+    MetricMapV2,
+)
+
+METRIC_PLOT_TYPES = {
+    "metric_by_horizon_mean": MetricByHorizonV2Mean,
+    "metric_by_horizon_sum": MetricByHorizonV2Sum,
+    "metric_by_horizon_location_mean": MetricByHorizonAndLocationMean,
+    "metric_by_time_mean": MetricByTimePeriodV2Mean,
+    "metric_by_time_sum": MetricByTimePeriodV2Sum,
+    "metric_by_time_location_mean": MetricByTimePeriodAndLocationV2Mean,
+    "metric_map": MetricMapV2,
+}
+
+
+# ---------- title/text helpers (from your file) ----------
+def title_chart(text: str, width: int = 600, font_size: int = 24, pad: int = 10):
+    return (
+        alt.Chart(pd.DataFrame({"x": [0], "y": [0]}))
+        .mark_text(text=text, fontSize=font_size, fontWeight="bold", align="center", baseline="top")
+        .properties(width=width, height=font_size + pad)
+    )
+
+
+def text_chart(text, line_length=80, font_size=12, align="left", pad_bottom=50):
+    lines = textwrap.wrap(text, width=line_length)
+    df = pd.DataFrame({"line": lines, "y": range(len(lines))})
+    line_spacing = font_size + 2
+    total_height = len(lines) * line_spacing + pad_bottom
+    return (
+        alt.Chart(df)
+        .mark_text(align=align, baseline="top", fontSize=font_size)
+        .encode(text="line", y=alt.Y("y:O", axis=None))
+        .properties(height=total_height)
+    )
+
+
+def _concat_h(charts):
+    if not charts:
+        return None
+    out = charts[0]
+    for c in charts[1:]:
+        out = out | c
+    return out
+
+
+def _concat_v(charts):
+    if not charts:
+        return None
+    out = charts[0]
+    for c in charts[1:]:
+        out = out & c
+    return out
+
+
+# ---------- plot component builder ----------
+def _build_plot_component(backtest, comp: dict, context: dict):
+    type = comp.get("type")
+    if type == "metric":
+        metric_name = comp.get("metric")
+        plot_type = comp.get("plot_type", "bar")  # -> Default
+
+        if not metric_name:
+            return text_chart("Metric name missing in YAML component.", line_length=60)
+
+        metric_cls = available_metrics.get(metric_name)
+        if metric_cls is None:
+            return text_chart(
+                f"Metric '{metric_name}' not found. Available: {', '.join(sorted(available_metrics.keys()))}",
+                line_length=60,
+            )
+
+        obs = context.get("flat_observations")
+        fcst = context.get("flat_forecasts")
+
+        metric = metric_cls()
+        metric_df = metric.get_metric(obs, fcst)
+
+        print("=== METRIC:", metric_name, "PLOT_TYPE:", plot_type, "===")
+        print(metric_df.head())
+        print(metric_df.columns)
+        print("rows:", len(metric_df))
+
+        plot_class = METRIC_PLOT_TYPES.get(plot_type)
+        if plot_class is None:
+            return text_chart(
+                f"Unknown plot_type '{plot_type}' for metric '{metric_name}'.",
+                line_length=60,
+            )
+        plotter = plot_class(metric_df)
+        return plotter.plot()
+
+    return text_chart(f"Unknown plot kind: {type}", line_length=60)
+
+
+# ---------- MAIN: build_from_yaml ----------
+def build_from_yaml(yaml_str: str, backtest, **context):
+    """
+    name: TestPlot
+    title: Overskrift som vises øverst
+    configuration:
+        - row:
+            - plot:
+                type: metric
+                metric: crps_per_location
+                plot_type: metric_by_horizon_mean
+            - text:
+                value: "Litt tekst underveis."
+        - row:
+            - plot:
+                type: metric
+                metric: above_truth
+            - text:
+                value: "Ratio of Samples Above Truth (per time & horizon)."
+    """
+    # Parse YAML into python dict
+    configuration = yaml.safe_load(yaml_str)
+
+    # Retrieve data
+    title = configuration.get("title")
+    rows_spec = configuration.get("configuration", [])
+
+    # Prepare flat data
+    if "flat_observations" in context and "flat_forecasts" in context:
+        flat_obs = context["flat_observations"]
+        flat_fcst = context["flat_forecasts"]
+    else:
+        if backtest is None:
+            raise ValueError(
+                "build_from_yaml: either provide a real BackTest or pass "
+                "'flat_observations' and 'flat_forecasts' in context."
+            )
+        evaluation = Evaluation.from_backtest(backtest)
+        flat_data = evaluation.to_flat()
+        flat_obs = flat_data.observations
+        flat_fcst = flat_data.forecasts
+
+    # overwrite / extend context with normalized keys
+    context = {
+        **context,
+        "flat_observations": flat_obs,
+        "flat_forecasts": flat_fcst,
+    }
+
+    vrows = []
+    if title:
+        vrows.append(title_chart(title))
+
+    for r in rows_spec:
+        components = r.get("row", [])
+        hcharts = []
+        for c in components:
+            if "plot" in c:
+                chart = _build_plot_component(backtest, c["plot"], context)
+                hcharts.append(chart)
+            elif "text" in c:
+                txt = c["text"]
+                if isinstance(txt, dict):
+                    val = txt.get("value", "")
+                else:
+                    val = str(txt)
+                hcharts.append(text_chart(val, line_length=60))
+            else:
+                hcharts.append(text_chart("Unknown component", line_length=60))
+        vrows.append(_concat_h(hcharts))
+
+    # Compose final chart
+    chart = _concat_v([ch for ch in vrows if ch is not None])
+    return chart
+
+
+class ForecastStub:
+    def __init__(self, period, org_unit, last_seen_period, quantiles):
+        """
+        quantiles can be:
+        - Mapping: {0.1: v, 0.25: v, 0.5: v, 0.75: v, 0.9: v}
+        - float/int/np.floating: single value -> replicated across quantiles
+        - sequence aligned to [0.1, 0.25, 0.5, 0.75, 0.9]
+        """
+        self.period = period
+        self.org_unit = org_unit
+        self.last_seen_period = last_seen_period
+
+        qkeys = [0.1, 0.25, 0.5, 0.75, 0.9]
+        if isinstance(quantiles, Mapping):
+            qd = {float(k): (None if quantiles[k] is None else float(quantiles[k])) for k in quantiles}
+        elif isinstance(quantiles, (list, tuple, np.ndarray)):
+            qd = {
+                qkeys[i]: (None if quantiles[i] is None else float(quantiles[i]))
+                for i in range(min(len(qkeys), len(quantiles)))
+            }
+        elif isinstance(quantiles, (int, float, np.floating)) or quantiles is None:
+            val = None if quantiles is None else float(quantiles)
+            qd = {q: val for q in qkeys}
+        else:
+            qd = {q: None for q in qkeys}
+        for q in qkeys:
+            qd.setdefault(q, None)
+        self._qs = qd
+
+    def get_quantiles(self, qs):
+        return [self._qs.get(float(q)) for q in qs]
+
+
+class DatasetStub:
+    def __init__(self, observations):
+        self.observations = observations
+
+
+class BackTestStub:
+    def __init__(self, forecasts, dataset):
+        self.forecasts = forecasts
+        self.dataset = dataset
+
+
+class ObservationStub:
+    def __init__(self, period, org_unit, feature_name, value):
+        self.period = period  # e.g. '2023-01-02'
+        self.org_unit = org_unit  # e.g. 'loc1'
+        self.feature_name = feature_name  # 'disease_cases'
+        self.value = value  # float/int
+
+
+# ---------- main ----------
+if __name__ == "__main__":
+    DATA_DIR = "../../../../metrics/Assessment_example_chap_compatible/example_data"
+    forecasts_path = DATA_DIR + "/forecasts.csv"
+    obs_path = DATA_DIR + "/observations.csv"
+
+    def week_to_date(s):
+        dt = datetime.strptime(f"{s}-1", "%G-W%V-%u")
+        return dt.strftime("%Y-%m-%d")
+
+    # load
+    fc = pd.read_csv(forecasts_path)
+    obs = pd.read_csv(obs_path)
+
+    # just convert time_period to real dates; keep everything else as-is
+    fc_std = fc.copy()
+    fc_std["time_period"] = fc_std["time_period"].astype(str).map(week_to_date)
+
+    obs_std = obs.copy()
+    obs_std["time_period"] = obs_std["time_period"].astype(str).map(week_to_date)
+
+    # YAML
+    yaml_cfg = """
+    name: TestPlot
+    title: Overskrift som vises øverst
+    configuration:
+        - row:
+            - plot:
+                type: metric
+                metric: detailed_crps
+                plot_type: metric_by_horizon_mean
+            - text:
+                value: "CRPS by horizon mean."
+        - row:
+            - plot: 
+                type: metric
+                metric: samples_above_truth
+                plot_type: metric_by_horizon_mean
+            - text:
+                value: "Ratio of Samples Above Truth (per location & horizon)."
+        - row: 
+            - plot: 
+                type: metric
+                metric: detailed_rmse
+                plot_type: metric_by_time_location_mean
+            - text: 
+                value: "Detailed RMSE by time period and location mean."
+        - row: 
+            - plot: 
+                type: metric
+                metric: peak_value_diff
+                plot_type: metric_by_time_location_mean
+            - text: 
+                value: "Peak Value Difference by time period and location mean."
+    """
+
+    # 🔹 Pass flat_observations and flat_forecasts directly
+    chart = build_from_yaml(
+        yaml_cfg,
+        backtest=None,  # we don't use Evaluation here
+        flat_observations=obs_std,
+        flat_forecasts=fc_std,
+    )
+
+    chart.save("backtest_dashboard_from_yaml.json")
+    print("✅ Saved backtest_dashboard_from_yaml.json")

--- a/chap_core/plotting/yaml_plot.py
+++ b/chap_core/plotting/yaml_plot.py
@@ -1,0 +1,194 @@
+# --- dependencies ---
+import altair as alt
+import pandas as pd
+import textwrap
+import yaml
+
+from chap_core.database.tables import BackTest
+from chap_core.assessment.evaluation import Evaluation
+from chap_core.assessment.metrics import available_metrics
+
+from chap_core.plotting.evaluation_plot import (
+    MetricByHorizonV2Mean,
+    MetricByHorizonV2Sum,
+    MetricByHorizonAndLocationMean,
+    MetricByTimePeriodV2Mean,
+    MetricByTimePeriodV2Sum,
+    MetricByTimePeriodAndLocationV2Mean,
+    MetricMapV2,
+)
+
+alt.data_transformers.enable("vegafusion")
+
+"""
+    YAML structure example:
+
+    name: TestPlot
+    title: Overskrift som vises øverst
+    configuration:
+      - row:
+          - plot:
+              type: metric
+              metric: detailed_crps
+              plot_type: metric_by_horizon_mean
+          - text:
+              value: "Mean Detailed CRPS by horizon."
+      - row:
+          - plot:
+              type: metric
+              metric: samples_above_truth
+              plot_type: metric_by_time_mean
+          - text:
+              value: "Samples above truth by time period."
+"""
+
+METRIC_PLOT_TYPES = {
+    "metric_by_horizon_mean": MetricByHorizonV2Mean,
+    "metric_by_horizon_sum": MetricByHorizonV2Sum,
+    "metric_by_horizon_location_mean": MetricByHorizonAndLocationMean,
+    "metric_by_time_mean": MetricByTimePeriodV2Mean,
+    "metric_by_time_sum": MetricByTimePeriodV2Sum,
+    "metric_by_time_location_mean": MetricByTimePeriodAndLocationV2Mean,
+    "metric_map": MetricMapV2,
+}
+
+
+def title_chart(text: str, width: int = 600, font_size: int = 24, pad: int = 10):
+    return (
+        alt.Chart(pd.DataFrame({"x": [0], "y": [0]}))
+        .mark_text(
+            text=text,
+            fontSize=font_size,
+            fontWeight="bold",
+            align="center",
+            baseline="top",
+        )
+        .properties(width=width, height=font_size + pad)
+    )
+
+
+def text_chart(text, line_length=80, font_size=12, align="left", pad_bottom=50):
+    lines = textwrap.wrap(str(text), width=line_length)
+    df = pd.DataFrame({"line": lines, "y": range(len(lines))})
+    line_spacing = font_size + 2
+    total_height = len(lines) * line_spacing + pad_bottom
+    return (
+        alt.Chart(df)
+        .mark_text(align=align, baseline="top", fontSize=font_size)
+        .encode(text="line", y=alt.Y("y:O", axis=None))
+        .properties(height=total_height)
+    )
+
+
+def _concat_h(charts):
+    charts = [c for c in charts if c is not None]
+    if not charts:
+        return None
+    out = charts[0]
+    for c in charts[1:]:
+        out = out | c
+    return out
+
+
+def _concat_v(charts):
+    charts = [c for c in charts if c is not None]
+    if not charts:
+        return None
+    out = charts[0]
+    for c in charts[1:]:
+        out = out & c
+    return out
+
+
+def _build_plot_component(comp: dict, context: dict):
+    comp_type = comp.get("type") or comp.get("kind")
+
+    if comp_type == "metric":
+        metric_name = comp.get("metric")
+        plot_type = comp.get("plot_type")
+
+        if not metric_name:
+            return text_chart("Metric name missing in YAML component.", line_length=60)
+
+        metric_class = available_metrics.get(metric_name)
+        if metric_class is None:
+            return text_chart(
+                f"Metric '{metric_name}' not found.\nAvailable: {', '.join(sorted(available_metrics.keys()))}",
+                line_length=60,
+            )
+
+        flat_obs = context["flat_observations"]
+        flat_fcst = context["flat_forecasts"]
+
+        metric = metric_class()
+
+        metric_df = metric.compute(flat_obs, flat_fcst)
+
+        plot_class = METRIC_PLOT_TYPES.get(plot_type)
+        if plot_class is None:
+            return text_chart(
+                f"Unknown plot_type '{plot_type}' for metric '{metric_name}'.\n"
+                f"Available plot types: {', '.join(sorted(METRIC_PLOT_TYPES.keys()))}",
+                line_length=60,
+            )
+
+        required_cols = []
+
+        missing = [c for c in required_cols if c not in metric_df.columns]
+        if missing:
+            return text_chart(
+                f"Plot type '{plot_type}' requires columns {missing}, "
+                f"but metric '{metric_name}' returned columns {list(metric_df.columns)}.",
+                line_length=80,
+            )
+
+        plotter = plot_class(metric_df)
+        return plotter.plot()
+
+    return text_chart(f"Unknown plot kind: {comp_type}", line_length=60)
+
+
+def build_from_yaml(yaml_str: str, backtest: BackTest, **context):
+    configuration = yaml.safe_load(yaml_str)
+
+    title = configuration.get("title")
+    rows_spec = configuration.get("configuration", [])
+
+    if backtest is None:
+        raise ValueError("build_from_yaml requires a real BackTest object.")
+
+    evaluation = Evaluation.from_backtest(backtest)
+    flat_data = evaluation.to_flat()
+    flat_obs = flat_data.observations
+    flat_fcst = flat_data.forecasts
+
+    context = {
+        **context,
+        "flat_observations": flat_obs,
+        "flat_forecasts": flat_fcst,
+    }
+
+    vrows = []
+    if title:
+        vrows.append(title_chart(title))
+
+    for row in rows_spec:
+        components = row.get("row", [])
+        hcharts = []
+        for comp in components:
+            if "plot" in comp:
+                chart = _build_plot_component(comp["plot"], context)
+                hcharts.append(chart)
+            elif "text" in comp:
+                txt = comp["text"]
+                if isinstance(txt, dict):
+                    val = txt.get("value", "")
+                else:
+                    val = str(txt)
+                hcharts.append(text_chart(val, line_length=60))
+            else:
+                hcharts.append(text_chart("Unknown component", line_length=60))
+        vrows.append(_concat_h(hcharts))
+
+    chart = _concat_v([ch for ch in vrows if ch is not None])
+    return chart

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -4,6 +4,7 @@ from sqlmodel import SQLModel
 
 from chap_core.assessment.metrics.rmse import RMSE, RMSEAggregate, DetailedRMSE
 from chap_core.assessment.metrics.mae import MAE, MAEAggregate
+from chap_core.assessment.metrics.peak_diff import PeakValueDiffMetric, PeakPeriodLagMetric
 from chap_core.assessment.metrics import compute_all_aggregated_metrics_from_backtest
 from chap_core.assessment.flat_representations import FlatForecasts, FlatObserved
 import pytest
@@ -208,3 +209,278 @@ def test_read_example_weekly_predictions(data_path):
     data = pd.read_csv(data_path / "example_weekly_predictions.csv")
     data = SamplesWithTruth.from_pandas(data)
     print(type(data.time_period))
+
+
+# --- Peak diff metric tests ---
+
+
+@pytest.fixture
+def flat_observations_week():
+    """
+    Observations with a clear peak per location.
+
+    loc1: peak at 2023-W02, value = 20
+    loc2: peak at 2023-W03, value = 9
+    """
+    obs_df = pd.DataFrame(
+        {
+            "location": ["loc1", "loc1", "loc1", "loc2", "loc2", "loc2"],
+            "time_period": [
+                "2023-W01",
+                "2023-W02",
+                "2023-W03",
+                "2023-W01",
+                "2023-W02",
+                "2023-W03",
+            ],
+            "disease_cases": [10.0, 20.0, 15.0, 5.0, 7.0, 9.0],
+        }
+    )
+    return FlatObserved(obs_df)
+
+
+@pytest.fixture
+def flat_forecasts_week():
+    """
+    Forecasts with one horizon where we control the forecast peak.
+
+    horizon_distance = 1 for all.
+
+    loc1 forecast_mean by week:
+        W01: 8
+        W02: 18 (peak)
+        W03: 12
+
+    loc2 forecast_mean by week:
+        W01: 4
+        W02: 10 (peak)
+        W03: 6
+    """
+    fc_df = pd.DataFrame(
+        {
+            "location": ["loc1", "loc1", "loc1", "loc2", "loc2", "loc2"],
+            "time_period": [
+                "2023-W01",
+                "2023-W02",
+                "2023-W03",
+                "2023-W01",
+                "2023-W02",
+                "2023-W03",
+            ],
+            "horizon_distance": [1, 1, 1, 1, 1, 1],
+            "sample": [0, 0, 0, 0, 0, 0],
+            "forecast": [8.0, 18.0, 12.0, 4.0, 10.0, 6.0],
+        }
+    )
+    return FlatForecasts(fc_df)
+
+
+def test_peak_value_diff_metric_weekly(flat_observations_week, flat_forecasts_week):
+    """
+    PeakValueDiffMetric should return:
+        metric = truth_peak_value - pred_peak_value, per location & horizon.
+
+    For the fixtures:
+
+    loc1:
+        truth peak: 20 (at 2023-W02)
+        pred peak:  18 (at 2023-W02)
+        => metric = 20 - 18 = 2
+
+    loc2:
+        truth peak:  9 (at 2023-W03)
+        pred peak:  10 (at 2023-W02)
+        => metric = 9 - 10 = -1
+    """
+    metric = PeakValueDiffMetric()
+    result = metric.compute(flat_observations_week, flat_forecasts_week)
+
+    result_sorted = result.sort_values(["location", "horizon_distance"]).reset_index(drop=True)
+
+    expected = pd.DataFrame(
+        {
+            "location": ["loc1", "loc2"],
+            "time_period": ["2023-W02", "2023-W03"],
+            "horizon_distance": [1, 1],
+            "metric": [2.0, -1.0],
+        }
+    )
+
+    expected_sorted = expected.sort_values(["location", "horizon_distance"]).reset_index(drop=True)
+    pd.testing.assert_frame_equal(result_sorted, expected_sorted)
+
+
+def test_peak_period_lag_metric_weekly(flat_observations_week, flat_forecasts_week):
+    """
+    PeakPeriodLagMetric should return:
+        metric = time_index(pred_peak) - time_index(truth_peak)
+
+    With weekly strings, that corresponds to:
+    - same week -> 0
+    - one week earlier than truth -> -1
+    - one week later than truth -> +1
+
+    For our fixtures:
+
+    loc1:
+        truth peak: 2023-W02
+        pred peak:  2023-W02
+        => lag = 0
+
+    loc2:
+        truth peak: 2023-W03
+        pred peak:  2023-W02
+        => lag = index(W02) - index(W03) = -1
+    """
+    metric = PeakPeriodLagMetric()
+    result = metric.compute(flat_observations_week, flat_forecasts_week)
+
+    result_sorted = result.sort_values(["location", "horizon_distance"]).reset_index(drop=True)
+
+    expected = pd.DataFrame(
+        {
+            "location": ["loc1", "loc2"],
+            "time_period": ["2023-W02", "2023-W03"],
+            "horizon_distance": [1, 1],
+            "metric": [0.0, -1.0],
+        }
+    )
+
+    expected_sorted = expected.sort_values(["location", "horizon_distance"]).reset_index(drop=True)
+    pd.testing.assert_frame_equal(result_sorted, expected_sorted)
+
+
+@pytest.fixture
+def flat_observations_monthly():
+    """
+    Observations with a clear monthly peak per location.
+
+    loc1: peak at 2023-02, value = 20
+    loc2: peak at 2023-03, value = 9
+    """
+    obs_df = pd.DataFrame(
+        {
+            "location": ["loc1", "loc1", "loc1", "loc2", "loc2", "loc2"],
+            "time_period": [
+                "2023-01",
+                "2023-02",
+                "2023-03",
+                "2023-01",
+                "2023-02",
+                "2023-03",
+            ],
+            "disease_cases": [10.0, 20.0, 15.0, 5.0, 7.0, 9.0],
+        }
+    )
+    return FlatObserved(obs_df)
+
+
+@pytest.fixture
+def flat_forecasts_monthly():
+    """
+    Forecasts with one horizon where we control the forecast peak.
+
+    horizon_distance = 1 for all.
+
+    loc1 forecast_mean by month:
+        2023-01: 8
+        2023-02: 18 (peak)
+        2023-03: 12
+
+    loc2 forecast_mean by month:
+        2023-01: 4
+        2023-02: 10 (peak)
+        2023-03: 6
+    """
+    fc_df = pd.DataFrame(
+        {
+            "location": ["loc1", "loc1", "loc1", "loc2", "loc2", "loc2"],
+            "time_period": [
+                "2023-01",
+                "2023-02",
+                "2023-03",
+                "2023-01",
+                "2023-02",
+                "2023-03",
+            ],
+            "horizon_distance": [1, 1, 1, 1, 1, 1],
+            "sample": [0, 0, 0, 0, 0, 0],
+            "forecast": [8.0, 18.0, 12.0, 4.0, 10.0, 6.0],
+        }
+    )
+    return FlatForecasts(fc_df)
+
+
+def test_peak_value_diff_metric_monthly(flat_observations_monthly, flat_forecasts_monthly):
+    """
+    PeakValueDiffMetric (monthly) should return:
+        metric = truth_peak_value - pred_peak_value, per location & horizon.
+
+    For the fixtures:
+
+    loc1:
+        truth peak: 20 at 2023-02
+        pred peak:  18 at 2023-02
+        => metric = 20 - 18 = 2
+
+    loc2:
+        truth peak:  9 at 2023-03
+        pred peak:  10 at 2023-02
+        => metric = 9 - 10 = -1
+    """
+    metric = PeakValueDiffMetric()
+    result = metric.compute(flat_observations_monthly, flat_forecasts_monthly)
+
+    result_sorted = result.sort_values(["location", "horizon_distance"]).reset_index(drop=True)
+
+    expected = pd.DataFrame(
+        {
+            "location": ["loc1", "loc2"],
+            "time_period": ["2023-02", "2023-03"],
+            "horizon_distance": [1, 1],
+            "metric": [2.0, -1.0],
+        }
+    )
+    expected_sorted = expected.sort_values(["location", "horizon_distance"]).reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(result_sorted, expected_sorted)
+
+
+def test_peak_period_lag_metric_monthly(flat_observations_monthly, flat_forecasts_monthly):
+    """
+    PeakPeriodLagMetric (monthly) should return:
+        metric = time_index(pred_peak) - time_index(truth_peak)
+
+    With monthly strings and _time_index logic:
+      index = year * 12 + (month - 1)
+
+    So difference of one month earlier = -1, one month later = +1.
+
+    For our fixtures:
+
+    loc1:
+        truth peak: 2023-02
+        pred peak:  2023-02
+        => lag = 0
+
+    loc2:
+        truth peak: 2023-03
+        pred peak:  2023-02
+        => lag = index(2023-02) - index(2023-03) = -1
+    """
+    metric = PeakPeriodLagMetric()
+    result = metric.compute(flat_observations_monthly, flat_forecasts_monthly)
+
+    result_sorted = result.sort_values(["location", "horizon_distance"]).reset_index(drop=True)
+
+    expected = pd.DataFrame(
+        {
+            "location": ["loc1", "loc2"],
+            "time_period": ["2023-02", "2023-03"],
+            "horizon_distance": [1, 1],
+            "metric": [0.0, -1.0],
+        }
+    )
+    expected_sorted = expected.sort_values(["location", "horizon_distance"]).reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(result_sorted, expected_sorted)


### PR DESCRIPTION
## Summary

- Update peak_diff metrics to support weekly, monthly, and daily time periods (not just weekly)
- Rename `PeakWeekLagMetric` to `PeakPeriodLagMetric` for clarity
- Add `yaml_plot.py` for CHAP-compatible YAML-based plotting
- Add `produce_plots_from_yaml.py` demo script
- Add tests for peak_diff metrics with weekly and monthly data

This PR extracts the valuable new features from PR #126 (which had significant merge conflicts due to overlapping metric changes that were already merged via different commits).

## Test plan

- [x] Existing tests pass
- [x] New peak_diff tests for weekly data pass
- [x] New peak_diff tests for monthly data pass