### PR TITLE
perf(cli): improve startup time with lazy imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ config/configured_models/*
 # === OS-Specific ===
 .DS_Store
 chap_core.egg-info
+
+# === Generated Files ===
+chap_core/cli_endpoints/_generated.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 WORKDIR /app
 
-COPY --chown=root:root ./pyproject.toml ./uv.lock ./.python-version ./gunicorn.conf.py ./alembic.ini README.md ./
+COPY --chown=root:root ./pyproject.toml ./uv.lock ./.python-version ./gunicorn.conf.py ./alembic.ini README.md ./hatch_build.py ./
 COPY --chown=root:root ./chap_core ./chap_core
 COPY --chown=root:root ./config ./config
 COPY --chown=root:root ./alembic ./alembic

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -23,7 +23,7 @@ ENV PATH="/root/.cargo/bin:$PATH"
 WORKDIR /app
 
 # Copy chap-core source files
-COPY --chown=chap:chap ./pyproject.toml ./uv.lock ./.python-version ./README.md ./
+COPY --chown=chap:chap ./pyproject.toml ./uv.lock ./.python-version ./README.md ./hatch_build.py ./
 COPY --chown=chap:chap ./chap_core ./chap_core
 COPY --chown=chap:chap ./config ./config
 COPY --chown=chap:chap ./alembic.ini ./alembic.ini

--- a/chap_core/__init__.py
+++ b/chap_core/__init__.py
@@ -2,9 +2,7 @@
 
 from pathlib import Path
 
-from . import data, fetch
 from .log_config import is_debug_mode
-from .models.model_template_interface import ModelTemplateInterface
 
 __author__ = """Chap Team"""
 __email__ = "chap@dhis2.org"
@@ -37,4 +35,4 @@ def get_temp_dir() -> Path:
     return temp_dir
 
 
-__all__ = ["fetch", "data", "ModelTemplateInterface", "is_debug_mode", "get_temp_dir"]
+__all__ = ["is_debug_mode", "get_temp_dir"]

--- a/chap_core/cli.py
+++ b/chap_core/cli.py
@@ -15,7 +15,7 @@ from chap_core.cli_endpoints import evaluate, forecast, init, preference_learn, 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-app = App()
+app = App(version_flags=["--version", "-v"])
 
 # Register commands from each module
 evaluate.register_commands(app)

--- a/chap_core/cli_endpoints/_common.py
+++ b/chap_core/cli_endpoints/_common.py
@@ -4,21 +4,10 @@ import logging
 from pathlib import Path
 from typing import Any, Literal, Optional
 
-import pandas as pd
-import yaml
-
-from chap_core.database.model_templates_and_config_tables import ModelConfiguration
-from chap_core.datatypes import FullData
-from chap_core.geometry import Polygons
-from chap_core.models.model_template import ModelTemplate
-from chap_core.spatio_temporal_data.multi_country_dataset import MultiCountryDataSet
-from chap_core.spatio_temporal_data.temporal_dataclass import DataSet, DataSetMetaData
-from chap_core.file_io.example_data_set import datasets
-
 logger = logging.getLogger(__name__)
 
 
-def append_to_csv(file_object, data_frame: pd.DataFrame):
+def append_to_csv(file_object, data_frame):
     data_frame.to_csv(file_object, mode="a", header=False)
 
 
@@ -29,6 +18,11 @@ def get_model(
     name,
     run_directory_type: Literal["latest", "timestamp", "use_existing"] | None,
 ) -> Any:
+    import yaml
+
+    from chap_core.database.model_templates_and_config_tables import ModelConfiguration
+    from chap_core.models.model_template import ModelTemplate
+
     template = ModelTemplate.from_directory_or_github_url(
         name,
         base_working_dir=Path("./runs/"),
@@ -48,6 +42,8 @@ def get_model(
 
 
 def save_results(report_filename: str | None, results_dict: dict[Any, Any]):
+    import pandas as pd
+
     data = []
     full_data = {}
     first_model = True
@@ -110,7 +106,7 @@ def load_dataset_from_csv(
     csv_path: Path,
     geojson_path: Optional[Path] = None,
     column_mapping: Optional[dict[str, str]] = None,
-) -> DataSet:
+):
     """
     Load dataset from CSV file with optional GeoJSON polygons.
 
@@ -123,6 +119,12 @@ def load_dataset_from_csv(
     Returns:
         DataSet loaded from CSV with polygons if provided
     """
+    import pandas as pd
+
+    from chap_core.datatypes import FullData
+    from chap_core.geometry import Polygons
+    from chap_core.spatio_temporal_data.temporal_dataclass import DataSet, DataSetMetaData
+
     logging.info(f"Loading dataset from {csv_path}")
 
     if column_mapping is not None:
@@ -150,7 +152,13 @@ def load_dataset(
     dataset_name: Any | None,
     polygons_id_field: str | None,
     polygons_json: Path | None,
-) -> DataSet:
+):
+    from chap_core.datatypes import FullData
+    from chap_core.geometry import Polygons
+    from chap_core.spatio_temporal_data.multi_country_dataset import MultiCountryDataSet
+    from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+    from chap_core.file_io.example_data_set import datasets
+
     if dataset_name is None:
         assert dataset_csv is not None, "Must specify a dataset name or a dataset csv file"
         logging.info(f"Loading dataset from {dataset_csv}")

--- a/chap_core/cli_endpoints/forecast.py
+++ b/chap_core/cli_endpoints/forecast.py
@@ -4,19 +4,12 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from chap_core.assessment.forecast import multi_forecast as do_multi_forecast
-from chap_core.models.utils import get_model_from_directory_or_github_url
-from chap_core.plotting.prediction_plot import plot_forecast_from_summaries
-from chap_core import api
-from chap_core.file_io.example_data_set import datasets, DataSetType
-from chap_core.time_period.date_util_wrapper import delta_month
-
 logger = logging.getLogger(__name__)
 
 
 def forecast(
     model_name: str,
-    dataset_name: DataSetType,
+    dataset_name: str,
     n_months: int,
     model_path: Optional[str] = None,
     out_path: Optional[str] = Path("./"),
@@ -31,6 +24,7 @@ def forecast(
         model_path: Optional[str]: Path to the model if model_name is external. Can ge a github repo url starting with https://github.com and ending with .git or a path to a local directory.
         out_path: Optional[str]: Path to save the output file, default is the current directory
     """
+    from chap_core import api
 
     out_file = Path(out_path) / f"{model_name}_{dataset_name}_forecast_results_{n_months}.html"
     f = open(out_file, "w")
@@ -42,11 +36,17 @@ def forecast(
 
 def multi_forecast(
     model_name: str,
-    dataset_name: DataSetType,
+    dataset_name: str,
     n_months: int,
     pre_train_months: int,
     out_path: Path = Path(""),
 ):
+    from chap_core.assessment.forecast import multi_forecast as do_multi_forecast
+    from chap_core.file_io.example_data_set import datasets
+    from chap_core.models.utils import get_model_from_directory_or_github_url
+    from chap_core.plotting.prediction_plot import plot_forecast_from_summaries
+    from chap_core.time_period.date_util_wrapper import delta_month
+
     model = get_model_from_directory_or_github_url(model_name)
     model_name = model.name
 

--- a/chap_core/cli_endpoints/utils.py
+++ b/chap_core/cli_endpoints/utils.py
@@ -8,20 +8,7 @@ from typing import Annotated, Optional
 
 from cyclopts import Parameter
 
-import numpy as np
-import pandas as pd
-import xarray as xr
-import yaml
-
-from chap_core.assessment.dataset_splitting import train_test_generator
-from chap_core.database.model_templates_and_config_tables import ModelConfiguration
-from chap_core.datatypes import FullData
-from chap_core.log_config import initialize_logging
-from chap_core.models.utils import get_model_template_from_directory_or_github_url
-from chap_core.plotting.dataset_plot import StandardizedFeaturePlot
-from chap_core.plotting.season_plot import SeasonCorrelationBarPlot
-from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
-from chap_core.file_io.example_data_set import datasets
+from chap_core.cli_endpoints._generated import PLOT_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +23,16 @@ def sanity_check_model(
     """
     Check that a model can be loaded, trained and used to make predictions
     """
+    import numpy as np
+    import yaml
+
+    from chap_core.assessment.dataset_splitting import train_test_generator
+    from chap_core.database.model_templates_and_config_tables import ModelConfiguration
+    from chap_core.datatypes import FullData
+    from chap_core.models.utils import get_model_template_from_directory_or_github_url
+    from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+    from chap_core.file_io.example_data_set import datasets
+
     if dataset_path is None:
         dataset = datasets["hydromet_5_filtered"].load()
     else:
@@ -113,6 +110,8 @@ def test(**base_kwargs):
     """
     Simple test-command to check that the chap command works
     """
+    from chap_core.log_config import initialize_logging
+
     initialize_logging()
 
     logger.debug("Debug message")
@@ -120,6 +119,11 @@ def test(**base_kwargs):
 
 
 def plot_dataset(data_filename: Path, plot_name: str = "standardized_feature_plot"):
+    import pandas as pd
+
+    from chap_core.plotting.dataset_plot import StandardizedFeaturePlot
+    from chap_core.plotting.season_plot import SeasonCorrelationBarPlot
+
     dataset_plot_registry = {
         "standardized_feature_plot": StandardizedFeaturePlot,
         "season_plot": SeasonCorrelationBarPlot,
@@ -129,15 +133,6 @@ def plot_dataset(data_filename: Path, plot_name: str = "standardized_feature_plo
     plotter = plot_cls(df)
     fig = plotter.plot()
     fig.show()
-
-
-def _get_plot_type_help() -> str:
-    """Generate help text listing available plot types from the registry."""
-    from chap_core.assessment.backtest_plots import list_backtest_plots
-
-    plots = list_backtest_plots()
-    plot_list = ", ".join(f'"{p["id"]}"' for p in plots)
-    return f"Type of plot to generate. Available: {plot_list}"
 
 
 def plot_backtest(
@@ -151,7 +146,7 @@ def plot_backtest(
     ],
     plot_type: Annotated[
         str,
-        Parameter(help=_get_plot_type_help()),
+        Parameter(help=f"Type of plot to generate. Available: {', '.join(f'{p!r}' for p in PLOT_TYPES)}"),
     ] = "metrics_dashboard",
 ):
     """
@@ -230,6 +225,9 @@ def export_metrics(
         output_file: Path to output CSV file
         metric_ids: Optional list of metric IDs to compute. If None, all metrics are computed at AGGREGATE level.
     """
+    import pandas as pd
+    import xarray as xr
+
     from chap_core.assessment.evaluation import Evaluation
     from chap_core.assessment.metrics import available_metrics
 

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -20,7 +20,7 @@ from chap_core.log_config import is_debug_mode
 from chap_core.predictor.naive_estimator import NaiveEstimator
 from chap_core.time_period import Month, Week
 
-from .. import ModelTemplateInterface
+from ..models.model_template_interface import ModelTemplateInterface
 from ..external.model_configuration import ModelTemplateConfigV2
 from ..models import ModelTemplate
 from ..models.configured_model import ConfiguredModel

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,39 @@
+"""Hatchling build hook to generate CLI constants at build time."""
+
+import re
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class GenerateConstantsHook(BuildHookInterface):
+    """Build hook that generates constants for CLI help text."""
+
+    PLUGIN_NAME = "generate-constants"
+
+    def initialize(self, version, build_data):
+        root = Path(self.root)
+        backtest_plots_dir = root / "chap_core" / "assessment" / "backtest_plots"
+        plot_ids = self._extract_plot_ids(backtest_plots_dir)
+
+        output_path = root / "chap_core" / "cli_endpoints" / "_generated.py"
+        output_path.write_text(
+            f'"""Auto-generated at build time. Do not edit."""\n\n'
+            f"PLOT_TYPES = {plot_ids!r}\n"
+        )
+
+        build_data["artifacts"].append("chap_core/cli_endpoints/_generated.py")
+
+    def _extract_plot_ids(self, directory: Path) -> list[str]:
+        """Extract plot IDs from @backtest_plot decorators using regex."""
+        pattern = re.compile(r'@backtest_plot\s*\(\s*id\s*=\s*["\']([^"\']+)["\']')
+        plot_ids = []
+
+        for py_file in directory.glob("*.py"):
+            if py_file.name == "__init__.py":
+                continue
+            content = py_file.read_text()
+            matches = pattern.findall(content)
+            plot_ids.extend(matches)
+
+        return sorted(plot_ids)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ chap-runner = "chap_core.models.model_rest_api_wrapper:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.hooks.custom]
+
 
 [tool.ruff]
 target-version = "py313"

--- a/tests/preference_learning/test_preference_learn_cli.py
+++ b/tests/preference_learning/test_preference_learn_cli.py
@@ -42,8 +42,8 @@ class TestPreferenceLearningParams:
 class TestPreferenceLearnCLI:
     @patch("chap_core.cli_endpoints.preference_learn._create_evaluation")
     @patch("chap_core.cli_endpoints.preference_learn._compute_metrics")
-    @patch("chap_core.cli_endpoints.preference_learn.load_dataset_from_csv")
-    @patch("chap_core.cli_endpoints.preference_learn.discover_geojson")
+    @patch("chap_core.cli_endpoints._common.load_dataset_from_csv")
+    @patch("chap_core.cli_endpoints._common.discover_geojson")
     def test_preference_learn_metric_mode(
         self,
         mock_discover_geojson,
@@ -114,8 +114,8 @@ learning_rate:
 
     @patch("chap_core.cli_endpoints.preference_learn._create_evaluation")
     @patch("chap_core.cli_endpoints.preference_learn._compute_metrics")
-    @patch("chap_core.cli_endpoints.preference_learn.load_dataset_from_csv")
-    @patch("chap_core.cli_endpoints.preference_learn.discover_geojson")
+    @patch("chap_core.cli_endpoints._common.load_dataset_from_csv")
+    @patch("chap_core.cli_endpoints._common.discover_geojson")
     def test_preference_learn_resumes_from_state(
         self,
         mock_discover_geojson,
@@ -174,9 +174,9 @@ learning_rate:
         dataset_csv = tmp_path / "test_data.csv"
         dataset_csv.write_text("location,time_period,disease_cases\nA,2020-01,10")
 
-        with patch("chap_core.cli_endpoints.preference_learn.discover_geojson") as mock_geojson:
-            with patch("chap_core.cli_endpoints.preference_learn.load_dataset_from_csv") as mock_load:
-                with patch("chap_core.cli_endpoints.preference_learn.ModelTemplate") as mock_template:
+        with patch("chap_core.cli_endpoints._common.discover_geojson") as mock_geojson:
+            with patch("chap_core.cli_endpoints._common.load_dataset_from_csv") as mock_load:
+                with patch("chap_core.models.model_template.ModelTemplate") as mock_template:
                     mock_geojson.return_value = None
                     mock_load.return_value = MagicMock()
 

--- a/tests/test_command_line_interface_adaptor.py
+++ b/tests/test_command_line_interface_adaptor.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from pydantic import BaseModel
 
-from chap_core import ModelTemplateInterface
+from chap_core.models.model_template_interface import ModelTemplateInterface
 from chap_core.adaptors.command_line_interface import generate_template_app
 from chap_core.database.model_templates_and_config_tables import ModelTemplateInformation, ModelConfiguration
 from chap_core.datatypes import Samples


### PR DESCRIPTION
## Summary
Reduce CLI startup time from ~2s to ~0.35s by:
- Moving heavy imports (numpy, pandas, xarray, etc.) inside functions in CLI endpoint modules
- Generating plot type constants at build time using a Hatchling build hook to avoid importing `backtest_plots` module for CLI help text
- Adding `-v` alias for `--version` flag

## Changes
- `hatch_build.py`: New build hook that extracts plot IDs from source files at build/install time
- `pyproject.toml`: Enable custom build hook
- `.gitignore`: Ignore generated `_generated.py` file
- `chap_core/cli_endpoints/*.py`: Move heavy imports inside functions
- `chap_core/__init__.py`: Remove unused exports
- `chap_core/cli.py`: Add `-v` version flag alias

## Test plan
- [x] `time chap --version` ~0.35s
- [x] `time chap --help` ~0.35s  
- [x] `chap -v` works
- [x] `chap plot-backtest --help` shows available plot types
- [x] `make lint` passes
- [x] `make test` passes (507 passed)