### PR TITLE
fix: filter locations with no disease data in first train split

### DIFF
--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -16,6 +16,7 @@ from chap_core.api_types import (
     FeatureCollectionModel,
     PredictionEntry,
 )
+from chap_core.assessment.dataset_splitting import train_test_generator
 from chap_core.database.base_tables import DBModel
 from chap_core.database.dataset_tables import DataSet as DataSetTable
 from chap_core.database.dataset_tables import DataSetCreateInfo, Observation
@@ -145,6 +146,41 @@ def _validate_full_dataset(
     )
     assert len(new_dataset.locations()), new_dataset.locations()
     return new_dataset, rejected_list
+
+
+def _find_locations_with_target_data(
+    dataset: DataSet,
+    target_name: str = "disease_cases",
+) -> tuple[set[str], list[ValidationError]]:
+    """Identify locations that have at least some non-NaN target data.
+
+    Returns the set of locations to keep and validation errors for rejected ones.
+    """
+    locations_to_keep = set()
+    rejected = []
+    for location, data in dataset.items():
+        target = getattr(data, target_name)
+        if np.any(np.logical_not(np.isnan(target))):
+            locations_to_keep.add(location)
+        else:
+            rejected.append(
+                ValidationError(
+                    reason="No disease data in the first training split",
+                    orgUnit=location,
+                    feature_name=target_name,
+                    time_periods=[],
+                )
+            )
+    return locations_to_keep, rejected
+
+
+def _filter_dataset_by_locations(
+    dataset: DataSet,
+    locations_to_keep: set[str],
+) -> DataSet:
+    """Return a new dataset containing only the specified locations."""
+    new_data = {location: data for location, data in dataset.items() if location in locations_to_keep}
+    return dataset.__class__(new_data, polygons=dataset.polygons, metadata=dataset.metadata)
 
 
 @router.get("/compatible-backtests/{backtestId}", response_model=list[BackTestRead], tags=["Backtests"])
@@ -519,6 +555,13 @@ async def create_backtest_with_data(
 ):
     feature_names, provided_data_processed = _read_dataset(request)
     provided_data_processed, rejections = _validate_full_dataset(feature_names, provided_data_processed)
