### PR TITLE
feat: auto-start chapkit service for directory-based models

### DIFF
--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -255,44 +255,45 @@ def evaluate2(
         is_chapkit_model=run_config.is_chapkit_model,
     )
 
-    model = template.get_model(configuration)
-    estimator = model()
+    with template:
+        model = template.get_model(configuration)
+        estimator = model()
 
-    model_template_db = ModelTemplateDB(
-        id=template.model_template_config.name,
-        name=template.model_template_config.name,
-        version=template.model_template_config.version or "unknown",
-    )
+        model_template_db = ModelTemplateDB(
+            id=template.model_template_config.name,
+            name=template.model_template_config.name,
+            version=template.model_template_config.version or "unknown",
+        )
 
-    configured_model_db = ConfiguredModelDB(
-        id="cli_eval",
-        model_template_id=model_template_db.id,
-        model_template=model_template_db,
-        configuration=configuration.model_dump() if configuration else {},
-    )
+        configured_model_db = ConfiguredModelDB(
+            id="cli_eval",
+            model_template_id=model_template_db.id,
+            model_template=model_template_db,
+            configuration=configuration.model_dump() if configuration else {},
+        )
 
-    logger.info(
-        f"Running backtest with {backtest_params.n_splits} splits, {backtest_params.n_periods} periods, stride {backtest_params.stride}"
-    )
-    logger.debug(f"Including {historical_context_years} years of historical context for plotting")
-    evaluation = Evaluation.create(
-        configured_model=configured_model_db,
-        estimator=estimator,
-        dataset=dataset,
-        backtest_params=backtest_params,
-        backtest_name=f"{model_name}_evaluation",
-        historical_context_years=historical_context_years,
-    )
+        logger.info(
+            f"Running backtest with {backtest_params.n_splits} splits, {backtest_params.n_periods} periods, stride {backtest_params.stride}"
+        )
+        logger.debug(f"Including {historical_context_years} years of historical context for plotting")
+        evaluation = Evaluation.create(
+            configured_model=configured_model_db,
+            estimator=estimator,
+            dataset=dataset,
+            backtest_params=backtest_params,
+            backtest_name=f"{model_name}_evaluation",
+            historical_context_years=historical_context_years,
+        )
 
-    logger.info(f"Exporting evaluation to {output_file}")
-    evaluation.to_file(
-        filepath=output_file,
-        model_name=model_name,
-        model_configuration=configuration.model_dump() if configuration else {},
-        model_version=template.model_template_config.version or "unknown",
-    )
+        logger.info(f"Exporting evaluation to {output_file}")
+        evaluation.to_file(
+            filepath=output_file,
+            model_name=model_name,
+            model_configuration=configuration.model_dump() if configuration else {},
+            model_version=template.model_template_config.version or "unknown",
+        )
 
-    logger.info(f"Evaluation complete. Results saved to {output_file}")
+        logger.info(f"Evaluation complete. Results saved to {output_file}")
 
 
 def register_commands(app):

--- a/chap_core/exceptions.py
+++ b/chap_core/exceptions.py
@@ -19,3 +19,9 @@ class ModelConfigurationException(Exception): ...
 
 
 class InvalidDateError(Exception): ...
+
+
+class ChapkitServiceStartupError(Exception):
+    """Raised when a chapkit model service fails to start."""
+
+    ...

