### PR TITLE
docs: update chap evaluate to chap eval with URL datasets

### DIFF
--- a/docs/contributor/chap-contributor-setup.md
+++ b/docs/contributor/chap-contributor-setup.md
@@ -63,12 +63,10 @@ If you are an external contributor without write-access to the chap-core reposit
 It is also good to see if you can run chap evaluation on an external model. The recommended command is `chap eval`:
 
 ```bash
-chap eval --model-name https://github.com/dhis2-chap/chap_auto_ewars --dataset-csv example_data/laos_subset.csv --output-file eval.nc --backtest-params.n-splits 2
+chap eval --model-name https://github.com/dhis2-chap/chap_auto_ewars --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --backtest-params.n-splits 2
 ```
 
 If the above command runs successfully, an `eval.nc` file will be generated with the results.
-
-> **Note:** The legacy `chap evaluate` command is deprecated and will be removed in v2.0.
 
 You have now successfully setup a development version of the chap-cli tool and you are ready to start developing.
 If you have any problems installing or setting up the environment, feel free to [contact us](https://github.com/dhis2-chap/chap-core/wiki>).

--- a/docs/contributor/evaluation_pipeline.md
+++ b/docs/contributor/evaluation_pipeline.md
@@ -135,7 +135,7 @@ High-level evaluation abstraction:
 
 ## Code Flow: `Evaluation.create()`
 
-Step-by-step walkthrough of what happens when `Evaluation.create()` is called (e.g. from the CLI `chap evaluate` command):
+Step-by-step walkthrough of what happens when `Evaluation.create()` is called (e.g. from the CLI `chap eval` command):
 
 1. **`backtest()`** is called with the estimator and dataset
 2. Inside `backtest()`, **`train_test_generator()`** computes the split index and creates:

--- a/docs/contributor/evaluation_walkthrough.md
+++ b/docs/contributor/evaluation_walkthrough.md
@@ -2,7 +2,7 @@
 
 This walkthrough is for educational purposes. It breaks the evaluation pipeline
 into individual steps so you can see what happens at each stage. In practice,
-use the higher-level `Evaluation.create` (section 7) or the CLI `chap evaluate`
+use the higher-level `Evaluation.create` (section 7) or the CLI `chap eval`
 command rather than calling the lower-level splitting and prediction functions
 directly.
 

--- a/docs/contributor/evaluation_walkthrough_exec.md
+++ b/docs/contributor/evaluation_walkthrough_exec.md
@@ -2,7 +2,7 @@
 
 This walkthrough is for educational purposes. It breaks the evaluation pipeline
 into individual steps so you can see what happens at each stage. In practice,
-use the higher-level `Evaluation.create` (section 7) or the CLI `chap evaluate`
+use the higher-level `Evaluation.create` (section 7) or the CLI `chap eval`
 command rather than calling the lower-level splitting and prediction functions
 directly.
 

--- a/docs/external_models/chap_evaluate_examples.md
+++ b/docs/external_models/chap_evaluate_examples.md
@@ -1,32 +1,30 @@
-# Examples of chap evaluate commands
-
-> **Deprecation Notice:** The `chap evaluate` command is deprecated and will be removed in v2.0. For new evaluations, use `chap eval` instead. See the [eval Reference](../chap-cli/eval-reference.md) for the recommended evaluation workflow.
+# Examples of chap eval commands
 
 The following are examples of running various chap-integrated models on various datasets:
 
 * minimalist_example_r: 
-`chap evaluate --model-name https://github.com/dhis2-chap/minimalist_example_r --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=2`
+`chap eval --model-name https://github.com/dhis2-chap/minimalist_example_r --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 2`
 * minimalist_multiregion_r: 
-`chap evaluate --model-name https://github.com/dhis2-chap/minimalist_multiregion_r --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=2`
+`chap eval --model-name https://github.com/dhis2-chap/minimalist_multiregion_r --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 2`
 * minimalist_example_lag_r: 
-`chap evaluate --model-name https://github.com/dhis2-chap/minimalist_example_lag_r --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=2`
+`chap eval --model-name https://github.com/dhis2-chap/minimalist_example_lag_r --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 2`
 * Madagascar_ARIMA: 
-`chap evaluate --model-name https://github.com/dhis2-chap/Madagascar_ARIMA --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=2`
-* Epidemiar: `chap evaluate --model-name https://github.com/dhis2-chap/epidemiar_example_model --dataset-csv ../epidemiar_example_data/input/laos_test_data.csv --report-filename report.pdf --debug --n-splits=2`
-* chap_auto_ewars_weekly: `chap evaluate --model-name https://github.com/dhis2-chap/chap_auto_ewars_weekly --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=1`
-* chap_auto_ewars: `chap evaluate --model-name https://github.com/dhis2-chap/chap_auto_ewars --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=1`
+`chap eval --model-name https://github.com/dhis2-chap/Madagascar_ARIMA --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 2`
+* Epidemiar: `chap eval --model-name https://github.com/dhis2-chap/epidemiar_example_model --dataset-csv ../epidemiar_example_data/input/laos_test_data.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 2`
+* chap_auto_ewars_weekly: `chap eval --model-name https://github.com/dhis2-chap/chap_auto_ewars_weekly --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 1`
+* chap_auto_ewars: `chap eval --model-name https://github.com/dhis2-chap/chap_auto_ewars --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 1`
 
-Note that the Epidemiar command uses a local file path for the supplied dataset as it requires weekly data, which is not currently available in Chap's internal datasets. The command above works when cloning the epidemiar_example_model locally and if the command is run from the folder chap-core, then it assumes that the cloned repository is in the same folder as chap-core, and we use the relative file path. You can also simply dowload the csv file laos_test_data.csv from the github folder and reference the path to the local file.
+Note that the Epidemiar command uses a local file path for the supplied dataset as it requires weekly data. The command above works when cloning the epidemiar_example_model locally and if the command is run from the folder chap-core, then it assumes that the cloned repository is in the same folder as chap-core, and we use the relative file path. You can also simply download the csv file laos_test_data.csv from the github folder and reference the path to the local file.
 
-chap_auto_ewars only accepts mothly data while chap_auto_ewars_weekly can use both weekly and monthly data, should be combined together soon. Additionaly there is a version of chap_auto_ewars which uses spatial smoothing and a geojson file which can be ran as
-* `chap evaluate --model-name https://github.com/Halvardgithub/chap_auto_ewars --dataset-csv ../chap_auto_ewars/example_data_Viet/historic_data.csv --polygons-json ../chap_auto_ewars/example_data_Viet/vietnam.json --report-filename report.pdf --debug --n-splits=1 --polygons-id-field VARNAME_1`
+chap_auto_ewars only accepts monthly data while chap_auto_ewars_weekly can use both weekly and monthly data, should be combined together soon. Additionally there is a version of chap_auto_ewars which uses spatial smoothing and a geojson file which can be ran as
+* `chap eval --model-name https://github.com/Halvardgithub/chap_auto_ewars --dataset-csv ../chap_auto_ewars/example_data_Viet/historic_data.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 1`
 The above uses local files and their relative paths, the files are available at the github url.
 
 ## For Windows users
-Windows users might have issues with the commands above. The solution is to clone the repositories for the external models and add the optional command `--run-directory-type use_existing`. An example is shown below.
-* minimalist_example_r: `chap evaluate --model-name /mnt/c/Users/NAME/Documents/GitHub/minimalist_example_r/ --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=2 --run-directory-type use_existing`
+Windows users might have issues with the commands above. The solution is to clone the repositories for the external models and add the optional command `--run-config.run-directory-type use_existing`. An example is shown below.
+* minimalist_example_r: `chap eval --model-name /mnt/c/Users/NAME/Documents/GitHub/minimalist_example_r/ --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 2 --run-config.run-directory-type use_existing`
 
 Note that you need to use your own local file path, and if you are using WSL and ubuntu this might be with `mnt` from linux, even on a Windows system. 
 
 ### Warnings
-When running the command with a local file path for the model folder you can in theory run the command from any folder, not just from chap-core. However, running `chap evaluate` with `--run-directory-type use_existing` from the same folder as you are using as the `--model-name` will cause an inifnite copying loop. Sometimes, if a command fails, it might be neccessary to exit and open the folder again, for example run `cd ../chap-core` to go one folder up and then back to chap-core. Additionaly, having an active VPN can aslo confuse Chap and cause the commands to fail.
+When running the command with a local file path for the model folder you can in theory run the command from any folder, not just from chap-core. However, running `chap eval` with `--run-config.run-directory-type use_existing` from the same folder as you are using as the `--model-name` will cause an infinite copying loop. Sometimes, if a command fails, it might be necessary to exit and open the folder again, for example run `cd ../chap-core` to go one folder up and then back to chap-core. Additionally, having an active VPN can also confuse Chap and cause the commands to fail.

--- a/docs/external_models/chapkit.md
+++ b/docs/external_models/chapkit.md
@@ -113,9 +113,7 @@ Along with the data, Chap sends a `run_info` object containing runtime parameter
 
 ## How to run a chapkit model from the command line
 
-> **Deprecation Notice:** The `chap evaluate` command shown below is deprecated and will be removed in v2.0. For chapkit model evaluation, use `chap eval` with `--run-config.is-chapkit-model` instead. See the [Evaluation Workflow](../chap-cli/evaluation-workflow.md) for details on `chap eval`.
-
-To test that the model is working with chap, you can use the `chap evaluate` command. Instead of a github url or model name, you simply specify the REST API url to the model and add --is-chapkit-model to the command to tell chap that the model is a chapkit model.
+To test that the model is working with chap, you can use the `chap eval` command. Instead of a github url or model name, you simply specify the REST API url to the model and add `--run-config.is-chapkit-model` to the command to tell chap that the model is a chapkit model.
 
 **Example:**
 
@@ -135,7 +133,7 @@ docker run -p 5001:8000 ghcr.io/dhis2-chap/chtorch:chapkit2-8f17ee3
 Then we can run the following command to evaluate the model. Note the http://localhost:5001 url, which tells chap to look for the model at that url.
 
 ```console
-chap evaluate --model-name http://localhost:5001 --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=2 --model-configuration-yaml testconfig.yaml --prediction-length 3 --is-chapkit-model
+chap eval --model-name http://localhost:5001 --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 2 --backtest-params.n-periods 3 --model-configuration-yaml testconfig.yaml --run-config.is-chapkit-model
 ```
 
 

--- a/docs/external_models/model_explainability.md
+++ b/docs/external_models/model_explainability.md
@@ -2,7 +2,7 @@
 
 Note that this is a temporary solution and that this functionality will be integrated and expanded upon in the future, but it serves as a simple ad-hoc solution for now.
 
-Understanding why a model makes certain predictions is important both for building trust in forecasts and for guiding model development. This page describes how to extract and visualise explanatory information from your model within the Chap framework. This tutorial will explain how to alter your model code to save the desired files generated in the model code and where to find them after a run is complete. This tutorial assumes you are using `chap evaluate` from the CLI.
+Understanding why a model makes certain predictions is important both for building trust in forecasts and for guiding model development. This page describes how to extract and visualise explanatory information from your model within the Chap framework. This tutorial will explain how to alter your model code to save the desired files generated in the model code and where to find them after a run is complete. This tutorial assumes you are using `chap eval` from the CLI.
 
 We provide examples in both *R* and *Python*.
 

--- a/docs/external_models/running_models_in_chap.md
+++ b/docs/external_models/running_models_in_chap.md
@@ -2,37 +2,35 @@
 
 In order to run Chap, you should first follow our [guide for how to install Chap](../chap-cli/chap-core-cli-setup.md).
 
-> **Deprecation Notice:** The `chap evaluate` command shown below is deprecated and will be removed in v2.0. For new evaluations, use `chap eval` instead. See the [eval Reference](../chap-cli/eval-reference.md) and [Evaluation Workflow](../chap-cli/evaluation-workflow.md) for the recommended approach.
-
-Models that are compatible with Chap can be used with the `chap evaluate` command.
+Models that are compatible with Chap can be used with the `chap eval` command.
 An external model can be provided to Chap in two ways:
 
 - By specifying a path to a local code base:
 
 ```bash
-$ chap evaluate --model-name /path/to/your/model/directory --dataset-name ISIMIP_dengue_harmonized --dataset-country brazil --report-filename report.pdf --ignore-environment  --debug
+$ chap eval --model-name /path/to/your/model/directory --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.ignore-environment --run-config.debug
 ```
 
 - By specifying a github URL to a git repo (the url needs to start with https://github.com/):
 
 ```bash
-$ chap evaluate --model-name https://github.com/dhis2-chap/minimalist_example --dataset-name ISIMIP_dengue_harmonized --dataset-country brazil --report-filename report.pdf --ignore-environment  --debug
+$ chap eval --model-name https://github.com/dhis2-chap/minimalist_example --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.ignore-environment --run-config.debug
 ```
 
-Note the `--ignore-environment` in the above commands.
+Note the `--run-config.ignore-environment` in the above commands.
 This means that we don't ask Chap to use Docker or a Python environment when running the model.
 This can be useful when developing and testing custom models before deploying them to a production environment.
 Instead the model will be run directly using the current environment you are in.
 This usually works fine when developing a model, but requires you to have both chap-core and the dependencies of your model available.
 
-As an example, the following command runs the chap_auto_ewars model on public ISMIP data for Brazil (this does not use --ignore-environment and will set up
+As an example, the following command runs the chap_auto_ewars model (this does not use --run-config.ignore-environment and will set up
 a docker container based on the specifications in the MLproject file of the model):
 
 ```bash
-$ chap evaluate --model-name https://github.com/dhis2-chap/chap_auto_ewars --dataset-name ISIMIP_dengue_harmonized --dataset-country brazil
+$ chap eval --model-name https://github.com/dhis2-chap/chap_auto_ewars --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot
 ```
 
-If the above command runs without any error messages, you have successfully evaluated the model through Chap, and a file `report.pdf` should have been generated with predictions for various regions.
+If the above command runs without any error messages, you have successfully evaluated the model through Chap, and an `eval.nc` file should have been generated along with an HTML plot with predictions for various regions.
 
 A folder `runs/model_name/latest` should also have been generated that contains copy of your model directory along with data files used. This can be useful to inspect if something goes wrong.
 
@@ -40,10 +38,10 @@ A folder `runs/model_name/latest` should also have been generated that contains 
 
 We are currently working on experimental functionality for passing options and other parameters through Chap to the model.
 
-The first way we plan to support this is when evaluating a model using the same `chap evaluate` command as described above.
+The first way we plan to support this is when evaluating a model using the same `chap eval` command as described above.
 
 This functionality is under development. Below is a minimal working example using the model `naive_python_model_with_mlproject_file_and_docker`. This model has a user_option `some_option`, which we can specify in a yaml file:
 
 ```bash
-chap evaluate --model-name external_models/naive_python_model_with_mlproject_file_and_docker/ --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --n-splits 2 --model-configuration-yaml external_models/naive_python_model_with_mlproject_file_and_docker/example_model_configuration.yaml
+chap eval --model-name external_models/naive_python_model_with_mlproject_file_and_docker/ --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --backtest-params.n-splits 2 --model-configuration-yaml external_models/naive_python_model_with_mlproject_file_and_docker/example_model_configuration.yaml
 ```

--- a/docs/external_models/side_by_side_comparison.md
+++ b/docs/external_models/side_by_side_comparison.md
@@ -6,4 +6,3 @@ The most powerful way of comparing models is to install the Chap modelling platf
 
 As a simpler setup, you can evaluate your own and other models using the [Chap command line interface](../chap-cli/evaluation-workflow.md) with the `chap eval` command, and then compare the resulting predictions using `chap export-metrics`. See the [Evaluation Workflow](../chap-cli/evaluation-workflow.md) for the recommended approach.
 
-> **Note:** The legacy `chap evaluate` command is deprecated and will be removed in v2.0. See the [legacy examples](chap_evaluate_examples.md) for reference.

--- a/docs/external_models/surplus_after_refactoring.md
+++ b/docs/external_models/surplus_after_refactoring.md
@@ -1,6 +1,5 @@
 # Integrating External Models with DHIS2 through Chap
 
-> **Deprecation Notice:** The `chap evaluate` command examples shown in this document are deprecated and will be removed in v2.0. For new evaluations, use `chap eval` instead. See the [Evaluation Workflow](../chap-cli/evaluation-workflow.md) for the recommended approach.
 
 Assuming you have Chap running on a server with DHIS2 ([see this guide](../modeling-app/running-chap-on-server.md)), it is possible to
 make new external models available.
@@ -21,20 +20,20 @@ This model has been developed internally by the Chap team. Autoregressive weekly
 ## Epidemiar
 Epidemiar is a generalized additive model (GAM) used for climate health forecasts. It requires weekly epidemilogical data, like disease cases and population, and daily enviromental data. As most of the data in Chap is monthly or weekly we pass weekly data to the model, and then naively expand weekly data to daily data, which the epidemiar library again aggregates back to weekly data. The model produces a sample for each location per time point with and upper and lower boundary for some unknown quantiles. For more information regarding the model look [here](https://github.com/dhis2-chap/epidemiar_example_model). An example of running the model from the Chap command line interface is
 ```
-chap evaluate --model-name https://github.com/dhis2-chap/epidemiar_example_model --dataset-csv LOCAL_FILE_PATH/laos_test_data.csv --report-filename report.pdf --debug --n-splits=3
+chap eval --model-name https://github.com/dhis2-chap/epidemiar_example_model --dataset-csv LOCAL_FILE_PATH/laos_test_data.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 3
 ```
-which requires that `laos_test_data` is saved locally, but we are working on making weekly datasets available internaly in Chap.
+which requires that `laos_test_data` is saved locally, but we are working on making weekly datasets available.
 
 ## EWARS
 EWARS is a Bayesian hierarchical model implemented with the INLA library. We use a negative binomial likelihood in the observation layer and combine several latent effect, both spatial and temporal, in the latent layer. The latent layer is log-transformed and scaled by the population, so it effectivaly models the proprotion of cases in each region. Specifically the latent layers combine a first order cyclic random walk to capture the seasonal effect, this is also included in the lagged exogenous variables rainfall and temperature, then a spatial smoothing with an ICAR and an iid effect to capture the spatial heterogeneity. The ICAR and iid can also be combined, scaled and reparameterized to the BYM2 model. Further information is available in the [model repository](https://github.com/dhis2-chap/chap_auto_ewars). An example of running the model from the Chap command line interface is
 ```
-chap evaluate --model-name https://github.com/dhis2-chap/chap_auto_ewars --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=3
+chap eval --model-name https://github.com/dhis2-chap/chap_auto_ewars --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 3
 ```
 
 ## ARIMA
 A general ARIMA model is a timeseries model with an autoregressive part, a moving average part and the option to difference the original timeseries, often to make it stationary. Additonally we have lagged rainfall and temperature, which actually makes this an ARIMAX model, where the X indicates exogenous variables. This model handles each region individually and it expects monthly data for all the covariates. The model utilizes the `arima` function which chooses the order of the differencing, autoregression and the moving average for us. Further information is available in the [model repository](https://github.com/dhis2-chap/Madagascar_ARIMA). An example of running the model from the Chap command line interface is
 ```
-chap evaluate --model-name https://github.com/dhis2-chap/Madagascar_ARIMA --dataset-name ISIMIP_dengue_harmonized --dataset-country vietnam --report-filename report.pdf --debug --n-splits=3
+chap eval --model-name https://github.com/dhis2-chap/Madagascar_ARIMA --dataset-csv https://raw.githubusercontent.com/dhis2/climate-health-data/refs/heads/main/lao/chap_LAO_admin1_monthly.csv --output-file eval.nc --plot --run-config.debug --backtest-params.n-splits 3
 ```
 
 

--- a/docs/feature_tutorials/extended_predictor.md
+++ b/docs/feature_tutorials/extended_predictor.md
@@ -43,5 +43,3 @@ rm -f ./extended_predictor_test.nc
 ```
 
 When the requested `n-periods` exceeds the model's `max_prediction_length`, Chap automatically uses `ExtendedPredictor` to make iterative predictions.
-
-> **Note:** The legacy `chap evaluate` command is deprecated and will be removed in v2.0. Use `chap eval` instead.

--- a/docs/kigali-workshop/kigali-webinar-series/session-3/fork-example.md
+++ b/docs/kigali-workshop/kigali-webinar-series/session-3/fork-example.md
@@ -71,6 +71,6 @@ After following the README, and making changes to the code, you should commit an
 - You have a forked repository under your GitHub account
 - You can see the README.md file in the repository
 - You have been able to run the model in isolated mode
-- You have been able to run your model through chap (using the chap evaluate command) and you have gotten a report.pdf with some results.
+- You have been able to run your model through chap (using the chap eval command) and you have gotten evaluation results.
 - You have been able to make changes, and you have pushed the changes to your fork on Github
 

--- a/docs/kigali-workshop/kigali-webinar-series/session-3/install-chap.md
+++ b/docs/kigali-workshop/kigali-webinar-series/session-3/install-chap.md
@@ -1,5 +1,5 @@
 # 1. Installing Chap
-In this guide, you'll install the Chap command-line tool. Once installed, you can run chap evaluate to test any model against real datasets — which you'll do in the next guide in this session.
+In this guide, you'll install the Chap command-line tool. Once installed, you can run chap eval to test any model against real datasets — which you'll do in the next guide in this session.
 
 ## Why Chap?
 Chap (Climate and Health Assessment Platform) is a tool for developing and evaluating disease prediction models that use climate data. The `chap` command-line tool allows you to:
@@ -38,6 +38,6 @@ Run the following command:
 chap --help
 ```
 
-You should see output listing available commands including `evaluate`, `plot-backtest`, and `export-metrics`.
+You should see output listing available commands including `eval`, `plot-backtest`, and `export-metrics`.
 
 **Verification:** If you see the help output with available commands, Chap is installed correctly. You're ready for the next guide: [Implement your own model from a minimalist example](fork-example.md).


### PR DESCRIPTION
## Summary
- Replace all deprecated `chap evaluate` commands with `chap eval` across 13 documentation files
- Use URL-based dataset (`climate-health-data` repo) instead of built-in `--dataset-name ISIMIP_dengue_harmonized --dataset-country <country>` pattern
- Add `--plot` flag for direct HTML plot generation
- Update CLI flag syntax (`--debug` -> `--run-config.debug`, `--n-splits` -> `--backtest-params.n-splits`, etc.)
- Remove deprecation notices that are no longer needed

## Test plan
- [ ] Verify no remaining `chap evaluate` references: `grep -r "chap evaluate" docs/`
- [ ] Verify no remaining `--dataset-name` references: `grep -r "dataset-name" docs/`
- [ ] Verify docs build succeeds