+    backtest_params = BackTestParams(**request.model_dump())
+    train_set, _ = train_test_generator(
+        provided_data_processed, backtest_params.n_periods, backtest_params.n_splits, stride=backtest_params.stride
+    )
+    locations_to_keep, target_rejections = _find_locations_with_target_data(train_set)
+    provided_data_processed = _filter_dataset_by_locations(provided_data_processed, locations_to_keep)
+    rejections.extend(target_rejections)
     polygon_rejected = provided_data_processed.set_polygons(FeatureCollectionModel.model_validate(request.geojson))
     rejections.extend(
         ValidationError(reason="Missing polygon in geojson", orgUnit=location, feature_name="polygon", time_periods=[])

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -106,13 +106,13 @@ def _read_dataset(request):
     return feature_names, provided_data
 
 
-def _validate_full_dataset(
-    feature_names, provided_data, target_name="disease_cases"
-) -> tuple[DataSet, list[ValidationError]]:
-    new_data = {}
+def _find_locations_with_complete_covariates(
+    dataset: DataSet, feature_names: list[str], target_name: str = "disease_cases"
+) -> tuple[set[str], list[ValidationError]]:
+    """Identify locations that have no NaN values in covariate features."""
+    locations_to_keep = set()
     rejected_list = []
-    n_locations = len(provided_data.locations())
-    for location, data in provided_data.items():
+    for location, data in dataset.items():
         for feature_name in feature_names:
             if feature_name == target_name:
                 continue
@@ -129,8 +129,18 @@ def _validate_full_dataset(
                 )
                 break
         else:
-            new_data[location] = data
-    if not new_data:
+            locations_to_keep.add(location)
+    return locations_to_keep, rejected_list
+
+
+def _validate_full_dataset(
+    feature_names, provided_data, target_name="disease_cases"
+) -> tuple[DataSet, list[ValidationError]]:
+    n_locations = len(provided_data.locations())
+    locations_to_keep, rejected_list = _find_locations_with_complete_covariates(
+        provided_data, feature_names, target_name
+    )
+    if not locations_to_keep:
         raise HTTPException(
             status_code=400,
             detail={
@@ -140,11 +150,12 @@ def _validate_full_dataset(
             },
         )
 
-    new_dataset = provided_data.__class__(new_data, polygons=provided_data.polygons, metadata=provided_data.metadata)
+    new_dataset = _filter_dataset_by_locations(provided_data, locations_to_keep)
+    new_locations = list(new_dataset.locations())
     logger.info(
-        f"Remaining dataset after validation: {len(new_dataset.locations())} (from {n_locations}) locations: {list(new_dataset.locations())} "
+        f"Remaining dataset after validation: {len(new_locations)} (from {n_locations}) locations: {new_locations} "
     )
-    assert len(new_dataset.locations()), new_dataset.locations()
+    assert len(new_locations), new_locations
     return new_dataset, rejected_list
 
 

--- a/tests/integration/rest_api/test_validation.py
+++ b/tests/integration/rest_api/test_validation.py
@@ -5,7 +5,13 @@ from fastapi.testclient import TestClient
 
 from chap_core.datatypes import create_tsdataclass
 from chap_core.rest_api.app import app
-from chap_core.rest_api.v1.routers.analytics import _validate_full_dataset
+from chap_core.api_types import BackTestParams
+from chap_core.assessment.dataset_splitting import train_test_generator
+from chap_core.rest_api.v1.routers.analytics import (
+    _filter_dataset_by_locations,
+    _find_locations_with_target_data,
+    _validate_full_dataset,
+)
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 from chap_core.time_period import PeriodRange
 
@@ -32,3 +38,62 @@ def test_validate_full_dataset_error_uses_camel_case():
     assert "org_unit" not in rejected_entry
     assert "feature_name" not in rejected_entry
     assert "time_periods" not in rejected_entry
+
+
+def test_validate_target_in_first_train_split_rejects_all_nan_location():
+    dataclass = create_tsdataclass(["disease_cases", "rainfall"])
+    period_range = PeriodRange.from_strings(
+        ["2020-01", "2020-02", "2020-03", "2020-04", "2020-05", "2020-06", "2020-07", "2020-08", "2020-09", "2020-10"]
+    )
+    # loc1: has data throughout
+    data_good = dataclass(
+        period_range,
+        np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]),
+        np.array([1.0] * 10),
+    )
+    # loc2: all NaN disease_cases in the first train split (NaN for first 4 periods)
+    data_bad = dataclass(
+        period_range,
+        np.array([np.nan, np.nan, np.nan, np.nan, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]),
+        np.array([1.0] * 10),
+    )
+    dataset = DataSet({"loc1": data_good, "loc2": data_bad})
+
+    # n_periods=3, n_splits=2, stride=1 -> first train split ends at index -(3 + 1*1 + 1) = -5
+    # i.e. first train split = periods 2020-01 to 2020-06 (inclusive)
+    # loc2 has NaN for 2020-01 to 2020-04 but has 5.0 at 2020-05, so it should pass
+    params = BackTestParams(n_periods=3, n_splits=2, stride=1)
+    train_set, _ = train_test_generator(dataset, params.n_periods, params.n_splits, stride=params.stride)
+    locations_to_keep, rejected = _find_locations_with_target_data(train_set)
+    filtered = _filter_dataset_by_locations(dataset, locations_to_keep)
+    assert len(rejected) == 0
+    assert set(filtered.locations()) == {"loc1", "loc2"}
+
+
+def test_validate_target_in_first_train_split_rejects_when_no_data():
+    dataclass = create_tsdataclass(["disease_cases", "rainfall"])
+    period_range = PeriodRange.from_strings(
+        ["2020-01", "2020-02", "2020-03", "2020-04", "2020-05", "2020-06", "2020-07", "2020-08", "2020-09", "2020-10"]
+    )
+    data_good = dataclass(
+        period_range,
+        np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]),
+        np.array([1.0] * 10),
+    )
+    # loc2: all NaN disease_cases in the first train split (first 6 periods all NaN)
+    data_bad = dataclass(
+        period_range,
+        np.array([np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 7.0, 8.0, 9.0, 10.0]),
+        np.array([1.0] * 10),
+    )
+    dataset = DataSet({"loc1": data_good, "loc2": data_bad})
+
+    # first train split = periods 2020-01 to 2020-06 -> loc2 is all NaN there
+    params = BackTestParams(n_periods=3, n_splits=2, stride=1)
+    train_set, _ = train_test_generator(dataset, params.n_periods, params.n_splits, stride=params.stride)
+    locations_to_keep, rejected = _find_locations_with_target_data(train_set)
+    filtered = _filter_dataset_by_locations(dataset, locations_to_keep)
+    assert len(rejected) == 1
+    assert rejected[0].org_unit == "loc2"
+    assert "loc2" not in filtered.locations()
+    assert "loc1" in filtered.locations()


### PR DESCRIPTION
## Summary
- Locations whose `disease_cases` are entirely NaN in the first training window cause external models (e.g. `weekly_ar`) to crash with `ValueError: array of sample points is empty` during interpolation
- The `create-backtest-with-data` endpoint now uses `train_test_generator` to compute the first train split and filters out locations without any target data in that window before queuing the backtest job
- Splits the logic into two functions: `_find_locations_with_target_data` (checks the train split) and `_filter_dataset_by_locations` (filters the full dataset)

## Test plan
- [x] Unit test: location with some data in first train split is kept
- [x] Unit test: location with all-NaN data in first train split is rejected
- [x] Full test suite passes (628 passed)