### PR TITLE
refactor: reduce verbose logging output in CLI commands

### DIFF
--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -274,7 +274,7 @@ def evaluate2(
     logger.info(
         f"Running backtest with {backtest_params.n_splits} splits, {backtest_params.n_periods} periods, stride {backtest_params.stride}"
     )
-    logger.info(f"Including {historical_context_years} years of historical context for plotting")
+    logger.debug(f"Including {historical_context_years} years of historical context for plotting")
     evaluation = Evaluation.create(
         configured_model=configured_model_db,
         estimator=estimator,

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -435,9 +435,7 @@ class SessionWrapper:
 
         if dataset.geojson:
             logger.info(f"Loading polygons from geojson for dataset id {dataset_id}")
-            new_dataset.set_polygons(Polygons.from_geojson(
-                json.loads(dataset.geojson), id_property="district"
-            ).data)
+            new_dataset.set_polygons(Polygons.from_geojson(json.loads(dataset.geojson), id_property="district").data)
 
         return new_dataset
 

--- a/chap_core/docker_helper_functions.py
+++ b/chap_core/docker_helper_functions.py
@@ -41,10 +41,10 @@ def run_command_through_docker_container(
         logging.error(f"Current directory is {os.getcwd()}")
         raise
 
-    logger.info(
+    logger.debug(
         f"Running command {command} in docker image {docker_image_name} with mount {working_dir_full_path}:/home/run/"
     )
-    logger.info(
+    logger.debug(
         f"Equivalent docker command: docker run -w /home/run -v {working_dir_full_path}:/home/run/ {docker_image_name} {command}"
     )
     container = client.containers.run(

--- a/chap_core/models/external_model.py
+++ b/chap_core/models/external_model.py
@@ -169,11 +169,11 @@ class ExternalModel(ExternalModelBase):
         return self
 
     def predict(self, historic_data: DataSet, future_data: DataSet) -> DataSet:
-        logging.info("Running predict")
+        logging.debug("Running predict")
         future_data_name = Path(self._working_dir) / "future_data.csv"
         historic_data_name = Path(self._working_dir) / "historic_data.csv"
         start_time = future_data.start_timestamp
-        logger.info(f"Predicting on dataset from {start_time} to {future_data.end_timestamp}")
+        logger.debug(f"Predicting on dataset from {start_time} to {future_data.end_timestamp}")
 
         for filename, dataset in [
             (future_data_name, future_data),

--- a/chap_core/models/utils.py
+++ b/chap_core/models/utils.py
@@ -61,7 +61,7 @@ def _get_model_code_base(model_path, base_working_dir, run_dir_type):
         model_name = Path(model_path).name
 
     run_dir_type, working_dir = _get_working_dir(model_path, base_working_dir, run_dir_type, model_name)
-    logger.info(f"Writing results to {working_dir}")
+    logger.debug(f"Writing results to {working_dir}")
 
     if is_github:
         working_dir.mkdir(parents=True)
@@ -78,10 +78,10 @@ def _get_model_code_base(model_path, base_working_dir, run_dir_type):
             logger.info(f"Cloning repository {model_path} (shallow clone)")
             repo = git.Repo.clone_from(model_path, working_dir, depth=1)
     elif run_dir_type == "use_existing":
-        logging.info("Not copying any model files, using existing directory")
+        logging.debug("Not copying any model files, using existing directory")
     else:
         # copy contents of model_path to working_dir
-        logger.info(f"Copying files from {model_path} to {working_dir}")
+        logger.debug(f"Copying files from {model_path} to {working_dir}")
         shutil.copytree(
             model_path,
             working_dir,
@@ -134,19 +134,19 @@ def get_model_template_from_directory_or_github_url(
     """
 
     if is_chapkit_model:
-        logger.info("Model is chapkit model")
+        logger.debug("Model is chapkit model")
         # For now, we assume that if a model template has a url on localhost it is
         # a chapkit model
         template = ExternalChapkitModelTemplate(model_template_path)
         assert template.name is not None, template
         return template
 
-    logger.info(
+    logger.debug(
         f"Getting model template from {model_template_path}. Ignore env: {ignore_env}. Base working dir: {base_working_dir}. Run dir type: {run_dir_type}"
     )
     working_dir = _get_model_code_base(model_template_path, base_working_dir, run_dir_type)
 
-    logger.info(f"Current directory is {os.getcwd()}, working dir is {working_dir.absolute()}")
+    logger.debug(f"Current directory is {os.getcwd()}, working dir is {working_dir.absolute()}")
     assert os.path.isdir(working_dir), working_dir
     assert os.path.isdir(os.path.abspath(working_dir)), working_dir
 

--- a/chap_core/runners/command_line_runner.py
+++ b/chap_core/runners/command_line_runner.py
@@ -20,7 +20,7 @@ class CommandLineRunner(Runner):
 
 def run_command(command: str, working_directory=Path(".")):
     """Runs a unix command using subprocess"""
-    logging.info(f"Running command: {command}")
+    logging.debug(f"Running command: {command}")
     # command = command.split()
 
     try:
@@ -103,7 +103,7 @@ class CommandLineTrainPredictRunner(TrainPredictRunner):
         keys = self._handle_polygons(self._train_command, keys, polygons_file_name)
         keys = self._handle_config(self._train_command, keys)
         command = self._format_command(self._train_command, keys)
-        logger.info(f"Running command {command}")
+        logger.debug(f"Running command {command}")
         return self._runner.run_command(command)
 
     def predict(self, model_file_name, historic_data, future_data, output_file, polygons_file_name=None):

--- a/chap_core/runners/docker_runner.py
+++ b/chap_core/runners/docker_runner.py
@@ -19,7 +19,7 @@ class DockerRunner(Runner):
         self._model_configuration_filename = model_configuration_filename
 
     def run_command(self, command):
-        logger.info(f"Running command {command} in docker container {self._docker_name} in {self._working_dir}")
+        logger.debug(f"Running command {command} in docker container {self._docker_name} in {self._working_dir}")
         return run_command_through_docker_container(self._docker_name, self._working_dir, command)
 
     def teardown(self):

--- a/chap_core/runners/helper_functions.py
+++ b/chap_core/runners/helper_functions.py
@@ -32,8 +32,8 @@ def get_train_predict_runner_from_model_template_config(
         runner_type = ""
         skip_environment = True
 
-    logger.info(f"skip_environement: {skip_environment}, runner_type: {runner_type}")
-    logger.info(f"Model Configuration: {model_configuration}")
+    logger.debug(f"skip_environment: {skip_environment}, runner_type: {runner_type}")
+    logger.debug(f"Model Configuration: {model_configuration}")
     yaml_filename = "model_configuration_for_run.yaml"
     model_configuration_file = working_dir / yaml_filename
     with open(model_configuration_file, "w") as file:
@@ -64,7 +64,7 @@ def get_train_predict_runner_from_model_template_config(
         else:
             assert model_template_config.docker_env is not None
 
-        logging.info(f"Docker image is {model_template_config.docker_env.image}")
+        logging.debug(f"Docker image is {model_template_config.docker_env.image}")
         command_runner = DockerRunner(model_template_config.docker_env.image, working_dir)
         return DockerTrainPredictRunner(command_runner, train_command, predict_command, yaml_filename)
     else:
@@ -86,7 +86,7 @@ def get_train_predict_runner(
     If runner_type is "docker", the mlproject file is parsed to create a runner
     if skip_environment, mlflow and docker is not used, instead returning a TrainPredictRunner that uses the command line
     """
-    logger.info(f"skip_environement: {skip_environment}, runner_type: {runner_type}")
+    logger.debug(f"skip_environment: {skip_environment}, runner_type: {runner_type}")
     if skip_environment or runner_type == "docker":
         working_dir = mlproject_file.parent
 

--- a/chap_core/runners/mlflow_runner.py
+++ b/chap_core/runners/mlflow_runner.py
@@ -46,7 +46,7 @@ class MlFlowTrainPredictRunner(TrainPredictRunner):
             raise ModelFailedException(str(e)) from e
 
     def predict(self, model_file_name, historic_data, future_data, output_file, polygons_file_name=None):
-        logging.info("Running predict with output to %s" % output_file)
+        logging.debug("Running predict with output to %s" % output_file)
         if self.model_configuration_filename is not None:
             ("Model configuration not supported for MLflow runner")
         params = {
@@ -55,7 +55,7 @@ class MlFlowTrainPredictRunner(TrainPredictRunner):
             "model": str(model_file_name),
             "out_file": str(output_file),
         }
-        logging.info("Params for predict: %s" % params)
+        logging.debug("Params for predict: %s" % params)
         extra_params = {
             "model_config": str(self.model_configuration_filename) if self.model_configuration_filename else None,
         }

--- a/chap_core/spatio_temporal_data/temporal_dataclass.py
+++ b/chap_core/spatio_temporal_data/temporal_dataclass.py
@@ -362,9 +362,10 @@ class DataSet(Generic[FeaturesT]):
             )
 
         data_dict = {}
+        non_string_locations = []
         for location, data in df.groupby("location"):
             if not isinstance(location, str):
-                logging.warning(f"Location {location} is not a string, converting to string")
+                non_string_locations.append(location)
                 location = str(location)
 
             time_element = data["time_period"].iloc[0]
@@ -374,6 +375,9 @@ class DataSet(Generic[FeaturesT]):
 
             data_dict[location] = dataclass.from_pandas(data.sort_values(by="time_period"), fill_missing)
         data_dict = cls._fill_missing(data_dict)
+
+        if non_string_locations:
+            logging.warning(f"{len(non_string_locations)} location(s) are not strings, converting to strings")
 
         return cls(data_dict)
 


### PR DESCRIPTION
## Summary
- Consolidate repeated location warnings into a single message (e.g., "5 location(s) are not strings" instead of 5 separate warnings)
- Change internal implementation details from INFO to DEBUG level across model loading, command execution, and docker/mlflow runners
- Keep essential user-facing messages at INFO level (dataset loading, model cloning, backtest progress, completion)

## Test plan
- [x] Run `make lint` - passed
- [x] Run `make test` - 263 passed
- [x] Manual test of `evaluate2` command shows cleaner output