### PR TITLE
bump uv version for worker image

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -17,7 +17,7 @@ ENV GIT_REVISION=${GIT_REVISION}
 USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates docker.io && \
-    curl -LsSf https://astral.sh/uv/0.10/install.sh | sh && \
+    curl -LsSf https://astral.sh/uv/0.11.4/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add uv to PATH


### PR DESCRIPTION
Chap fails to start worker on NREC

https://astral.sh/uv/0.10/install.sh no longer exists (according to Claude), logs here http://158.39.75.126/logs/chap-core-master/chap-core-master.txt, see "(22) The requested URL returned error: 404"

Switched to 0.11.4