### PR TITLE
feat: add K-trajectory uncertainty propagation to ExtendedPredictor

### DIFF
--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -300,6 +300,15 @@ def eval_cmd(
             'Format: {"model_name": "csv_column"}. Example: {"rainfall": "precipitation_mm"}'
         ),
     ] = None,
+    n_trajectories: Annotated[
+        int,
+        Parameter(
+            help="Number of trajectories for multi-step uncertainty propagation when ExtendedPredictor is used. "
+            "The first trajectory always uses the mean (k=1, default, no extra cost). "
+            "Each additional trajectory draws a random sample for history updates, allowing uncertainty to grow. "
+            "Only relevant when the model's max_prediction_length is shorter than the forecast horizon."
+        ),
+    ] = 1,
 ):
     """Evaluate a model using backtesting and export results to NetCDF format.
 
@@ -371,7 +380,7 @@ def eval_cmd(
                 logger.warning(
                     f"Wrapping model to extend prediction length from {model_info.max_prediction_length} to {backtest_params.n_periods}. This is done iteratively, and may worsen model performance"
                 )
-                estimator = ExtendedPredictor(estimator, backtest_params.n_periods)
+                estimator = ExtendedPredictor(estimator, backtest_params.n_periods, n_trajectories=n_trajectories)
 
         model_template_db = ModelTemplateDB(
             id=template.model_template_config.name,

--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -304,7 +304,7 @@ def eval_cmd(
         int,
         Parameter(
             help="Number of trajectories for multi-step uncertainty propagation when ExtendedPredictor is used. "
-            "The first trajectory always uses the mean (k=1, default, no extra cost). "
+            "The first trajectory always uses the mean (n_trajectories=1, default, no extra cost). "
             "Each additional trajectory draws a random sample for history updates, allowing uncertainty to grow. "
             "Only relevant when the model's max_prediction_length is shorter than the forecast horizon."
         ),

--- a/chap_core/external/ExtendedPredictor.py
+++ b/chap_core/external/ExtendedPredictor.py
@@ -7,10 +7,18 @@ from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 
 
 class ExtendedPredictor(ConfiguredModel):
-    def __init__(self, configured_model: ConfiguredModel, desired_scope, n_trajectories: int = 1):
+    def __init__(
+        self,
+        configured_model: ConfiguredModel,
+        desired_scope,
+        n_trajectories: int = 1,
+    ):
+        if n_trajectories < 1:
+            raise ValueError(f"n_trajectories must be at least 1, got {n_trajectories}")
         self._config_model = configured_model
         self._desired_scope = desired_scope
         self._n_trajectories = n_trajectories
+        self._rng = np.random.default_rng()
 
     def train(self, train_data: DataSet, extra_args=None):
         self._config_model.train(train_data, extra_args)
@@ -45,9 +53,12 @@ class ExtendedPredictor(ConfiguredModel):
             traj_df = traj_df.rename(columns={f"sample_{i}": f"sample_{offset + i}" for i in range(n_samples)})
             trajectory_dfs.append(traj_df)
 
-        result = trajectory_dfs[0]
+        base_df = trajectory_dfs[0].set_index(["time_period", "location"])
         for traj_df in trajectory_dfs[1:]:
-            result = result.merge(traj_df, on=["time_period", "location"])
+            traj_indexed = traj_df.set_index(["time_period", "location"])
+            sample_cols = [col for col in traj_indexed.columns if col.startswith("sample_")]
+            base_df = base_df.join(traj_indexed[sample_cols], how="inner")
+        result = base_df.reset_index()
 
         return DataSet.from_pandas(result, Samples)
 
@@ -104,8 +115,7 @@ class ExtendedPredictor(ConfiguredModel):
         if use_mean:
             new_rows["disease_cases"] = new_rows[sample_cols].mean(axis=1)
         else:
-            rng = np.random.default_rng()
-            chosen_col = rng.choice(sample_cols)
+            chosen_col = self._rng.choice(sample_cols)
             new_rows["disease_cases"] = new_rows[chosen_col]
 
         # Drop the original sample columns

--- a/chap_core/external/ExtendedPredictor.py
+++ b/chap_core/external/ExtendedPredictor.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 
 from chap_core.datatypes import Samples
@@ -6,9 +7,10 @@ from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 
 
 class ExtendedPredictor(ConfiguredModel):
-    def __init__(self, configured_model: ConfiguredModel, desired_scope):
+    def __init__(self, configured_model: ConfiguredModel, desired_scope, n_trajectories: int = 1):
         self._config_model = configured_model
         self._desired_scope = desired_scope
+        self._n_trajectories = n_trajectories
 
     def train(self, train_data: DataSet, extra_args=None):
         self._config_model.train(train_data, extra_args)
@@ -34,6 +36,22 @@ class ExtendedPredictor(ConfiguredModel):
 
         assert self._desired_scope >= min_pred_length
 
+        trajectory_dfs = []
+        for traj_idx in range(self._n_trajectories):
+            use_mean = traj_idx == 0
+            traj_df = self._run_trajectory(historic_df.copy(), future_df, max_pred_length, use_mean)
+            n_samples = sum(1 for col in traj_df.columns if col.startswith("sample_"))
+            offset = traj_idx * n_samples
+            traj_df = traj_df.rename(columns={f"sample_{i}": f"sample_{offset + i}" for i in range(n_samples)})
+            trajectory_dfs.append(traj_df)
+
+        result = trajectory_dfs[0]
+        for traj_df in trajectory_dfs[1:]:
+            result = result.merge(traj_df, on=["time_period", "location"])
+
+        return DataSet.from_pandas(result, Samples)
+
+    def _run_trajectory(self, historic_df, future_df, max_pred_length: int, use_mean: bool) -> pd.DataFrame:
         remaining_time_periods = self._desired_scope
         predictions = pd.DataFrame()
 
@@ -66,16 +84,15 @@ class ExtendedPredictor(ConfiguredModel):
             future_time_idx += newly_predicted
             remaining_time_periods -= newly_predicted
 
-            historic_df = self.update_historic_data(historic_df, new_prediction_pandas, newly_predicted)
+            historic_df = self.update_historic_data(historic_df, new_prediction_pandas, newly_predicted, use_mean)
 
         # Remove duplicate time periods, keeping the last (most recent) prediction
         # This is important because later predictions are more accurate (shorter prediction horizon)
         predictions = predictions.drop_duplicates(subset=["time_period", "location"], keep="last")
         predictions = predictions.reset_index(drop=True)
+        return predictions
 
-        return DataSet.from_pandas(predictions, Samples)
-
-    def update_historic_data(self, historic_data_pandas, predictions_pandas, num_predictions):
+    def update_historic_data(self, historic_data_pandas, predictions_pandas, num_predictions, use_mean: bool = True):
         # Select rows by time period, not by row index, to include all locations
         unique_time_periods = predictions_pandas["time_period"].unique()
         time_periods_to_add = unique_time_periods[:num_predictions]
@@ -84,8 +101,12 @@ class ExtendedPredictor(ConfiguredModel):
         # Find all columns that start with "sample_"
         sample_cols = [col for col in new_rows.columns if col.startswith("sample_")]
 
-        # Replace them with a single column "disease_cases" as the average
-        new_rows["disease_cases"] = new_rows[sample_cols].mean(axis=1)
+        if use_mean:
+            new_rows["disease_cases"] = new_rows[sample_cols].mean(axis=1)
+        else:
+            rng = np.random.default_rng()
+            chosen_col = rng.choice(sample_cols)
+            new_rows["disease_cases"] = new_rows[chosen_col]
 
         # Drop the original sample columns
         new_rows = new_rows.drop(columns=sample_cols)

--- a/docs/feature_tutorials/extended_predictor.md
+++ b/docs/feature_tutorials/extended_predictor.md
@@ -10,7 +10,7 @@ The `ExtendedPredictor` wraps a `ConfiguredModel` and extends its prediction cap
 
 1. **Iterative Prediction**: When the desired prediction scope exceeds the model's `max_prediction_length`, the predictor makes multiple prediction calls in sequence.
 
-2. **Rolling History Update**: After each prediction step, the predicted values are appended to the historic data. Sample columns are averaged to produce a single `disease_cases` value for use in subsequent predictions.
+2. **Rolling History Update**: After each prediction step, the predicted values are appended to the historic data. By default (1 trajectory), sample columns are averaged to produce a single `disease_cases` value for subsequent predictions. With multiple trajectories, later trajectories draw a random sample instead of the mean, allowing uncertainty to grow over the horizon.
 
 3. **Overlap Handling**: When predictions overlap (which happens in later iterations), duplicates are removed by keeping the most recent prediction for each time period and location.
 
@@ -43,5 +43,20 @@ rm -f ./extended_predictor_test.nc
 ```
 
 When the requested `n-periods` exceeds the model's `max_prediction_length`, Chap automatically uses `ExtendedPredictor` to make iterative predictions.
+
+To enable uncertainty growth over the prediction horizon, use `--n-trajectories`. The first trajectory always uses the mean (default behavior, no extra cost). Each additional trajectory draws a random sample for history updates:
+
+```bash
+chap eval --model-name external_models/naive_python_model_uv \
+    --dataset-csv example_data/laos_subset.csv \
+    --output-file ./extended_predictor_test.nc \
+    --backtest-params.n-periods 6 \
+    --backtest-params.n-splits 2 \
+    --n-trajectories 2
+```
+
+```bash
+rm -f ./extended_predictor_test.nc
+```
 
 > **Note:** The legacy `chap evaluate` command is deprecated and will be removed in v2.0. Use `chap eval` instead.

--- a/external_models/naive_python_model_uv/MLproject
+++ b/external_models/naive_python_model_uv/MLproject
@@ -1,5 +1,8 @@
 name: naive_python_uv
 
+min_prediction_length: 1
+max_prediction_length: 3
+
 uv_env: pyproject.toml
 
 entry_points:

--- a/tests/external/test_extended_predictor.py
+++ b/tests/external/test_extended_predictor.py
@@ -545,6 +545,14 @@ def test_overlap_correct_final_count():
         )
 
 
+def test_n_trajectories_invalid():
+    """Test that n_trajectories < 1 raises ValueError."""
+    mock_model = MockModel()
+    with pytest.raises(ValueError, match="n_trajectories must be at least 1"):
+        ExtendedPredictor(mock_model, desired_scope=6, n_trajectories=0)
+
+
+
 def test_n_trajectories_doubles_sample_columns():
     """Test that n_trajectories=2 produces 2x sample columns with the same (time_period, location) pairs."""
     data = create_multi_location_data(num_locations=2, num_future_periods=6)

--- a/tests/external/test_extended_predictor.py
+++ b/tests/external/test_extended_predictor.py
@@ -543,3 +543,27 @@ def test_overlap_correct_final_count():
         assert len(loc_df) == desired_scope, (
             f"Location {loc} should have {desired_scope} predictions after deduplication, got {len(loc_df)}"
         )
+
+
+def test_n_trajectories_doubles_sample_columns():
+    """Test that n_trajectories=2 produces 2x sample columns with the same (time_period, location) pairs."""
+    data = create_multi_location_data(num_locations=2, num_future_periods=6)
+
+    mock_model_1 = MockModel(min_pred_length=2, max_pred_length=3)
+    mock_model_2 = MockModel(min_pred_length=2, max_pred_length=3)
+
+    predictor_1 = ExtendedPredictor(mock_model_1, desired_scope=6, n_trajectories=1)
+    predictor_2 = ExtendedPredictor(mock_model_2, desired_scope=6, n_trajectories=2)
+
+    result_1 = predictor_1.predict(data["historic_data"], data["future_data"]).to_pandas()
+    result_2 = predictor_2.predict(data["historic_data"], data["future_data"]).to_pandas()
+
+    sample_cols_1 = [c for c in result_1.columns if c.startswith("sample_")]
+    sample_cols_2 = [c for c in result_2.columns if c.startswith("sample_")]
+
+    assert len(sample_cols_2) == 2 * len(sample_cols_1)
+
+    # Same (time_period, location) pairs in both
+    pairs_1 = set(zip(result_1["time_period"], result_1["location"]))
+    pairs_2 = set(zip(result_2["time_period"], result_2["location"]))
+    assert pairs_1 == pairs_2


### PR DESCRIPTION
Adds K-trajectory uncertainty propagation to ExtendedPredictor so uncertainty grows over longer horizons instead of collapsing to the mean. Integrated with chap eval via --n-trajectories (default 1, same behavior as before). Feel free to reject if you don't think this is worth including.  