--- a/chap_core/models/chapkit_service_manager.py
+++ b/chap_core/models/chapkit_service_manager.py
@@ -1,0 +1,180 @@
+"""
+Manages lifecycle of chapkit model services started from local directories.
+"""
+
+import logging
+import os
+import signal
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from chap_core.exceptions import ChapkitServiceStartupError
+
+logger = logging.getLogger(__name__)
+
+
+def find_available_port(start_port: int = 8000, max_attempts: int = 100) -> int:
+    """Find an available port starting from start_port."""
+    for port in range(start_port, start_port + max_attempts):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            try:
+                sock.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    raise ChapkitServiceStartupError(f"Could not find available port in range {start_port}-{start_port + max_attempts}")
+
+
+def is_url(path_or_url: str) -> bool:
+    """Detect if input is a URL or a directory path."""
+    return path_or_url.startswith(("http://", "https://"))
+
+
+class ChapkitServiceManager:
+    """
+    Manages the lifecycle of a chapkit model service subprocess.
+
+    Usage:
+        with ChapkitServiceManager("/path/to/model") as manager:
+            url = manager.url
+            # Use the service...
+    """
+
+    def __init__(
+        self,
+        model_directory: str,
+        port: Optional[int] = None,
+        host: str = "127.0.0.1",
+        startup_timeout: int = 60,
+    ):
+        """
+        Initialize the service manager.
+
+        Args:
+            model_directory: Path to the chapkit model directory
+            port: Specific port to use, or None to auto-detect
+            host: Host to bind to (default: 127.0.0.1)
+            startup_timeout: Seconds to wait for service to become healthy
+        """
+        self.model_directory = Path(model_directory).resolve()
+        self.host = host
+        self.port = port
+        self.startup_timeout = startup_timeout
+        self._process: Optional[subprocess.Popen] = None
+        self._url: Optional[str] = None
+
+    @property
+    def url(self) -> str:
+        """Return the URL of the running service."""
+        if self._url is None:
+            raise RuntimeError("Service not started. Use as context manager.")
+        return self._url
+
+    def _validate_directory(self) -> None:
+        """Validate that the model directory exists and is valid."""
+        if not self.model_directory.exists():
+            raise ChapkitServiceStartupError(f"Model directory does not exist: {self.model_directory}")
+        if not self.model_directory.is_dir():
+            raise ChapkitServiceStartupError(f"Model path is not a directory: {self.model_directory}")
+
+    def _start_service(self) -> None:
+        """Start the fastapi dev server as a subprocess."""
+        if self.port is None:
+            self.port = find_available_port()
+
+        self._url = f"http://{self.host}:{self.port}"
+
+        command = [
+            "uv",
+            "run",
+            "fastapi",
+            "dev",
+            "--port",
+            str(self.port),
+            "--host",
+            self.host,
+        ]
+
+        logger.info(f"Starting chapkit service at {self._url} from {self.model_directory}")
+
+        self._process = subprocess.Popen(
+            command,
+            cwd=self.model_directory,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            preexec_fn=os.setsid if os.name != "nt" else None,
+        )
+
+    def _wait_for_healthy(self) -> None:
+        """Wait for the service to become healthy."""
+        start_time = time.time()
+        health_url = f"{self._url}/health"
+
+        while time.time() - start_time < self.startup_timeout:
+            if self._process.poll() is not None:
+                stdout, stderr = self._process.communicate()
+                raise ChapkitServiceStartupError(
+                    f"Service process died during startup.\nstdout: {stdout.decode()}\nstderr: {stderr.decode()}"
+                )
+
+            try:
+                response = httpx.get(health_url, timeout=2)
+                if response.status_code == 200:
+                    data = response.json()
+                    if data.get("status") == "healthy":
+                        logger.info(f"Service at {self._url} is healthy")
+                        return
+            except (httpx.RequestError, httpx.HTTPStatusError):
+                pass
+
+            logger.debug(f"Waiting for service at {health_url}...")
+            time.sleep(1)
+
+        self._stop_service()
+        raise ChapkitServiceStartupError(
+            f"Service at {self._url} did not become healthy within {self.startup_timeout} seconds"
+        )
+
+    def _stop_service(self) -> None:
+        """Stop the running service subprocess gracefully."""
+        if self._process is None:
+            return
+
+        logger.info(f"Stopping chapkit service at {self._url}")
+
+        try:
+            if os.name != "nt":
+                os.killpg(os.getpgid(self._process.pid), signal.SIGTERM)
+            else:
+                self._process.terminate()
+
+            try:
+                self._process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                logger.warning("Service did not stop gracefully, killing...")
+                if os.name != "nt":
+                    os.killpg(os.getpgid(self._process.pid), signal.SIGKILL)
+                else:
+                    self._process.kill()
+                self._process.wait()
+        except ProcessLookupError:
+            pass
+        finally:
+            self._process = None
+            self._url = None
+
+    def __enter__(self) -> "ChapkitServiceManager":
+        """Start the service when entering context."""
+        self._validate_directory()
+        self._start_service()
+        self._wait_for_healthy()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Stop the service when exiting context."""
+        self._stop_service()

--- a/chap_core/models/model_template.py
+++ b/chap_core/models/model_template.py
@@ -82,6 +82,14 @@ class ModelTemplate:
     def __str__(self):
         return f"ModelTemplate: {self._model_template_config}"
 
+    def __enter__(self) -> "ModelTemplate":
+        """Context manager entry (no-op for compatibility with ExternalChapkitModelTemplate)."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Context manager exit (no-op for compatibility with ExternalChapkitModelTemplate)."""
+        pass
+
     def get_config_class(self) -> type[ModelConfiguration]:
         """This will probably not be used"""
 

