### PR TITLE
Save model_info in Evaluation NetCDF metadata

### DIFF
--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -597,6 +597,7 @@ class Evaluation(EvaluationBase):
             model_name: Name of the model (optional)
             model_configuration: Model configuration dictionary (optional)
             model_version: Model version string (optional)
+            model_info: ModelTemplateConfigV2 object containing model metadata (optional)
         """
         flat_data = self.to_flat()
 

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -33,6 +33,7 @@ from chap_core.database.tables import BackTest, BackTestForecast
 from chap_core.datatypes import SamplesWithTruth
 from chap_core.rest_api.data_models import BackTestCreate
 from chap_core.time_period import TimePeriod
+from chap_core.external.model_configuration import ModelTemplateConfigV2
 
 try:
     from chap_core import __version__ as CHAP_VERSION
@@ -94,6 +95,7 @@ def _flat_data_to_xarray(flat_data: "FlatEvaluationData", model_metadata: dict) 
             "org_units": json.dumps(model_metadata.get("org_units", [])),
             "historical_context_periods": model_metadata.get("historical_context_periods", 0),
             "chap_version": CHAP_VERSION,
+            "model_info" : model_metadata.get("model_info")
         }
     )
 
@@ -585,6 +587,7 @@ class Evaluation(EvaluationBase):
         model_name: str | None = None,
         model_configuration: dict | None = None,
         model_version: str | None = None,
+        model_info: ModelTemplateConfigV2 | None = None,
     ) -> None:
         """
         Export evaluation to NetCDF file using xarray.
@@ -597,6 +600,12 @@ class Evaluation(EvaluationBase):
         """
         flat_data = self.to_flat()
 
+        model_template_json = (
+            model_info.model_dump_json(exclude_none=True)
+            if model_info is not None
+            else ""
+        )
+
         model_metadata = {
             "model_name": model_name or "",
             "model_configuration": model_configuration or {},
@@ -604,6 +613,7 @@ class Evaluation(EvaluationBase):
             "split_periods": self.get_split_periods(),
             "org_units": self.get_org_units(),
             "historical_context_periods": self._historical_context_periods,
+            "model_info": model_template_json,
         }
 
         ds = _flat_data_to_xarray(flat_data, model_metadata)

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -95,7 +95,7 @@ def _flat_data_to_xarray(flat_data: "FlatEvaluationData", model_metadata: dict) 
             "org_units": json.dumps(model_metadata.get("org_units", [])),
             "historical_context_periods": model_metadata.get("historical_context_periods", 0),
             "chap_version": CHAP_VERSION,
-            "model_info" : model_metadata.get("model_info")
+            "model_info": model_metadata.get("model_info"),
         }
     )
 
@@ -600,11 +600,7 @@ class Evaluation(EvaluationBase):
         """
         flat_data = self.to_flat()
 
