### PR TITLE
feat: improve predicted vs actual plot and use 1-based horizon distance

### DIFF
--- a/chap_core/assessment/backtest_plots/predicted_vs_actual_plot.py
+++ b/chap_core/assessment/backtest_plots/predicted_vs_actual_plot.py
@@ -12,6 +12,12 @@ import pandas as pd
 from chap_core.assessment.backtest_plots import BacktestPlotBase, ChartType, backtest_plot
 
 
+def _nice_tick_values(data_max: float) -> np.ndarray:
+    """Generate nice round tick values from 0 up to data_max."""
+    candidates = [0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000]
+    return np.array([v for v in candidates if v <= data_max * 1.1])
+
+
 @backtest_plot(
     plot_id="predicted_vs_actual",
     name="Predicted vs Actual",
@@ -34,12 +40,35 @@ class PredictedVsActualPlot(BacktestPlotBase):
         merged["log1p_predicted"] = np.log1p(merged["median_forecast"])
         merged["log1p_actual"] = np.log1p(merged["disease_cases"])
 
-        chart = (
-            alt.Chart(merged)
+        data_max = max(merged["median_forecast"].max(), merged["disease_cases"].max())
+        tick_values = _nice_tick_values(data_max)
+        log1p_ticks = np.log1p(tick_values).tolist()
+
+        axis_min = min(merged["log1p_predicted"].min(), merged["log1p_actual"].min())
+        axis_max = max(merged["log1p_predicted"].max(), merged["log1p_actual"].max())
+        merged["_identity_min"] = axis_min
+        merged["_identity_max"] = axis_max
+
+        scatter = (
+            alt.Chart()
             .mark_circle(size=60, opacity=0.7)
             .encode(
-                x=alt.X("log1p_predicted:Q", title="Predicted (log1p)"),
-                y=alt.Y("log1p_actual:Q", title="Actual (log1p)"),
+                x=alt.X(
+                    "log1p_predicted:Q",
+                    title="Predicted",
+                    axis=alt.Axis(
+                        values=log1p_ticks,
+                        labelExpr="round(exp(datum.value) - 1)",
+                    ),
+                ),
+                y=alt.Y(
+                    "log1p_actual:Q",
+                    title="Actual",
+                    axis=alt.Axis(
+                        values=log1p_ticks,
+                        labelExpr="round(exp(datum.value) - 1)",
+                    ),
+                ),
                 color=alt.Color("location:N", title="Location"),
                 tooltip=[
                     alt.Tooltip("location:N"),
@@ -48,6 +77,17 @@ class PredictedVsActualPlot(BacktestPlotBase):
                     alt.Tooltip("disease_cases:Q", format=".1f", title="Actual"),
                 ],
             )
+        )
+
+        identity_line = (
+            alt.Chart()
+            .mark_line(color="black", strokeDash=[4, 4])
+            .transform_fold(["_identity_min", "_identity_max"], as_=["_key", "_val"])
+            .encode(x=alt.X("_val:Q"), y=alt.Y("_val:Q"))
+        )
+
+        chart = (
+            alt.layer(scatter, identity_line, data=merged)
             .properties(width=250, height=250, title="Predicted vs Actual (log1p scale)")
             .facet(column=alt.Column("horizon_distance:O", title="Prediction Horizon"))
         )

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -644,9 +644,9 @@ class Evaluation(EvaluationBase):
         for (location, time_period, horizon_distance), group in forecasts_df.groupby(
             ["location", "time_period", "horizon_distance"]
         ):
-            # Calculate last_seen_period from horizon_distance
+            # Calculate last_seen_period from 1-based horizon_distance
             period = TimePeriod.parse(str(time_period))
-            last_seen_period = period - (int(str(horizon_distance)) * period.time_delta)
+            last_seen_period = period - ((int(str(horizon_distance)) - 1) * period.time_delta)
 
             # Get all sample values for this forecast, sorted by sample number
             values = group.sort_values("sample")["forecast"].tolist()

--- a/chap_core/assessment/flat_representations.py
+++ b/chap_core/assessment/flat_representations.py
@@ -54,10 +54,14 @@ class FlatMetric(FlatDataWithHorizon):
 
 
 def horizon_diff(period: str, period2: str) -> int:
-    """Calculate the difference between two time periods in terms of time units."""
+    """Calculate the 1-based horizon distance between two time periods.
+
+    Returns the number of time steps from period2 to period, counting from 1.
+    E.g. if period2 is the last seen period and period is the next one, returns 1.
+    """
     tp = TimePeriod.parse(period)
     tp2 = TimePeriod.parse(period2)
-    return int((tp - tp2) // tp.time_delta)
+    return int((tp - tp2) // tp.time_delta) + 1
 
 
 def _convert_backtest_to_flat_forecasts(backtest_forecasts: list[BackTestForecast]) -> pd.DataFrame:
@@ -240,5 +244,5 @@ class DataDimension(StrEnum):
 DIM_REGISTRY: Mapping[DataDimension, tuple[type, Check | None]] = {
     DataDimension.location: (str, None),
     DataDimension.time_period: (str, None),
-    DataDimension.horizon_distance: (int, Check.ge(0)),
+    DataDimension.horizon_distance: (int, Check.ge(1)),
 }

--- a/chap_core/assessment/metric_table.py
+++ b/chap_core/assessment/metric_table.py
@@ -5,9 +5,10 @@ from chap_core.time_period import TimePeriod
 
 
 def horizon_diff(period: str, period2: str) -> int:
+    """Calculate the 1-based horizon distance between two time periods."""
     tp = TimePeriod.parse(period)
     tp2 = TimePeriod.parse(period2)
-    return int((tp - tp2) // tp.time_delta)
+    return int((tp - tp2) // tp.time_delta) + 1
 
 
 def create_metric_table(metrics: list[BackTestMetric]):


### PR DESCRIPTION
## Summary
- Add a dashed identity line (y=x) to the predicted vs actual scatter plot
- Show axis tick labels in original scale (case counts) instead of log1p values, using explicit tick positions at nice round numbers to avoid duplicate labels
- Change horizon_distance from 0-based to 1-based so horizon 1 means the first forecast period ahead

## Test plan
- [x] All 29 backtest plot tests pass
- [x] All 166 evaluation tests pass
- [x] Lint passes

[CLIM-536](https://dhis2.atlassian.net/browse/CLIM-536)

[CLIM-536]: https://dhis2.atlassian.net/browse/CLIM-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