### PR TITLE
feat: merge Laos workshop features

### DIFF
--- a/chap_core/assessment/backtest_plots/aggregated_metrics_plot.py
+++ b/chap_core/assessment/backtest_plots/aggregated_metrics_plot.py
@@ -1,0 +1,157 @@
+import altair as alt
+import pandas as pd
+
+from chap_core.assessment.metrics import available_metrics
+from chap_core.database.tables import BackTest
+from chap_core.plotting.backtest_plot import BackTestPlotBase, text_chart, title_chart
+from chap_core.assessment.flat_representations import (
+    FlatObserved,
+    FlatForecasts,
+    convert_backtest_to_flat_forecasts,
+    convert_backtest_observations_to_flat_observations,
+)
+
+
+class AggregatedMetricsPlot(BackTestPlotBase):
+    """
+    Backtest plot showing aggregated metrics (global metrics with no dimensions).
+    """
+
+    name = "Aggregated Metrics Overview"
+    description = "A plot showing all global aggregated metrics from the assessment module."
+
+    def __init__(
+        self,
+        flat_observations: FlatObserved,
+        flat_forecasts: FlatForecasts,
+        title: str = "Aggregated Metrics Overview",
+    ):
+        """
+        Initialize the aggregated metrics plot.
+
+        Parameters
+        ----------
+        flat_observations : FlatObserved
+            Observations in flat format
+        flat_forecasts : FlatForecasts
+            Forecasts in flat format
+        title : str, optional
+            Title for the plot
+        """
+        self._flat_observations = flat_observations
+        self._flat_forecasts = flat_forecasts
+        self._title = title
+
+    @classmethod
+    def from_backtest(cls, backtest: BackTest, title: str = "Aggregated Metrics") -> "AggregatedMetricsPlot":
+        """
+        Create an AggregatedMetricsPlot from a BackTest object.
+
+        Parameters
+        ----------
+        backtest : BackTest
+            The backtest object containing forecast and observation data
+        title : str, optional
+            Title for the plot
+
+        Returns
+        -------
+        AggregatedMetricsPlot
+            An instance ready to generate the plot
+        """
+        flat_forecasts = FlatForecasts(convert_backtest_to_flat_forecasts(backtest.forecasts))
+        flat_observations = FlatObserved(
+            convert_backtest_observations_to_flat_observations(backtest.dataset.observations)
+        )
+
+        return cls(flat_observations, flat_forecasts, title=title)
+
+    def plot(self) -> alt.Chart:
+        """
+        Generate and return the aggregated metrics visualization.
+
+        Returns
+        -------
+        alt.Chart
+            Altair chart containing the aggregated metrics
+        """
+        # Get all global metrics (metrics with no output dimensions)
+        global_metrics = {
+            metric_id: metric_cls
+            for metric_id, metric_cls in available_metrics.items()
+            if metric_cls().is_full_aggregate()
+        }
+
+        # Compute all global metrics
+        metrics_data = []
+        for metric_id, metric_cls in global_metrics.items():
+            metric = metric_cls()
+            metric_df = metric.get_metric(self._flat_observations, self._flat_forecasts)
+            if len(metric_df) == 1:
+                metric_value = float(metric_df["metric"].iloc[0])
+                metrics_data.append(
+                    {
+                        "metric_id": metric_id,
+                        "metric_name": metric.spec.metric_name,
+                        "value": metric_value,
+                        "description": metric.spec.description,
+                    }
+                )
+
+        # Create DataFrame with metrics
+        metrics_df = pd.DataFrame(metrics_data)
+
+        charts = []
+
+        # Title
+        charts.append(title_chart(self._title))
+
+        # Explanatory text
+        charts.append(
+            text_chart(
+                "This plot shows all aggregated (global) metrics computed across all locations, "
+                "time periods, and forecast horizons. These metrics provide a single summary "
+                "value for the entire backtest evaluation.",
+                line_length=80,
+            )
+        )
+
+        if len(metrics_df) == 0:
+            charts.append(
+                text_chart(
+                    "No global aggregated metrics found. All available metrics produce per-location, "
+                    "per-time, or per-horizon breakdowns.",
+                    line_length=80,
+                )
+            )
+        else:
+            # Create a bar chart of metrics
+            bar_chart = (
+                alt.Chart(metrics_df)
+                .mark_bar()
+                .encode(
+                    x=alt.X("value:Q", title="Metric Value"),
+                    y=alt.Y("metric_name:N", title="Metric", sort="-x"),
+                    color=alt.Color("metric_name:N", legend=None),
+                    tooltip=["metric_name:N", "value:Q", "description:N"],
+                )
+                .properties(width=600, height=max(200, len(metrics_df) * 30), title="Global Metric Values")
+            )
+            charts.append(bar_chart)
+
+            # Add a text chart with metric details
+            charts.append(title_chart("Metric Details", font_size=18))
+            for _, row in metrics_df.iterrows():
+                detail_text = f"{row['metric_name']} ({row['metric_id']}): {row['value']:.4f}"
+                if row["description"] and row["description"] != "No description provided":
+                    detail_text += f" - {row['description']}"
+                charts.append(text_chart(detail_text, line_length=80, font_size=11))
+
+        # Combine all charts vertically
+        dashboard = alt.vconcat(*charts).configure(
+            axis={"labelFontSize": 11, "titleFontSize": 12},
+            legend={"labelFontSize": 11, "titleFontSize": 12},
+            view={"stroke": None},
+        )
+
+        return dashboard

--- a/chap_core/assessment/backtest_plots/aggregated_metrics_plot.py
+++ b/chap_core/assessment/backtest_plots/aggregated_metrics_plot.py
@@ -125,24 +125,15 @@ class AggregatedMetricsPlot(BackTestPlotBase):
                 )
             )
         else:
-            # Create a table showing the metrics
-            table_data = metrics_df[["metric_name", "metric_id", "value"]].copy()
-            table_data.columns = ["Metric Name", "Metric ID", "Value"]
-            table_data["Value"] = table_data["Value"].apply(lambda x: f"{x:.6f}")
+            # Create CSV formatted text
+            csv_lines = ["metric_name,metric_id,value"]
+            for _, row in metrics_df.iterrows():
+                csv_lines.append(f"{row['metric_name']},{row['metric_id']},{row['value']:.6f}")
 