--- a/chap_core/models/utils.py
+++ b/chap_core/models/utils.py
@@ -135,10 +135,12 @@ def get_model_template_from_directory_or_github_url(
 
     if is_chapkit_model:
         logger.debug("Model is chapkit model")
-        # For now, we assume that if a model template has a url on localhost it is
-        # a chapkit model
+        # ExternalChapkitModelTemplate now handles both URLs and directory paths.
+        # For directory mode, the caller must use it as a context manager.
         template = ExternalChapkitModelTemplate(model_template_path)
-        assert template.name is not None, template
+        # Only verify name for URL mode (service already running)
+        if template._is_url_mode:
+            assert template.name is not None, template
         return template
 
     logger.debug(

--- a/tests/external/test_external_chapkit_model.py
+++ b/tests/external/test_external_chapkit_model.py
@@ -1,10 +1,17 @@
-from chap_core.assessment.dataset_splitting import train_test_generator
-from chap_core.models.external_chapkit_model import ExternalChapkitModelTemplate
-import pytest
-import httpx
+from unittest.mock import patch
 
-# from chap_core.models.external_chapkit_model import ExternalChapkitModel, ExternalChapkitModelTemplate
+import httpx
+import pytest
+
+from chap_core.assessment.dataset_splitting import train_test_generator
+from chap_core.exceptions import ChapkitServiceStartupError
 from chap_core.file_io.example_data_set import datasets
+from chap_core.models.chapkit_service_manager import (
+    ChapkitServiceManager,
+    find_available_port,
+    is_url,
+)
+from chap_core.models.external_chapkit_model import ExternalChapkitModelTemplate
 
 model_url = "http://localhost:8003"
 
@@ -54,3 +61,69 @@ def test_chapkit_model_wrapping(service_available):
     template = ExternalChapkitModelTemplate(service_available)
     config = template.get_model_template_config()
     print(config)
+
+
+class TestIsUrl:
+    def test_http_url(self):
+        assert is_url("http://localhost:8000") is True
+
+    def test_https_url(self):
+        assert is_url("https://example.com/model") is True
+
+    def test_directory_path(self):
+        assert is_url("/path/to/model") is False
+
+    def test_relative_path(self):
+        assert is_url("./models/my_model") is False
+
+
+class TestFindAvailablePort:
+    def test_finds_port(self):
+        port = find_available_port(start_port=10000)
+        assert 10000 <= port < 10100
+
+    def test_raises_when_no_ports_available(self):
+        with patch("socket.socket") as mock_socket:
+            mock_instance = mock_socket.return_value.__enter__.return_value
+            mock_instance.bind.side_effect = OSError
+            with pytest.raises(ChapkitServiceStartupError):
+                find_available_port(start_port=10000, max_attempts=5)
+
+
+class TestChapkitServiceManager:
+    def test_validates_nonexistent_directory(self, tmp_path):
+        manager = ChapkitServiceManager(str(tmp_path / "nonexistent"))
+        with pytest.raises(ChapkitServiceStartupError, match="does not exist"):
+            manager._validate_directory()
+
+    def test_url_property_before_start(self, tmp_path):
+        manager = ChapkitServiceManager(str(tmp_path))
+        with pytest.raises(RuntimeError, match="Service not started"):
+            _ = manager.url
+
+
+class TestExternalChapkitModelTemplateDetection:
+    def test_detects_url_mode(self):
+        template = ExternalChapkitModelTemplate("http://localhost:8000")
+        assert template._is_url_mode is True
+
+    def test_detects_directory_mode(self, tmp_path):
+        template = ExternalChapkitModelTemplate(str(tmp_path))
+        assert template._is_url_mode is False
+
+
+class TestExternalChapkitModelTemplateDirectoryMode:
+    def test_raises_without_context_manager_is_healthy(self, tmp_path):
+        template = ExternalChapkitModelTemplate(str(tmp_path))
+        with pytest.raises(RuntimeError, match="context manager"):
+            template.is_healthy()
+
+    def test_raises_without_context_manager_get_model(self, tmp_path):
+        template = ExternalChapkitModelTemplate(str(tmp_path))
+        with pytest.raises(RuntimeError, match="context manager"):
+            template.get_model({})
+
+    def test_raises_without_context_manager_name(self, tmp_path):
+        template = ExternalChapkitModelTemplate(str(tmp_path))
+        with pytest.raises(RuntimeError, match="context manager"):
+            _ = template.name


### PR DESCRIPTION
## Summary
- Add ChapkitServiceManager to automatically start/stop chapkit services when using local model directories
- ExternalChapkitModelTemplate now supports both URL mode (existing) and directory mode (new) via context manager
- ModelTemplate gains no-op context manager methods for compatibility
- Update evaluate2 CLI to use template as context manager

## Test plan
- [x] Tested with `chap evaluate2 ../chapkit/examples/ml_r/ --dataset-csv laos.csv --output-file tmp.nc --backtest-params.n-splits 1 --run-config.is-chapkit-model`
- [x] Unit tests pass
- [x] Lint passes