-        model_template_json = (
-            model_info.model_dump_json(exclude_none=True)
-            if model_info is not None
-            else ""
-        )
+        model_template_json = model_info.model_dump_json(exclude_none=True) if model_info is not None else ""
 
         model_metadata = {
             "model_name": model_name or "",

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -31,9 +31,9 @@ from chap_core.database.dataset_tables import DataSet, Observation, ObservationB
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
 from chap_core.database.tables import BackTest, BackTestForecast
 from chap_core.datatypes import SamplesWithTruth
+from chap_core.external.model_configuration import ModelTemplateConfigV2
 from chap_core.rest_api.data_models import BackTestCreate
 from chap_core.time_period import TimePeriod
-from chap_core.external.model_configuration import ModelTemplateConfigV2
 
 try:
     from chap_core import __version__ as CHAP_VERSION

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -601,7 +601,7 @@ class Evaluation(EvaluationBase):
         """
         flat_data = self.to_flat()
 
-        model_template_json = model_info.model_dump_json(exclude_none=True) if model_info is not None else ""
+
 
         model_metadata = {
             "model_name": model_name or "",
@@ -610,8 +610,10 @@ class Evaluation(EvaluationBase):
             "split_periods": self.get_split_periods(),
             "org_units": self.get_org_units(),
             "historical_context_periods": self._historical_context_periods,
-            "model_info": model_template_json,
         }
+
+        if model_info is not None:
+            model_metadata["model_info"] = model_info.model_dump_json(exclude_none=True)
 
         ds = _flat_data_to_xarray(flat_data, model_metadata)
         ds.to_netcdf(filepath)

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -84,20 +84,22 @@ def _flat_data_to_xarray(flat_data: "FlatEvaluationData", model_metadata: dict) 
     ds = xr.Dataset(data_vars)
 
     # Add global attributes
-    ds.attrs.update(
-        {
-            "title": "CHAP Model Evaluation Results",
-            "model_name": model_metadata.get("model_name", ""),
-            "model_configuration": json.dumps(model_metadata.get("model_configuration", {})),
-            "model_version": model_metadata.get("model_version", ""),
-            "created_date": datetime.datetime.now().isoformat(),
-            "split_periods": json.dumps(model_metadata.get("split_periods", [])),
-            "org_units": json.dumps(model_metadata.get("org_units", [])),
-            "historical_context_periods": model_metadata.get("historical_context_periods", 0),
-            "chap_version": CHAP_VERSION,
-            "model_info": model_metadata.get("model_info"),
-        }
-    )
+    attrs = {
+        "title": "CHAP Model Evaluation Results",
+        "model_name": model_metadata.get("model_name", ""),
+        "model_configuration": json.dumps(model_metadata.get("model_configuration", {})),
+        "model_version": model_metadata.get("model_version", ""),
+        "created_date": datetime.datetime.now().isoformat(),
+        "split_periods": json.dumps(model_metadata.get("split_periods", [])),
+        "org_units": json.dumps(model_metadata.get("org_units", [])),
+        "historical_context_periods": model_metadata.get("historical_context_periods", 0),
+        "chap_version": CHAP_VERSION,
+    }
+
+    if "model_info" in model_metadata:
+        attrs["model_info"] = model_metadata["model_info"]
+
+    ds.attrs.update(attrs)
 
     return ds
 

--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -429,7 +429,7 @@ def eval_cmd(
             model_name=model_name,
             model_configuration=configuration.model_dump() if configuration else {},
             model_version=template.model_template_config.version or "unknown",
-            model_info=model_info or None,
+            model_info=model_info,
         )
 
         logger.info(f"Evaluation complete. Results saved to {output_file}")

--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -429,6 +429,7 @@ def eval_cmd(
             model_name=model_name,
             model_configuration=configuration.model_dump() if configuration else {},
             model_version=template.model_template_config.version or "unknown",
+            model_info=model_info or None,
         )
 
         logger.info(f"Evaluation complete. Results saved to {output_file}")

--- a/tests/evaluation/test_evaluation_serialization.py
+++ b/tests/evaluation/test_evaluation_serialization.py
@@ -10,6 +10,7 @@ import xarray as xr
 
 from chap_core.assessment.evaluation import Evaluation, FlatEvaluationData
 from chap_core.assessment.flat_representations import FlatForecasts, FlatObserved
+from chap_core.external.model_configuration import ModelTemplateConfigV2
 
 
 class TestEvaluationSerialization:
@@ -71,6 +72,35 @@ class TestEvaluationSerialization:
         assert ds.attrs["model_version"] == "2.1.0"
         assert "created_date" in ds.attrs
         assert "chap_version" in ds.attrs
+
+        ds.close()
+
+    def test_to_file_includes_model_info(self, backtest, tmp_path):
+        """Test that to_file includes model_info in metadata."""
+        evaluation = Evaluation.from_backtest(backtest)
+        output_file = tmp_path / "test_evaluation_with_model_info.nc"
+
+        model_info = ModelTemplateConfigV2(
+            name="test-model",
+            version="1.2.3",
+            source_url="https://example.com/model",
+        )
+
+        evaluation.to_file(
+            filepath=output_file,
+            model_name="TestModel",
+            model_info=model_info,
+        )
+
+        ds = xr.open_dataset(output_file)
+
+        assert "model_info" in ds.attrs
+        assert ds.attrs["model_info"]
+
+        parsed_model_info = ModelTemplateConfigV2.model_validate_json(ds.attrs["model_info"])
+        assert parsed_model_info.name == model_info.name
+        assert parsed_model_info.version == model_info.version
+        assert parsed_model_info.source_url == model_info.source_url
 
         ds.close()
 


### PR DESCRIPTION
Currently, the model card generator(not merged yet) can not access the model template model_info from the model template directly, and requires the run directory as an additional input. This PR stores serialized model_info in Evaluation NetCDF metadata during Evaluation.to_file( ), so model card generation can use only the evaluation file path.