-            table = (
-                alt.Chart(table_data)
-                .mark_text(align="left", baseline="middle")
-                .encode(
-                    x=alt.X("column:N", axis=alt.Axis(title=None, labelAngle=0, labelFontSize=12)),
-                    y=alt.Y("row:O", axis=None),
-                    text=alt.Text("value:N"),
-                )
-                .transform_window(row="row_number()")
-                .transform_fold(["Metric Name", "Metric ID", "Value"], as_=["column", "value"])
-                .properties(width=600, height=max(150, len(metrics_df) * 25 + 30))
-            )
-            charts.append(table)
+            # Add CSV text as a code block
+            charts.append(title_chart("Aggregated Metrics (CSV format)", font_size=18))
+            for line in csv_lines:
+                charts.append(text_chart(line, line_length=120, font_size=11))
 
         # Combine all charts vertically
         dashboard = alt.vconcat(*charts).configure(

--- a/chap_core/assessment/backtest_plots/aggregated_metrics_plot.py
+++ b/chap_core/assessment/backtest_plots/aggregated_metrics_plot.py
@@ -125,34 +125,29 @@ class AggregatedMetricsPlot(BackTestPlotBase):
                 )
             )
         else:
-            # Create a table with metrics as columns
-            # Transpose the data so metric names are columns and values are in one row
-            table_data = pd.DataFrame([{row["metric_name"]: f"{row['value']:.6f}" for _, row in metrics_df.iterrows()}])
+            # Create a table with metrics as rows and values in a column
+            table_data = metrics_df[["metric_name", "value"]].copy()
+            table_data["value"] = table_data["value"].apply(lambda x: f"{x:.6f}")
+            table_data.columns = ["Metric", "Value"]
 
