### PR TITLE
feat: embed CLI-generated plots in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ target/
 # === Documentation ===
 docs/chap_core*.rst
 docs/modules.rst
+docs/generated/*
+!docs/generated/.gitkeep
 site/
 
 # === Environment and Secrets ===

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean coverage dist docs help install lint lint/flake8 test-chapkit-compose
+.PHONY: clean coverage dist docs docs-with-plots generate-doc-assets help install lint lint/flake8 test-chapkit-compose
 .DEFAULT_GOAL := help
 
 define PRINT_HELP_PYSCRIPT
@@ -26,6 +26,7 @@ clean: ## remove all build, test, coverage and Python artifacts
 	@rm -rf target/
 	@rm -rf site/
 	@rm -rf .cache
+	@rm -f comparison_doctest.csv comparison_specific_doctest.csv eval_doctest.nc plot_doctest.html metrics_doctest.csv
 
 lint: ## check and fix code style with ruff, run type checking
 	@echo "Linting code..."
@@ -76,9 +77,17 @@ coverage: ## run tests with coverage reporting
 	@uv run coverage xml
 	@echo "Coverage report: htmlcov/index.html"
 
+generate-doc-assets: ## generate plots for documentation (slow, runs model evaluation)
+	uv run pytest tests/test_documentation_slow.py::TestSlowDocumentationBash -v --run-slow
+	@mkdir -p docs/generated
+	@cp -f plot_doctest.html docs/generated/ 2>/dev/null || true
+	@rm -f comparison_doctest.csv comparison_specific_doctest.csv eval_doctest.nc plot_doctest.html metrics_doctest.csv
+
 docs: ## generate MkDocs HTML documentation
 	uv run mkdocs build
 	@echo "Docs: site/index.html"
+
+docs-with-plots: generate-doc-assets docs ## generate documentation with embedded plots
 
 dist: clean ## build source and wheel package
 	uv build

--- a/docs/chap-cli/evaluation-workflow.md
+++ b/docs/chap-cli/evaluation-workflow.md
@@ -181,10 +181,6 @@ chap export-metrics \
     --output-file ./comparison_doctest.csv
 ```
 
-```bash
-rm -f ./comparison_doctest.csv
-```
-
 ### Output Format
 
 The CSV contains one row per evaluation with metadata and metric columns:
@@ -220,10 +216,6 @@ chap export-metrics \
     --metric-ids crps
 ```
 
-```bash
-rm -f ./comparison_specific_doctest.csv
-```
-
 ## Complete Example: Standard Models
 
 Here's a complete workflow using the included example dataset (`example_data/laos_subset.csv`) with a minimal model for fast testing:
@@ -245,16 +237,13 @@ chap plot-backtest \
     --output-file ./plot_doctest.html
 ```
 
+<iframe src="../generated/plot_doctest.html" width="100%" height="500px" frameborder="0"></iframe>
+
 ```bash
 # Step 3: Export metrics
 chap export-metrics \
     --input-files ./eval_doctest.nc \
     --output-file ./metrics_doctest.csv
-```
-
-```bash
-# Cleanup
-rm -f ./eval_doctest.nc ./plot_doctest.html ./metrics_doctest.csv
 ```
 
 The GeoJSON file `example_data/laos_subset.geojson` is automatically discovered since it has the same base name as the CSV.

--- a/docs/contributor/writing_building_documentation.md
+++ b/docs/contributor/writing_building_documentation.md
@@ -104,3 +104,46 @@ SKIP_FILES = [
 
 - `tests/test_documentation.py` - Fast documentation tests
 - `tests/test_documentation_slow.py` - Slow documentation tests (marked with `@pytest.mark.slow`)
+
+
+## Embedding CLI-generated plots
+
+Some documentation pages include bash blocks that generate plot files (e.g., `chap plot-backtest`). These plots can be embedded inline in the rendered docs so readers see the actual output of the shown commands.
+
+### How it works
+
+1. Bash blocks in documentation run via mktestdocs during slow tests, generating output files (e.g., `.html` plots) in the project root.
+2. `make generate-doc-assets` runs these tests and copies the generated plot files to `docs/generated/`.
+3. An `<iframe>` tag in the markdown references the copied file, and `mkdocs build` includes it in the site.
+
+The result is that the plot shown in the docs is the exact output of the CLI command displayed above it.
+
+### Adding a new embedded plot
+
+1. Add your `chap plot-backtest` bash block to the documentation as usual. The bash block will be tested by mktestdocs.
+
+2. After the bash block, add an iframe pointing to `docs/generated/`:
+
+    ```html
+    <iframe src="../generated/my_plot.html" width="100%" height="500px" frameborder="0"></iframe>
+    ```
+
+    Adjust the `src` path relative to the markdown file's location in `docs/`.
+
+3. Update the `generate-doc-assets` target in the `Makefile` to copy the new file:
+
+    ```makefile
+    @cp -f my_plot.html docs/generated/ 2>/dev/null || true
+    ```
+
+4. Add the filename to the cleanup line in both the `generate-doc-assets` and `clean` targets.
+
+### Building docs with plots
+
+```console
+# Build docs without plots (fast)
+make docs
+
+# Build docs with embedded plots (slow, runs model evaluation)
+make docs-with-plots
+```


### PR DESCRIPTION
## Summary
- Embed plots generated by CLI commands directly in the docs, so readers see the actual output of the shown `chap plot-backtest` commands
- Add `make docs-with-plots` target that runs the doc bash blocks via mktestdocs, copies generated HTML plots to `docs/generated/`, then builds the docs
- Document the embedding workflow for contributors

## Test plan
- [ ] Run `make docs-with-plots` and verify the plot appears inline in the evaluation workflow page
- [ ] Run `make test-docs-slow` and verify the slow doc bash tests still pass
- [ ] Run `make clean` and verify doctest artifacts are removed

CLIM-472