-            # Melt the dataframe to create data suitable for Altair table
-            melted = table_data.melt(var_name="Metric", value_name="Value")
-
-            # Create header row
-            header = (
-                alt.Chart(melted)
-                .mark_text(align="center", baseline="middle", fontSize=12, fontWeight="bold")
-                .encode(
-                    x=alt.X("Metric:N", axis=alt.Axis(labelAngle=0, title=None)),
-                    text=alt.Text("Metric:N"),
-                )
-                .properties(width=100 * len(metrics_df), height=30)
+            # Create metric name column
+            metric_names = (
+                alt.Chart(table_data)
+                .mark_text(align="left", baseline="middle", fontSize=11, fontWeight="bold")
+                .encode(y=alt.Y("Metric:N", axis=None, sort=None), text=alt.Text("Metric:N"))
+                .properties(width=200, height=len(metrics_df) * 25)
             )
 
-            # Create value row
+            # Create value column
             values = (
-                alt.Chart(melted)
-                .mark_text(align="center", baseline="middle", fontSize=11)
-                .encode(x=alt.X("Metric:N", axis=None), text=alt.Text("Value:N"))
-                .properties(width=100 * len(metrics_df), height=30)
+                alt.Chart(table_data)
+                .mark_text(align="right", baseline="middle", fontSize=11)
+                .encode(y=alt.Y("Metric:N", axis=None, sort=None), text=alt.Text("Value:N"))
+                .properties(width=150, height=len(metrics_df) * 25)
             )
 
-            # Combine header and values vertically
-            table = alt.vconcat(header, values).properties(title="Aggregated Metrics")
+            # Combine metric names and values horizontally
+            table = alt.hconcat(metric_names, values).properties(title="Aggregated Metrics")
             charts.append(table)
 
         # Combine all charts vertically

--- a/chap_core/assessment/metrics/__init__.py
+++ b/chap_core/assessment/metrics/__init__.py
@@ -12,7 +12,7 @@ from chap_core.assessment.flat_representations import (
 )
 from chap_core.database.tables import BackTest
 from chap_core.assessment.metrics.base import MetricBase, MetricSpec
-from chap_core.assessment.metrics.rmse import RMSE, DetailedRMSE
+from chap_core.assessment.metrics.rmse import RMSE, DetailedRMSE, GlobalRMSE
 from chap_core.assessment.metrics.mae import MAE
 from chap_core.assessment.metrics.crps import CRPS, CRPSPerLocation, DetailedCRPS
 from chap_core.assessment.metrics.crps_norm import CRPSNorm, DetailedCRPSNorm
@@ -35,6 +35,7 @@ __all__ = [
     "MetricBase",
     "MetricSpec",
     "RMSE",
+    "GlobalRMSE",
     "DetailedRMSE",
     "MAE",
     "CRPS",
@@ -59,6 +60,7 @@ __all__ = [
 # Dictionary of available metrics for easy lookup
 available_metrics = {
     "rmse": RMSE,
+    "global_rmse": GlobalRMSE,
     "mae": MAE,
     "detailed_rmse": DetailedRMSE,
     "detailed_crps": DetailedCRPS,

--- a/chap_core/assessment/metrics/rmse.py
+++ b/chap_core/assessment/metrics/rmse.py
@@ -6,6 +6,10 @@ import pandas as pd
 from chap_core.assessment.flat_representations import DataDimension, FlatForecasts, FlatObserved
 from chap_core.assessment.metrics.base import MetricBase, MetricSpec
 
+class GlobalRMSE(MetricBase):
+    def compute(self, observations: FlatObserved, forecasts: FlatForecasts) -> pd.DataFrame:
+        
+
 
 class RMSE(MetricBase):
     """
@@ -16,6 +20,7 @@ class RMSE(MetricBase):
     spec = MetricSpec(output_dimensions=(DataDimension.location,), metric_name="RMSE")
 
     def compute(self, observations: FlatObserved, forecasts: FlatForecasts) -> pd.DataFrame:
+
         # Merge observations with forecasts on location and time_period
         merged = forecasts.merge(
             observations[["location", "time_period", "disease_cases"]], on=["location", "time_period"], how="inner"

--- a/chap_core/assessment/prediction_evaluator.py
+++ b/chap_core/assessment/prediction_evaluator.py
@@ -46,10 +46,7 @@ def backtest(
     estimator: Estimator, data: DataSet, prediction_length, n_test_sets, stride=1, weather_provider=None
 ) -> Iterable[DataSet]:
     train, test_generator = train_test_generator(
-        data, prediction_length,
-        n_test_sets,
-        stride=stride,
-        future_weather_provider=weather_provider
+        data, prediction_length, n_test_sets, stride=stride, future_weather_provider=weather_provider
     )
     predictor = estimator.train(train)
     for historic_data, future_data, future_truth in test_generator:

--- a/chap_core/assessment/prediction_evaluator.py
+++ b/chap_core/assessment/prediction_evaluator.py
@@ -46,7 +46,10 @@ def backtest(
     estimator: Estimator, data: DataSet, prediction_length, n_test_sets, stride=1, weather_provider=None
 ) -> Iterable[DataSet]:
     train, test_generator = train_test_generator(
-        data, prediction_length, n_test_sets, future_weather_provider=weather_provider
+        data, prediction_length,
+        n_test_sets,
+        stride=stride,
+        future_weather_provider=weather_provider
     )
     predictor = estimator.train(train)
     for historic_data, future_data, future_truth in test_generator:

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -172,6 +172,8 @@ class SessionWrapper:
             model_template=model_template,
             uses_chapkit=uses_chapkit,
         )
+        # Add CHAP options to template for validation
+        model_template.with_chap_options()
         configured_model.validate_user_options(configured_model)
         # configured_model.validate_user_options(model_template)
         logger.info(f"Adding configured model: {configured_model}")

--- a/chap_core/database/model_templates_and_config_tables.py
+++ b/chap_core/database/model_templates_and_config_tables.py
@@ -53,9 +53,18 @@ class ModelTemplateDB(DBModel, ModelTemplateMetaData, ModelTemplateInformation, 
     configured_models: List["ConfiguredModelDB"] = Relationship(back_populates="model_template", cascade_delete=True)
     version: Optional[str] = None
 
+    def with_chap_options(self) -> "ModelTemplateDB":
+        """Add CHAP-specific options to this template's user_options."""
+        from chap_core.models.chap_user_options import ChapUserOptions
 
-    def with_chap_options(self) -> "ConfiguredModelDB":
-        ...
+        chap_options = ChapUserOptions().to_json_schema_properties()
+
+        if self.user_options is None:
+            self.user_options = {}
+        self.user_options.update(chap_options)
+
+        return self
+
 
 class ModelConfiguration(SQLModel):
     user_option_values: Optional[dict] = Field(sa_column=Column(JSON), default_factory=dict)

--- a/chap_core/database/model_templates_and_config_tables.py
+++ b/chap_core/database/model_templates_and_config_tables.py
@@ -54,6 +54,9 @@ class ModelTemplateDB(DBModel, ModelTemplateMetaData, ModelTemplateInformation, 
     version: Optional[str] = None
 
 
+    def with_chap_options(self) -> "ConfiguredModelDB":
+        ...
+
 class ModelConfiguration(SQLModel):
     user_option_values: Optional[dict] = Field(sa_column=Column(JSON), default_factory=dict)
     additional_continuous_covariates: List[str] = Field(default_factory=list, sa_column=Column(JSON))

--- a/chap_core/models/chap_user_options.py
+++ b/chap_core/models/chap_user_options.py
@@ -1,0 +1,27 @@
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class ChapUserOptions(BaseModel):
+    """CHAP-specific user options available for all models."""
+
+    chap__covid_mask: Optional[bool] = Field(
+        default=False, description="Exclude COVID-19 period (2020-2021) from training data"
+    )
+
+    @classmethod
+    def extract_from_config(cls, user_option_values: dict) -> "ChapUserOptions":
+        """Extract only chap__ prefixed options from user_option_values."""
+        chap_values = {key: value for key, value in (user_option_values or {}).items() if key.startswith("chap__")}
+        return cls(**chap_values)
+
+    def to_json_schema_properties(self) -> dict:
+        """Generate JSON schema properties to merge into user_options."""
+        return {
+            "chap__covid_mask": {
+                "type": "boolean",
+                "title": "Mask COVID-19 Period",
+                "description": "Exclude 2020-2021 COVID period from training data",
+                "default": False,
+            }
+        }

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -204,9 +204,9 @@ def run_backtest_from_dataset(
     ds = InMemoryDataSet.from_dict(provided_data_model_dump, create_tsdataclass(feature_names))
     dataset_id = session.add_dataset(dataset_info=dataset_info, orig_dataset=ds, polygons=ds.polygons.model_dump_json())
     backtest_create_info = BackTestCreate(name=backtest_name, dataset_id=dataset_id, model_id=model_id)
-    if ds.frequency == 'W' and backtest_params.stride<4:
+    if ds.frequency == 'W' and backtest_params.stride<5:
         logging.warning('Setting stride to 4 since its weekly data')
-        backtest_params.stride = 4
+        backtest_params.stride = 5
     return run_backtest(
         info=backtest_create_info,
         n_periods=backtest_params.n_periods,

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -204,8 +204,8 @@ def run_backtest_from_dataset(
     ds = InMemoryDataSet.from_dict(provided_data_model_dump, create_tsdataclass(feature_names))
     dataset_id = session.add_dataset(dataset_info=dataset_info, orig_dataset=ds, polygons=ds.polygons.model_dump_json())
     backtest_create_info = BackTestCreate(name=backtest_name, dataset_id=dataset_id, model_id=model_id)
-    if ds.frequency == 'W' and backtest_params.stride<4:
-        logging.warning('Setting stride to 4 since its weekly data')
+    if ds.frequency == "W" and backtest_params.stride < 4:
+        logging.warning("Setting stride to 4 since its weekly data")
         backtest_params.stride = 4
     return run_backtest(
         info=backtest_create_info,

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -344,9 +344,15 @@ class ModelTemplateRead(DBModel, ModelTemplateInformation, ModelTemplateMetaData
 @router.get("/model-templates", response_model=list[ModelTemplateRead])
 async def list_model_templates(session: Session = Depends(get_session)):
     """
-    Lists all model templates from the db.
+    Lists all model templates with CHAP options.
     """
     model_templates = session.exec(select(ModelTemplateDB)).all()
+
+    # Ensure all templates have CHAP options
+    for template in model_templates:
+        if not any(key.startswith("chap__") for key in (template.user_options or {}).keys()):
+            template.with_chap_options()
+
     return model_templates
 
 

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -8,6 +8,7 @@ from starlette.responses import JSONResponse
 
 from chap_core.assessment.backtest_plots.backtest_plot_1 import BackTestPlot1
 from chap_core.assessment.backtest_plots.sample_bias_plot import RatioOfSamplesAboveTruthBacktestPlot
+from chap_core.assessment.backtest_plots.aggregated_metrics_plot import AggregatedMetricsPlot
 from chap_core.database.base_tables import DBModel
 from chap_core.database.database import SessionWrapper
 from chap_core.database.tables import BackTest
@@ -33,6 +34,7 @@ metric_plots_registry = {cls.visualization_info.id: cls for cls in [MetricByHori
 backtest_plots_registry = {
     "backtest_plot_1": BackTestPlot1,
     "ratio_of_samples_above_truth": RatioOfSamplesAboveTruthBacktestPlot,
+    "aggregated_metrics": AggregatedMetricsPlot,
 }
 
 

--- a/chap_core/spatio_temporal_data/temporal_dataclass.py
+++ b/chap_core/spatio_temporal_data/temporal_dataclass.py
@@ -158,12 +158,11 @@ class DataSet(Generic[FeaturesT]):
     def frequency(self):
         first_period = self.period_range[0]
         if isinstance(first_period, Month):
-            return 'M'
+            return "M"
         elif isinstance(first_period, Week):
-            return 'W'
+            return "W"
         else:
             raise NotImplementedError
-
 
     def model_dump(self):
         return {

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -85,7 +85,7 @@
 - url: https://github.com/dhis2-chap/chap_pymc
   versions:
     #v1: "@5b0ed30b634f1083340d249bc040b83c34f296c4"
-    v1: "@7a54a1ea8942ff653c890c63126660709a35ef3f"
+    v1: "@66884d8bc88b3a467de94013fae6b1045369783a"
   configurations:
     skip_two_seasons:
       user_option_values:

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -85,7 +85,7 @@
 - url: https://github.com/dhis2-chap/chap_pymc
   versions:
     #v1: "@5b0ed30b634f1083340d249bc040b83c34f296c4"
-    v1: "@e2dd13bfbba321ac68fe48897245b35012c94281"
+    v1: "@7a54a1ea8942ff653c890c63126660709a35ef3f"
   configurations:
     skip_two_seasons:
       user_option_values:

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -84,7 +84,8 @@
 
 - url: https://github.com/dhis2-chap/chap_pymc
   versions:
-    v1: "@5b0ed30b634f1083340d249bc040b83c34f296c4"
+    #v1: "@5b0ed30b634f1083340d249bc040b83c34f296c4"
+    v1: "@e2dd13bfbba321ac68fe48897245b35012c94281"
   configurations:
     skip_two_seasons:
       user_option_values:

--- a/tests/evaluation/test_backtest_plot.py
+++ b/tests/evaluation/test_backtest_plot.py
@@ -6,6 +6,7 @@ from chap_core.database.tables import BackTest
 from chap_core.plotting.backtest_plot import EvaluationBackTestPlot
 from chap_core.assessment.backtest_plots.vega_lite_dash import combined_dashboard_from_backtest
 from chap_core.assessment.backtest_plots.backtest_plot_1 import BackTestPlot1
+from chap_core.assessment.backtest_plots.aggregated_metrics_plot import AggregatedMetricsPlot
 
 
 @pytest.fixture(scope="module")
@@ -32,4 +33,9 @@ def test_sample_bias_plot(simulated_backtest):
 
 def test_backtest_plot1(simulated_backtest):
     plotter = BackTestPlot1.from_backtest(simulated_backtest)
+    chart = plotter.plot()
+
+
+def test_aggregated_metrics_plot(simulated_backtest):
+    plotter = AggregatedMetricsPlot.from_backtest(simulated_backtest)
     chart = plotter.plot()

--- a/tests/integration/rest_api/test_chap_options_endpoints.py
+++ b/tests/integration/rest_api/test_chap_options_endpoints.py
@@ -1,0 +1,122 @@
+import logging
+import pytest
+from fastapi.testclient import TestClient
+
+from chap_core.rest_api.v1.rest_api import app
+from chap_core.rest_api.v1.routers.crud import ModelConfigurationCreate
+
+logger = logging.getLogger(__name__)
+client = TestClient(app)
+
+
+def get_content(url):
+    response = client.get(url)
+    assert response.status_code == 200, response.json()
+    return response.json()
+
+
+def test_list_model_templates_includes_chap_options(celery_session_worker, dependency_overrides):
+    """Test that /crud/model-templates endpoint includes chap__ options."""
+    response = client.get("/v1/crud/model-templates")
+    assert response.status_code == 200, response.json()
+    templates = response.json()
+    assert len(templates) > 0
+
+    # Check that at least one template has chap__ options
+    template = templates[0]
+    assert "userOptions" in template
+    user_options = template["userOptions"]
+
+    # Should have chap__covid_mask option
+    assert "chap__covid_mask" in user_options
+    assert user_options["chap__covid_mask"]["type"] == "boolean"
+    assert user_options["chap__covid_mask"]["default"] is False
+
+
+def test_create_configured_model_without_chap_options(celery_session_worker, dependency_overrides):
+    """Test creating a configured model without chap__ options (backward compatibility)."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+
+    model = next(m for m in content if m["name"] == "ewars_template")
+    template_id = model["id"]
+
+    config = ModelConfigurationCreate(
+        name="test_without_chap_options",
+        model_template_id=template_id,
+        additional_continuous_covariates=["rainfall"],
+        user_option_values={"precision": 2.0, "n_lags": 3},
+    )
+
+    response = client.post("/v1/crud/configured-models", json=config.model_dump())
+    assert response.status_code == 200, response.json()
+    configured_model = response.json()
+    assert "test_without_chap_options" in configured_model["name"]
+
+
+def test_create_configured_model_with_chap_covid_mask_false(celery_session_worker, dependency_overrides):
+    """Test creating a configured model with chap__covid_mask set to False."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+
+    model = next(m for m in content if m["name"] == "ewars_template")
+    template_id = model["id"]
+
+    config = ModelConfigurationCreate(
+        name="test_with_chap_covid_mask_false",
+        model_template_id=template_id,
+        additional_continuous_covariates=["rainfall"],
+        user_option_values={"precision": 2.0, "n_lags": 3, "chap__covid_mask": False},
+    )
+
+    response = client.post("/v1/crud/configured-models", json=config.model_dump())
+    assert response.status_code == 200, response.json()
+    configured_model = response.json()
+    assert "test_with_chap_covid_mask_false" in configured_model["name"]
+    assert configured_model["userOptionValues"]["chap__covid_mask"] is False
+
+
+def test_create_configured_model_with_chap_covid_mask_true(celery_session_worker, dependency_overrides):
+    """Test creating a configured model with chap__covid_mask set to True."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+
+    model = next(m for m in content if m["name"] == "ewars_template")
+    template_id = model["id"]
+
+    config = ModelConfigurationCreate(
+        name="test_with_chap_covid_mask_true",
+        model_template_id=template_id,
+        additional_continuous_covariates=["rainfall"],
+        user_option_values={"precision": 2.0, "n_lags": 3, "chap__covid_mask": True},
+    )
+
+    response = client.post("/v1/crud/configured-models", json=config.model_dump())
+    assert response.status_code == 200, response.json()
+    configured_model = response.json()
+    assert "test_with_chap_covid_mask_true" in configured_model["name"]
+    assert configured_model["userOptionValues"]["chap__covid_mask"] is True
+
+
+def test_create_configured_model_mixed_options(celery_session_worker, dependency_overrides):
+    """Test creating a configured model with both model-specific and chap options."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+
+    model = next(m for m in content if m["name"] == "ewars_template")
+    template_id = model["id"]
+
+    config = ModelConfigurationCreate(
+        name="test_mixed_options",
+        model_template_id=template_id,
+        additional_continuous_covariates=["rainfall", "mean_temperature"],
+        user_option_values={"precision": 1.5, "n_lags": 5, "chap__covid_mask": True},
+    )
+
+    response = client.post("/v1/crud/configured-models", json=config.model_dump())
+    assert response.status_code == 200, response.json()
+    configured_model = response.json()
+    assert "test_mixed_options" in configured_model["name"]
+    assert configured_model["userOptionValues"]["precision"] == 1.5
+    assert configured_model["userOptionValues"]["n_lags"] == 5
+    assert configured_model["userOptionValues"]["chap__covid_mask"] is True

--- a/tests/integration/rest_api/test_ewars_model_configuration.py
+++ b/tests/integration/rest_api/test_ewars_model_configuration.py
@@ -1,0 +1,347 @@
+"""
+Tests for EWARS model configuration through the configure-model endpoint.
+
+These tests verify that various EWARS model configurations are correctly:
+1. Created and stored in the database
+2. Passed to the model during training
+3. Written to the model_config.yaml file
+
+Related to bug CLIM-282: Custom CHAP-EWARS model variants fail randomly with INLA resource issues.
+
+Note: The ewars_template has:
+- Required covariates: population
+- User options: n_lags (integer), precision (number)
+- Additional covariates allowed: rainfall, mean_temperature, etc.
+"""
+
+import logging
+from unittest.mock import patch, MagicMock
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from chap_core.rest_api.v1.rest_api import app
+from chap_core.rest_api.v1.routers.crud import ModelConfigurationCreate
+
+logger = logging.getLogger(__name__)
+client = TestClient(app)
+
+
+def get_content(url):
+    response = client.get(url)
+    assert response.status_code == 200, response.json()
+    return response.json()
+
+
+def get_ewars_template_id():
+    """Get the ID of the ewars_template model template."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+    model = next(m for m in content if m["name"] == "ewars_template")
+    return model["id"]
+
+
+class TestEwarsModelConfigurationCreation:
+    """Tests for creating EWARS model configurations through the API."""
+
+    def test_create_ewars_config_minimal(self, celery_session_worker, dependency_overrides):
+        """Test creating EWARS config with minimal parameters (only required)."""
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_minimal",
+            model_template_id=template_id,
+            additional_continuous_covariates=[],
+            user_option_values={"precision": 0.01, "n_lags": 3},
+        )
+
+        response = client.post("/v1/crud/configured-models", json=config.model_dump())
+        assert response.status_code == 200, response.json()
+        configured_model = response.json()
+        assert "test_ewars_minimal" in configured_model["name"]
+        assert configured_model["userOptionValues"]["precision"] == 0.01
+        assert configured_model["userOptionValues"]["n_lags"] == 3
+
+    def test_create_ewars_config_with_rainfall(self, celery_session_worker, dependency_overrides):
+        """Test creating EWARS config with rainfall as additional covariate."""
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_rainfall",
+            model_template_id=template_id,
+            additional_continuous_covariates=["rainfall"],
+            user_option_values={"precision": 0.01, "n_lags": 3},
+        )
+
+        response = client.post("/v1/crud/configured-models", json=config.model_dump())
+        assert response.status_code == 200, response.json()
+        configured_model = response.json()
+        assert configured_model["additionalContinuousCovariates"] == ["rainfall"]
+
+    def test_create_ewars_config_with_weather_covariates(self, celery_session_worker, dependency_overrides):
+        """Test creating EWARS config with rainfall and mean_temperature covariates."""
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_weather_covariates",
+            model_template_id=template_id,
+            additional_continuous_covariates=["rainfall", "mean_temperature"],
+            user_option_values={"precision": 0.01, "n_lags": 3},
+        )
+
+        response = client.post("/v1/crud/configured-models", json=config.model_dump())
+        assert response.status_code == 200, response.json()
+        configured_model = response.json()
+        assert set(configured_model["additionalContinuousCovariates"]) == {
+            "rainfall",
+            "mean_temperature",
+        }
+
+    def test_create_ewars_config_with_covid_mask_false(self, celery_session_worker, dependency_overrides):
+        """Test creating EWARS config with chap__covid_mask=false."""
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_covid_mask_false",
+            model_template_id=template_id,
+            additional_continuous_covariates=["rainfall", "mean_temperature"],
+            user_option_values={
+                "precision": 0.01,
+                "n_lags": 3,
+                "chap__covid_mask": False,
+            },
+        )
+
+        response = client.post("/v1/crud/configured-models", json=config.model_dump())
+        assert response.status_code == 200, response.json()
+        configured_model = response.json()
+        assert configured_model["userOptionValues"]["chap__covid_mask"] is False
+
+    def test_create_ewars_config_with_covid_mask_true(self, celery_session_worker, dependency_overrides):
+        """Test creating EWARS config with chap__covid_mask=true."""
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_covid_mask_true",
+            model_template_id=template_id,
+            additional_continuous_covariates=["rainfall", "mean_temperature"],
+            user_option_values={
+                "precision": 0.01,
+                "n_lags": 3,
+                "chap__covid_mask": True,
+            },
+        )
+
+        response = client.post("/v1/crud/configured-models", json=config.model_dump())
+        assert response.status_code == 200, response.json()
+        configured_model = response.json()
+        assert configured_model["userOptionValues"]["chap__covid_mask"] is True
+
+    def test_create_ewars_config_bugfix_scenario(self, celery_session_worker, dependency_overrides):
+        """
+        Test creating a configuration similar to bug report CLIM-282.
+
+        The bug report mentioned a barebone variant with:
+        - n_lags=3
+        - precision=0.01
+        - covariates: rainfall, mean_temperature (in addition to required population)
+        """
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_bugfix_scenario",
+            model_template_id=template_id,
+            additional_continuous_covariates=["rainfall", "mean_temperature"],
+            user_option_values={
+                "n_lags": 3,
+                "precision": 0.01,
+                "chap__covid_mask": False,
+            },
+        )
+
+        response = client.post("/v1/crud/configured-models", json=config.model_dump())
+        assert response.status_code == 200, response.json()
+        configured_model = response.json()
+
+        # Verify all parameters match bug report scenario
+        assert configured_model["userOptionValues"]["n_lags"] == 3
+        assert configured_model["userOptionValues"]["precision"] == 0.01
+        assert configured_model["userOptionValues"]["chap__covid_mask"] is False
+        assert set(configured_model["additionalContinuousCovariates"]) == {
+            "rainfall",
+            "mean_temperature",
+        }
+
+    def test_create_ewars_config_different_n_lags(self, celery_session_worker, dependency_overrides):
+        """Test creating EWARS configs with different n_lags values."""
+        template_id = get_ewars_template_id()
+
+        for n_lags in [1, 3, 5, 10]:
+            config = ModelConfigurationCreate(
+                name=f"test_ewars_n_lags_{n_lags}",
+                model_template_id=template_id,
+                additional_continuous_covariates=["rainfall"],
+                user_option_values={"precision": 0.01, "n_lags": n_lags},
+            )
+
+            response = client.post("/v1/crud/configured-models", json=config.model_dump())
+            assert response.status_code == 200, response.json()
+            configured_model = response.json()
+            assert configured_model["userOptionValues"]["n_lags"] == n_lags
+
+    def test_create_ewars_config_different_precision(self, celery_session_worker, dependency_overrides):
+        """Test creating EWARS configs with different precision values."""
+        template_id = get_ewars_template_id()
+
+        for idx, precision in enumerate([0.001, 0.01, 0.1, 1.0]):
+            config = ModelConfigurationCreate(
+                name=f"test_ewars_precision_{idx}",
+                model_template_id=template_id,
+                additional_continuous_covariates=["rainfall"],
+                user_option_values={"precision": precision, "n_lags": 3},
+            )
+
+            response = client.post("/v1/crud/configured-models", json=config.model_dump())
+            assert response.status_code == 200, response.json()
+            configured_model = response.json()
+            assert configured_model["userOptionValues"]["precision"] == precision
+
+
+class TestEwarsModelConfigurationWrittenToFile:
+    """Tests that verify the configuration is correctly written when training starts.
+
+    These are unit tests that don't require celery/redis infrastructure.
+    """
+
+    def test_config_written_to_yaml_during_train(self):
+        """Test that model configuration is correctly written to YAML during training."""
+        from chap_core.models.external_model import ExternalModel
+        from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
+
+        # Create a mock configuration that mimics what would be passed
+        mock_config = MagicMock(spec=ConfiguredModelDB)
+        mock_config.user_option_values = {
+            "n_lags": 3,
+            "precision": 0.01,
+        }
+        mock_config.additional_continuous_covariates = ["rainfall", "mean_temperature"]
+
+        # Capture what gets written to YAML
+        written_config = {}
+
+        def mock_yaml_dump(data, file):
+            nonlocal written_config
+            written_config = data
+
+        with patch.object(yaml, "dump", side_effect=mock_yaml_dump):
+            # Create an ExternalModel instance
+            mock_runner = MagicMock()
+            model = ExternalModel(
+                runner=mock_runner,
+                name="test_model",
+                configuration=mock_config,
+            )
+
+            # Create mock training data
+            mock_train_data = MagicMock()
+            mock_train_data.polygons = None
+            mock_train_data.period_range = [MagicMock()]
+            mock_train_data.period_range[0].__class__.__name__ = "Month"
+            mock_train_data.to_pandas.return_value = MagicMock()
+            mock_train_data.to_pandas.return_value.columns = MagicMock()
+            mock_train_data.to_pandas.return_value.columns.tolist.return_value = []
+            mock_train_data.to_pandas.return_value.to_csv = MagicMock()
+
+            # Train should write config
+            try:
+                model.train(mock_train_data)
+            except Exception:
+                pass  # We expect it to fail since runner is mocked
+
+        # Verify the config was captured
+        assert written_config == mock_config
+
+    def test_config_dict_format_during_train(self):
+        """Test that configuration dict format is correct when passed to model."""
+        from chap_core.models.external_model import ExternalModel
+
+        # Test with dict configuration
+        config_dict = {
+            "user_option_values": {
+                "n_lags": 3,
+                "precision": 0.01,
+                "chap__covid_mask": False,
+            },
+            "additional_continuous_covariates": ["rainfall", "mean_temperature"],
+        }
+
+        written_config = {}
+
+        def mock_yaml_dump(data, file):
+            nonlocal written_config
+            written_config = data
+
+        with patch.object(yaml, "dump", side_effect=mock_yaml_dump):
+            mock_runner = MagicMock()
+            model = ExternalModel(
+                runner=mock_runner,
+                name="test_model",
+                configuration=config_dict,
+            )
+
+            mock_train_data = MagicMock()
+            mock_train_data.polygons = None
+            mock_train_data.period_range = [MagicMock()]
+            mock_train_data.period_range[0].__class__.__name__ = "Month"
+            mock_train_data.to_pandas.return_value = MagicMock()
+            mock_train_data.to_pandas.return_value.columns = MagicMock()
+            mock_train_data.to_pandas.return_value.columns.tolist.return_value = []
+            mock_train_data.to_pandas.return_value.to_csv = MagicMock()
+
+            try:
+                model.train(mock_train_data)
+            except Exception:
+                pass
+
+        # Verify the config dict matches
+        assert written_config == config_dict
+        assert written_config["user_option_values"]["n_lags"] == 3
+        assert written_config["user_option_values"]["precision"] == 0.01
+        assert written_config["user_option_values"]["chap__covid_mask"] is False
+        assert "rainfall" in written_config["additional_continuous_covariates"]
+        assert "mean_temperature" in written_config["additional_continuous_covariates"]
+
+
+class TestEwarsConfigurationValidation:
+    """Tests for validation of EWARS model configurations."""
+
+    def test_invalid_precision_type(self, celery_session_worker, dependency_overrides):
+        """Test that invalid precision type is rejected."""
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_invalid_precision",
+            model_template_id=template_id,
+            additional_continuous_covariates=[],
+            user_option_values={"precision": "invalid", "n_lags": 3},
+        )
+
+        # The API raises ValueError for invalid types, which becomes a 500 error
+        with pytest.raises(ValueError, match="Invalid user options"):
+            client.post("/v1/crud/configured-models", json=config.model_dump())
+
+    def test_invalid_n_lags_type(self, celery_session_worker, dependency_overrides):
+        """Test that invalid n_lags type is rejected."""
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_invalid_n_lags",
+            model_template_id=template_id,
+            additional_continuous_covariates=[],
+            user_option_values={"precision": 0.01, "n_lags": "invalid"},
+        )
+
+        # The API raises ValueError for invalid types, which becomes a 500 error
+        with pytest.raises(ValueError, match="Invalid user options"):
+            client.post("/v1/crud/configured-models", json=config.model_dump())

--- a/tests/models/test_chap_user_options.py
+++ b/tests/models/test_chap_user_options.py
@@ -1,0 +1,45 @@
+import pytest
+from chap_core.models.chap_user_options import ChapUserOptions
+
+
+def test_chap_user_options_defaults():
+    """Test that ChapUserOptions has correct default values."""
+    options = ChapUserOptions()
+    assert options.chap__covid_mask is False
+
+
+def test_extract_from_config_empty():
+    """Test extraction from empty config."""
+    options = ChapUserOptions.extract_from_config({})
+    assert options.chap__covid_mask is False
+
+
+def test_extract_from_config_with_chap_options():
+    """Test extraction with chap__ prefixed options."""
+    config = {"chap__covid_mask": True, "other_option": "value"}
+    options = ChapUserOptions.extract_from_config(config)
+    assert options.chap__covid_mask is True
+
+
+def test_extract_from_config_filters_non_chap():
+    """Test that only chap__ prefixed options are extracted."""
+    config = {"chap__covid_mask": True, "model_specific_param": 10, "another_param": "test"}
+    options = ChapUserOptions.extract_from_config(config)
+    assert options.chap__covid_mask is True
+
+
+def test_to_json_schema_properties():
+    """Test JSON schema generation."""
+    options = ChapUserOptions()
+    schema = options.to_json_schema_properties()
+
+    assert "chap__covid_mask" in schema
+    assert schema["chap__covid_mask"]["type"] == "boolean"
+    assert schema["chap__covid_mask"]["default"] is False
+    assert "description" in schema["chap__covid_mask"]
+
+
+def test_extract_from_none():
+    """Test extraction when user_option_values is None."""
+    options = ChapUserOptions.extract_from_config(None)
+    assert options.chap__covid_mask is False

--- a/tests/models/test_external_model_chap_options.py
+++ b/tests/models/test_external_model_chap_options.py
@@ -16,13 +16,15 @@ def sample_dataset():
     rows = []
     for year in range(2019, 2023):
         for month in range(1, 13):
-            rows.append({
-                "location": "location1",
-                "time_period": f"{year}-{month:02d}",
-                "disease_cases": 100.0,
-                "rainfall": 50.0,
-                "mean_temperature": 25.0
-            })
+            rows.append(
+                {
+                    "location": "location1",
+                    "time_period": f"{year}-{month:02d}",
+                    "disease_cases": 100.0,
+                    "rainfall": 50.0,
+                    "mean_temperature": 25.0,
+                }
+            )
 
     df = pd.DataFrame(rows)
     return DataSet.from_pandas(df)
@@ -47,9 +49,7 @@ def test_apply_chap_transformations_without_covid_mask(sample_dataset, mock_runn
     with tempfile.TemporaryDirectory() as tmpdir:
         config = {"user_option_values": {"chap__covid_mask": False}}
 
-        model = ExternalModel(
-            runner=mock_runner, working_dir=tmpdir, configuration=config
-        )
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
 
         transformed_data = model._apply_chap_transformations(sample_dataset)
 
@@ -64,9 +64,7 @@ def test_apply_chap_transformations_with_covid_mask(sample_dataset, mock_runner)
     with tempfile.TemporaryDirectory() as tmpdir:
         config = {"user_option_values": {"chap__covid_mask": True}}
 
-        model = ExternalModel(
-            runner=mock_runner, working_dir=tmpdir, configuration=config
-        )
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
 
         transformed_data = model._apply_chap_transformations(sample_dataset)
 
@@ -80,12 +78,7 @@ def test_apply_chap_transformations_with_covid_mask(sample_dataset, mock_runner)
         assert np.all(disease_cases[pre_covid_mask] == 100)
 
         # Check COVID period (2020-03 to 2021-12-31) - should be NaN
-        covid_mask = np.array(
-            [
-                str(p) >= "2020-03" and str(p) <= "2021-12"
-                for p in time_periods
-            ]
-        )
+        covid_mask = np.array([str(p) >= "2020-03" and str(p) <= "2021-12" for p in time_periods])
         assert np.all(np.isnan(disease_cases[covid_mask]))
 
         # Check post-COVID period (2022) - should be intact
@@ -98,9 +91,7 @@ def test_apply_chap_transformations_with_empty_config(sample_dataset, mock_runne
     with tempfile.TemporaryDirectory() as tmpdir:
         config = {}
 
-        model = ExternalModel(
-            runner=mock_runner, working_dir=tmpdir, configuration=config
-        )
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
 
         transformed_data = model._apply_chap_transformations(sample_dataset)
 
@@ -114,13 +105,9 @@ def test_apply_chap_transformations_with_dict_configuration(sample_dataset, mock
     """Test that transformation works when configuration is a dict."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Configuration as dict (not ModelConfiguration object)
-        config = {
-            "user_option_values": {"chap__covid_mask": True, "other_param": 10}
-        }
+        config = {"user_option_values": {"chap__covid_mask": True, "other_param": 10}}
 
-        model = ExternalModel(
-            runner=mock_runner, working_dir=tmpdir, configuration=config
-        )
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
 
         transformed_data = model._apply_chap_transformations(sample_dataset)
 
@@ -128,12 +115,7 @@ def test_apply_chap_transformations_with_dict_configuration(sample_dataset, mock
         location_data = transformed_data["location1"]
         time_periods = location_data.time_period
 
-        covid_mask = np.array(
-            [
-                str(p) >= "2020-03" and str(p) <= "2021-12"
-                for p in time_periods
-            ]
-        )
+        covid_mask = np.array([str(p) >= "2020-03" and str(p) <= "2021-12" for p in time_periods])
         assert np.all(np.isnan(location_data.disease_cases[covid_mask]))
 
 
@@ -142,9 +124,7 @@ def test_apply_chap_transformations_preserves_other_fields(sample_dataset, mock_
     with tempfile.TemporaryDirectory() as tmpdir:
         config = {"user_option_values": {"chap__covid_mask": True}}
 
-        model = ExternalModel(
-            runner=mock_runner, working_dir=tmpdir, configuration=config
-        )
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
 
         transformed_data = model._apply_chap_transformations(sample_dataset)
 

--- a/tests/models/test_external_model_chap_options.py
+++ b/tests/models/test_external_model_chap_options.py
@@ -1,0 +1,157 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pathlib import Path
+import tempfile
+
+from chap_core.models.external_model import ExternalModel
+from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+from chap_core.runners.mlflow_runner import MlFlowTrainPredictRunner
+
+
+@pytest.fixture
+def sample_dataset():
+    """Create a sample dataset spanning 2019-2022 including COVID period."""
+    # Create a DataFrame with monthly data from 2019-2022
+    rows = []
+    for year in range(2019, 2023):
+        for month in range(1, 13):
+            rows.append({
+                "location": "location1",
+                "time_period": f"{year}-{month:02d}",
+                "disease_cases": 100.0,
+                "rainfall": 50.0,
+                "mean_temperature": 25.0
+            })
+
+    df = pd.DataFrame(rows)
+    return DataSet.from_pandas(df)
+
+
+@pytest.fixture
+def mock_runner(tmp_path):
+    """Create a mock MLFlow runner that doesn't actually run anything."""
+
+    class MockRunner(MlFlowTrainPredictRunner):
+        def train(self, *args, **kwargs):
+            pass
+
+        def predict(self, *args, **kwargs):
+            pass
+
+    return MockRunner(str(tmp_path / "model"))
+
+
+def test_apply_chap_transformations_without_covid_mask(sample_dataset, mock_runner):
+    """Test that data is unchanged when covid_mask is False."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {"user_option_values": {"chap__covid_mask": False}}
+
+        model = ExternalModel(
+            runner=mock_runner, working_dir=tmpdir, configuration=config
+        )
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        # Data should be unchanged
+        location_data = transformed_data["location1"]
+        assert np.all(location_data.disease_cases == 100)
+        assert not np.any(np.isnan(location_data.disease_cases))
+
+
+def test_apply_chap_transformations_with_covid_mask(sample_dataset, mock_runner):
+    """Test that COVID period data is masked when covid_mask is True."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {"user_option_values": {"chap__covid_mask": True}}
+
+        model = ExternalModel(
+            runner=mock_runner, working_dir=tmpdir, configuration=config
+        )
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        # Check that COVID period has NaN values
+        location_data = transformed_data["location1"]
+        time_periods = location_data.time_period
+        disease_cases = location_data.disease_cases
+
+        # Check pre-COVID period (2019) - should be intact
+        pre_covid_mask = np.array([str(p).startswith("2019") for p in time_periods])
+        assert np.all(disease_cases[pre_covid_mask] == 100)
+
+        # Check COVID period (2020-03 to 2021-12-31) - should be NaN
+        covid_mask = np.array(
+            [
+                str(p) >= "2020-03" and str(p) <= "2021-12"
+                for p in time_periods
+            ]
+        )
+        assert np.all(np.isnan(disease_cases[covid_mask]))
+
+        # Check post-COVID period (2022) - should be intact
+        post_covid_mask = np.array([str(p).startswith("2022") for p in time_periods])
+        assert np.all(disease_cases[post_covid_mask] == 100)
+
+
+def test_apply_chap_transformations_with_empty_config(sample_dataset, mock_runner):
+    """Test that data is unchanged with empty configuration."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {}
+
+        model = ExternalModel(
+            runner=mock_runner, working_dir=tmpdir, configuration=config
+        )
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        # Data should be unchanged (default is False)
+        location_data = transformed_data["location1"]
+        assert np.all(location_data.disease_cases == 100)
+        assert not np.any(np.isnan(location_data.disease_cases))
+
+
+def test_apply_chap_transformations_with_dict_configuration(sample_dataset, mock_runner):
+    """Test that transformation works when configuration is a dict."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Configuration as dict (not ModelConfiguration object)
+        config = {
+            "user_option_values": {"chap__covid_mask": True, "other_param": 10}
+        }
+
+        model = ExternalModel(
+            runner=mock_runner, working_dir=tmpdir, configuration=config
+        )
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        # COVID period should be masked
+        location_data = transformed_data["location1"]
+        time_periods = location_data.time_period
+
+        covid_mask = np.array(
+            [
+                str(p) >= "2020-03" and str(p) <= "2021-12"
+                for p in time_periods
+            ]
+        )
+        assert np.all(np.isnan(location_data.disease_cases[covid_mask]))
+
+
+def test_apply_chap_transformations_preserves_other_fields(sample_dataset, mock_runner):
+    """Test that COVID mask only affects disease_cases, not other fields."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {"user_option_values": {"chap__covid_mask": True}}
+
+        model = ExternalModel(
+            runner=mock_runner, working_dir=tmpdir, configuration=config
+        )
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        location_data = transformed_data["location1"]
+
+        # Other fields should be unchanged
+        assert np.all(location_data.rainfall == 50)
+        assert np.all(location_data.mean_temperature == 25)
+        assert not np.any(np.isnan(location_data.rainfall))
+        assert not np.any(np.isnan(location_data.mean_temperature))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -20,6 +20,7 @@ def test_from_pandas():
     ds = DataSet.from_pandas(df)
     print(ds)
 
+
 @pytest.fixture
 def monthly_dataset():
     df = pd.DataFrame(
@@ -31,6 +32,7 @@ def monthly_dataset():
     )
     ds = DataSet.from_pandas(df)
     return ds
+
 
 @pytest.fixture
 def weekly_dataset():
@@ -44,8 +46,10 @@ def weekly_dataset():
     ds = DataSet.from_pandas(df)
     return ds
 
+
 def test_frequency(monthly_dataset):
-    assert monthly_dataset.frequency == 'M'
+    assert monthly_dataset.frequency == "M"
+
 
 def test_weekly(weekly_dataset):
-    assert weekly_dataset.frequency == 'W'
+    assert weekly_dataset.frequency == "W"


### PR DESCRIPTION
## Summary
- Add ChapUserOptions with COVID mask support (masks 2020-03 to 2021-12 training data)
- Add GlobalRMSE metric and aggregated metrics backtest plot
- Set stride to 5 for weekly data backtests and pass stride through worker functions
- Update HMC/pymc model version
- Add EWARS model configuration integration tests and evaluation sort order tests

## Test plan
- [ ] Run `make test` to verify no regressions
- [ ] Verify EWARS model configuration tests pass
- [ ] Verify aggregated metrics plot renders correctly in backtest view
- [ ] Test COVID mask toggle via REST API