### PR TITLE
feat(compose): add ewars overlay using chapkit self-registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean coverage dist docs help install lint lint/flake8 test-chapkit-compose force-restart restart
+.PHONY: clean coverage dist docs help install lint lint/flake8 test-chapkit-compose force-restart restart chap-version
 .DEFAULT_GOAL := help
 
 define PRINT_HELP_PYSCRIPT
@@ -91,4 +91,7 @@ force-restart: ## tear down, rebuild, and start docker compose from scratch (WIP
 	docker compose -f compose.yml -f compose.ewars.yml down -v && docker compose -f compose.yml -f compose.ewars.yml build --no-cache && docker compose -f compose.yml -f compose.ewars.yml up --remove-orphans
 
 restart: ## soft restart docker compose (preserves volumes; rebuilds only on source changes)
-	docker compose -f compose.yml -f compose.ewars.yml down && docker compose -f compose.yml -f compose.ewars.yml up -d --build --remove-orphans
+	docker compose -f compose.yml -f compose.ewars.yml down && docker compose -f compose.yml -f compose.ewars.yml up -d --build --remove-orphans && $(MAKE) chap-version
+
+chap-version: ## print the chap_core version running inside the chap container
+	@docker compose -f compose.yml -f compose.ewars.yml exec -T chap python -c 'import chap_core; print(f"chap_core running in container: {chap_core.__version__}")' 2>/dev/null || echo "chap container not running"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean coverage dist docs help install lint lint/flake8 test-chapkit-compose force-restart
+.PHONY: clean coverage dist docs help install lint lint/flake8 test-chapkit-compose force-restart restart
 .DEFAULT_GOAL := help
 
 define PRINT_HELP_PYSCRIPT
@@ -87,5 +87,8 @@ dist: clean ## build source and wheel package
 install: clean ## sync dependencies and install package in development mode
 	uv sync
 
-force-restart: ## tear down, rebuild, and start docker compose from scratch
+force-restart: ## tear down, rebuild, and start docker compose from scratch (WIPES VOLUMES including chap-db)
 	docker compose -f compose.yml -f compose.ewars.yml down -v && docker compose -f compose.yml -f compose.ewars.yml build --no-cache && docker compose -f compose.yml -f compose.ewars.yml up --remove-orphans
+
+restart: ## soft restart docker compose (preserves volumes; rebuilds only on source changes)
+	docker compose -f compose.yml -f compose.ewars.yml down && docker compose -f compose.yml -f compose.ewars.yml up -d --build --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,4 @@ install: clean ## sync dependencies and install package in development mode
 	uv sync
 
 force-restart: ## tear down, rebuild, and start docker compose from scratch
-	docker compose down -v && docker compose build --no-cache && docker compose up --remove-orphans
+	docker compose -f compose.yml -f compose.ewars.yml down -v && docker compose -f compose.yml -f compose.ewars.yml build --no-cache && docker compose -f compose.yml -f compose.ewars.yml up --remove-orphans

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -308,6 +308,70 @@ class SessionWrapper:
 
         return configured_model
 
+    def _resolve_chapkit_live_source_url(
+        self,
+        *,
+        service_id: str,
+        stored_source_url: str | None,
+        template: ModelTemplateDB,
+    ) -> str | None:
+        """Prefer the live chapkit URL from the v2 service registry over the DB row.
+
+        Container recreations change the auto-detected docker hostname each time,
+        and the lazy `_sync_live_chapkit_services` hook only fires on
+        `GET /v1/crud/model-templates`. Without this the celery worker can grab
+        a stale `source_url` and fail with `httpx.ConnectError: Name or service
+        not known` as soon as a chapkit container has been recreated since the
+        last template list.
+
+        Looks up the Orchestrator (Redis) by `service_id` (= template name, which
+        is the chapkit service id). If the live URL differs from the stored one,
+        writes the fresh value back onto the template row so subsequent lookups
+        are consistent. Falls back to `stored_source_url` on any failure so we
+        preserve the existing behaviour for non-registry code paths (tests,
+        environments without Redis, etc.).
+        """
+        try:
+            from chap_core.rest_api.services.orchestrator import (
+                Orchestrator,
+                ServiceNotFoundError,
+            )
+            from chap_core.rest_api.v2.dependencies import get_redis
+
+            live = Orchestrator(redis_client=get_redis()).get(service_id)
+        except ImportError:
+            return stored_source_url
+        except Exception as exc:
+            # ServiceNotFoundError or redis unavailability: warn and fall back.
+            if exc.__class__.__name__ == "ServiceNotFoundError":
+                logger.warning(
+                    "Chapkit service %s not in v2 registry; falling back to stored source_url %s",
+                    service_id,
+                    stored_source_url,
+                )
+            else:
+                logger.debug(
+                    "Live orchestrator lookup failed for chapkit service %s",
+                    service_id,
+                    exc_info=True,
+                )
+            return stored_source_url
+
+        live_url = getattr(live, "url", None)
+        if not live_url:
+            return stored_source_url
+
+        if live_url != stored_source_url:
+            logger.info(
+                "Refreshing stale chapkit source_url for %s: %s -> %s",
+                service_id,
+                stored_source_url,
+                live_url,
+            )
+            template.source_url = live_url
+            self.session.commit()
+        return live_url
+
     def get_configured_model_with_code(self, configured_model_id: int) -> ConfiguredModel:
         logger.info(f"Getting configured model with id {configured_model_id}")
         configured_model = self.session.get(ConfiguredModelDB, configured_model_id)
@@ -322,9 +386,14 @@ class SessionWrapper:
         )  # TODO: seems hacky, how to fix?
 
         if configured_model.uses_chapkit:
-            logger.info(f"Assuming chapkit model at {configured_model.model_template.source_url}")
-            assert configured_model.model_template.source_url is not None
-            template = ExternalChapkitModelTemplate(configured_model.model_template.source_url)
+            source_url = self._resolve_chapkit_live_source_url(
+                service_id=template_name,
+                stored_source_url=configured_model.model_template.source_url,
+                template=configured_model.model_template,
+            )
+            logger.info(f"Assuming chapkit model at {source_url}")
+            assert source_url is not None
+            template = ExternalChapkitModelTemplate(source_url)
             logger.info(f"template: {template}")
             logger.info(f"configured_model: {configured_model}")
             return template.get_model(configured_model)  # type: ignore[arg-type, return-value]

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -332,29 +332,26 @@ class SessionWrapper:
         environments without Redis, etc.).
         """
         try:
-            from chap_core.rest_api.services.orchestrator import (
-                Orchestrator,
-                ServiceNotFoundError,
-            )
+            from chap_core.rest_api.services.orchestrator import Orchestrator, ServiceNotFoundError
             from chap_core.rest_api.v2.dependencies import get_redis
-
-            live = Orchestrator(redis_client=get_redis()).get(service_id)
         except ImportError:
             return stored_source_url
-        except Exception as exc:
-            # ServiceNotFoundError or redis unavailability: warn and fall back.
-            if exc.__class__.__name__ == "ServiceNotFoundError":
-                logger.warning(
-                    "Chapkit service %s not in v2 registry; falling back to stored source_url %s",
-                    service_id,
-                    stored_source_url,
-                )
-            else:
-                logger.debug(
-                    "Live orchestrator lookup failed for chapkit service %s",
-                    service_id,
-                    exc_info=True,
-                )
+
+        try:
+            live = Orchestrator(redis_client=get_redis()).get(service_id)
+        except ServiceNotFoundError:
+            logger.warning(
+                "Chapkit service %s not in v2 registry; falling back to stored source_url %s",
+                service_id,
+                stored_source_url,
+            )
+            return stored_source_url
+        except Exception:
+            logger.debug(
+                "Live orchestrator lookup failed for chapkit service %s",
+                service_id,
+                exc_info=True,
+            )
             return stored_source_url
 
         live_url = getattr(live, "url", None)
@@ -370,7 +367,7 @@ class SessionWrapper:
             )
             template.source_url = live_url
             self.session.commit()
-        return live_url
+        return cast("str", live_url)
 
     def get_configured_model_with_code(self, configured_model_id: int) -> ConfiguredModel:
         logger.info(f"Getting configured model with id {configured_model_id}")

--- a/chap_core/models/chapkit_rest_api_wrapper.py
+++ b/chap_core/models/chapkit_rest_api_wrapper.py
@@ -1,5 +1,6 @@
 """Synchronous REST API wrapper for CHAPKit service."""
 
+import contextlib
 import logging
 import time
 from typing import Any, cast
@@ -105,11 +106,9 @@ class CHAPKitRestAPIWrapper:
 
     def delete_config(self, config_id: str) -> None:
         """Delete a model configuration by id. Silently ignores failures."""
-        try:
+        # Best-effort cleanup for probe configs etc.
+        with contextlib.suppress(Exception):
             self._request("DELETE", f"/api/v1/configs/{config_id}")
-        except Exception:
-            # Best-effort cleanup for probe configs etc.
-            pass
 
     def get_config_schema(self) -> dict[str, Any]:
         """Get JSON Schema for model configuration."""

--- a/chap_core/models/chapkit_rest_api_wrapper.py
+++ b/chap_core/models/chapkit_rest_api_wrapper.py
@@ -103,6 +103,14 @@ class CHAPKitRestAPIWrapper:
         response = self._request("POST", "/api/v1/configs", json=config)
         return chapkit.ConfigOut.model_validate(response.json())
 
+    def delete_config(self, config_id: str) -> None:
+        """Delete a model configuration by id. Silently ignores failures."""
+        try:
+            self._request("DELETE", f"/api/v1/configs/{config_id}")
+        except Exception:
+            # Best-effort cleanup for probe configs etc.
+            pass
+
     def get_config_schema(self) -> dict[str, Any]:
         """Get JSON Schema for model configuration."""
         response = self._request("GET", "/api/v1/configs/$schema")

--- a/chap_core/models/external_chapkit_model.py
+++ b/chap_core/models/external_chapkit_model.py
@@ -8,6 +8,7 @@ from chap_core.models.chapkit_rest_api_wrapper import CHAPKitRestAPIWrapper, Run
 from chap_core.models.chapkit_service_manager import ChapkitServiceManager, is_url
 from chap_core.models.external_model import ExternalModelBase
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+from chap_core.time_period import TimePeriod
 
 logger = logging.getLogger(__name__)
 
@@ -199,6 +200,14 @@ class ExternalChapkitModelTemplate:
         else:
             model_configuration = dict(model_configuration)
 
+        # chap-core's ConfiguredModelDB row has an `additional_continuous_covariates`
+        # column with a `default_factory=list`, so dumping the row produces an
+        # explicit `[]` that would override whatever default the chapkit service's
+        # own BaseConfig schema declares. Drop the key when empty so the service's
+        # schema default applies (e.g. ewars defaults to ["rainfall","mean_temperature"]).
+        if not model_configuration.get("additional_continuous_covariates"):
+            model_configuration.pop("additional_continuous_covariates", None)
+
         timestamp = int(time.time() * 1000000)
         if "name" not in model_configuration:
             name = f"{self.name}_config_{timestamp}"
@@ -333,7 +342,15 @@ class ExternalChapkitModel(ExternalModelBase):
         # get artifact from the client
         prediction_data = self.client.get_prediction_artifact_dataframe(artifact_id)
         pd = prediction_data.to_pandas()
-        # Sort by location and time_period to ensure consecutive periods
+        # Drop any predictions before the future window start. Some models (e.g. EWARS)
+        # run inference over the combined historic+future frame and emit predictions for
+        # every row with NA disease_cases, which includes missing-reporting months in
+        # historic data. Mirrors the legacy path in ExternalCommandLineModel.predict.
+        if "time_period" in pd.columns:
+            start_time = future_data.start_timestamp
+            time_periods = [TimePeriod.parse(s) for s in pd.time_period.astype(str)]
+            mask = [start_time <= tp.start_timestamp for tp in time_periods]
+            pd = pd[mask]
         if "time_period" in pd.columns and "location" in pd.columns:
             pd = pd.sort_values(by=["location", "time_period"]).reset_index(drop=True)
         return DataSet.from_pandas(pd, Samples)

--- a/chap_core/rest_api/celery_tasks.py
+++ b/chap_core/rest_api/celery_tasks.py
@@ -33,10 +33,11 @@ class JobType(StrEnum):
     freely; only the string values are load-bearing.
     """
 
-    EVALUATION_LEGACY = "create_backtest"          # /v1/crud/backtests and /v1/analytics/create-backtest
-    EVALUATION = "create_backtest_from_data"       # /v1/analytics/create-backtest-with-data/
-    PREDICTION = "create_prediction"               # /v1/analytics/make-prediction
-    DATASET = "create_dataset"                     # /v1/analytics/make-dataset
+    EVALUATION_LEGACY = "create_backtest"  # /v1/crud/backtests and /v1/analytics/create-backtest
+    EVALUATION = "create_backtest_from_data"  # /v1/analytics/create-backtest-with-data/
+    PREDICTION = "create_prediction"  # /v1/analytics/make-prediction
+    DATASET = "create_dataset"  # /v1/analytics/make-dataset
+
 
 # We use get_task_logger to ensure we get the Celery-friendly logger
 # but you could also just use logging.getLogger(__name__) if you prefer.

--- a/chap_core/rest_api/celery_tasks.py
+++ b/chap_core/rest_api/celery_tasks.py
@@ -4,6 +4,7 @@ import logging
 import os
 from collections.abc import Callable
 from datetime import datetime
+from enum import StrEnum
 from typing import TypeVar, cast
 
 import celery
@@ -19,6 +20,18 @@ from ..log_config import CHAP_LOGS_DIR, get_status_logger
 from ..util import load_redis
 
 ReturnType = TypeVar("ReturnType")
+
+
+class JobType(StrEnum):
+    """Canonical job type labels surfaced to the UI and the /v1/jobs filter.
+
+    Values must stay stable across chap-core and the modeling app frontend;
+    agree on any rename before changing.
+    """
+
+    EVALUATION = "Evaluation"
+    PREDICTION = "Prediction"
+    DATASET = "Dataset"
 
 # We use get_task_logger to ensure we get the Celery-friendly logger
 # but you could also just use logging.getLogger(__name__) if you prefer.

--- a/chap_core/rest_api/celery_tasks.py
+++ b/chap_core/rest_api/celery_tasks.py
@@ -23,15 +23,20 @@ ReturnType = TypeVar("ReturnType")
 
 
 class JobType(StrEnum):
-    """Canonical job type labels surfaced to the UI and the /v1/jobs filter.
+    """Canonical job type strings surfaced to the UI and the /v1/jobs filter.
 
-    Values must stay stable across chap-core and the modeling app frontend;
-    agree on any rename before changing.
+    Values are the public contract with the modeling app frontend (see
+    `apps/modeling-app/src/hooks/useJobs.ts:JOB_TYPES`). The string values
+    look legacy/verbose because they match the FE's existing keys. Do not
+    rename the values in isolation -- coordinate a synchronized release
+    with the frontend before changing them. Rename the enum members
+    freely; only the string values are load-bearing.
     """
 
-    EVALUATION = "Evaluation"
-    PREDICTION = "Prediction"
-    DATASET = "Dataset"
+    EVALUATION_LEGACY = "create_backtest"          # /v1/crud/backtests and /v1/analytics/create-backtest
+    EVALUATION = "create_backtest_from_data"       # /v1/analytics/create-backtest-with-data/
+    PREDICTION = "create_prediction"               # /v1/analytics/make-prediction
+    DATASET = "create_dataset"                     # /v1/analytics/make-dataset
 
 # We use get_task_logger to ensure we get the Celery-friendly logger
 # but you could also just use logging.getLogger(__name__) if you prefer.

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -26,7 +26,7 @@ from chap_core.datatypes import create_tsdataclass
 from chap_core.spatio_temporal_data.converters import observations_to_dataset
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 
-from ...celery_tasks import JOB_NAME_KW, JOB_TYPE_KW, CeleryPool
+from ...celery_tasks import JOB_NAME_KW, JOB_TYPE_KW, CeleryPool, JobType
 from ...data_models import (
     BackTestCreate,
     BackTestRead,
@@ -89,7 +89,7 @@ def make_dataset(
         request.type,
         database_url=database_url,
         worker_config=worker_settings,
-        **{JOB_TYPE_KW: "create_dataset", JOB_NAME_KW: request.name},
+        **{JOB_TYPE_KW: JobType.DATASET, JOB_NAME_KW: request.name},
     )
 
     return ImportSummaryResponse(id=job.id, imported_count=imported_count, rejected=rejections)
@@ -365,7 +365,7 @@ async def create_backtest(request: MakeBacktestRequest, database_url: str = Depe
         request.n_splits,
         request.stride,
         database_url=database_url,
-        **{JOB_TYPE_KW: "create_backtest", JOB_NAME_KW: request.name},
+        **{JOB_TYPE_KW: JobType.EVALUATION, JOB_NAME_KW: request.name},
     )
 
     return JobResponse(id=job.id)
@@ -397,7 +397,7 @@ async def make_prediction(
         prediction_params=prediction_params,
         database_url=database_url,
         worker_config=worker_settings,
-        **{JOB_TYPE_KW: "create_prediction", JOB_NAME_KW: request.name},
+        **{JOB_TYPE_KW: JobType.PREDICTION, JOB_NAME_KW: request.name},
     )
     return JobResponse(id=job.id)
 
@@ -612,7 +612,7 @@ async def create_backtest_with_data(
         backtest_params=bt_params,
         database_url=database_url,
         worker_config=worker_settings,
-        **{JOB_TYPE_KW: "create_backtest_from_data", JOB_NAME_KW: request.name},
+        **{JOB_TYPE_KW: JobType.EVALUATION, JOB_NAME_KW: request.name},
     )
     job_id = job.id
     return ImportSummaryResponse(id=job_id, imported_count=imported_count, rejected=rejections)

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -365,7 +365,7 @@ async def create_backtest(request: MakeBacktestRequest, database_url: str = Depe
         request.n_splits,
         request.stride,
         database_url=database_url,
-        **{JOB_TYPE_KW: JobType.EVALUATION, JOB_NAME_KW: request.name},
+        **{JOB_TYPE_KW: JobType.EVALUATION_LEGACY, JOB_NAME_KW: request.name},
     )
 
     return JobResponse(id=job.id)

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -218,7 +218,7 @@ async def create_backtest(backtest: BackTestCreate, database_url: str = Depends(
         wf.run_backtest,
         backtest,
         database_url=database_url,
-        **{JOB_TYPE_KW: JobType.EVALUATION, JOB_NAME_KW: backtest.name},
+        **{JOB_TYPE_KW: JobType.EVALUATION_LEGACY, JOB_NAME_KW: backtest.name},
     )
 
     return JobResponse(id=job.id)

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -49,7 +49,7 @@ from chap_core.database.model_templates_and_config_tables import (
 from chap_core.database.tables import BackTest, Prediction, PredictionInfo
 from chap_core.datatypes import FullData, HealthPopulationData
 from chap_core.geometry import Polygons
-from chap_core.rest_api.celery_tasks import CeleryPool
+from chap_core.rest_api.celery_tasks import JOB_NAME_KW, JOB_TYPE_KW, CeleryPool, JobType
 from chap_core.spatio_temporal_data.converters import observations_to_dataset
 
 from ...data_models import BackTestCreate, BackTestRead, JobResponse
@@ -214,7 +214,12 @@ class BackTestUpdate(DBModel):
 
 @router.post("/backtests", response_model=JobResponse, tags=["Backtests"])
 async def create_backtest(backtest: BackTestCreate, database_url: str = Depends(get_database_url)):
-    job = worker.queue_db(wf.run_backtest, backtest, database_url=database_url)
+    job = worker.queue_db(
+        wf.run_backtest,
+        backtest,
+        database_url=database_url,
+        **{JOB_TYPE_KW: JobType.EVALUATION, JOB_NAME_KW: backtest.name},
+    )
 
     return JobResponse(id=job.id)
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -518,6 +518,7 @@ class ModelTemplateRead(DBModel, ModelTemplateInformation, ModelTemplateMetaData
     version: str | None = None
     archived: bool = False
     health_status: str | None = None
+    uses_chapkit: bool = False
 
 
 @router.get("/model-templates", response_model=list[ModelTemplateRead], tags=["Models"])

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -116,6 +116,40 @@ def _archive_stale_chapkit_templates(session: Session, service_list) -> None:
     session.commit()
 
 
+def _resolve_chapkit_default_additional_covariates(client) -> list[str]:
+    """Probe a chapkit service for its BaseConfig `additional_continuous_covariates` default.
+
+    Chapkit's `/api/v1/configs/$schema` endpoint doesn't expose `default_factory`
+    values, so the only way to learn what the service considers a sensible default
+    covariate set is to materialize a config with an empty `data` dict and read
+    the pydantic-populated result back. We then delete the probe config to avoid
+    leaving cruft in the service's DB.
+
+    Returns an empty list on any failure — callers should treat the missing
+    defaults as "no additional covariates".
+    """
+    import time
+
+    probe_name = f"__chap_probe_defaults_{int(time.time() * 1000000)}__"
+    try:
+        probe = client.create_config({"name": probe_name, "data": {}})
+    except Exception:
+        logger.debug("Chapkit default probe POST failed", exc_info=True)
+        return []
+
+    try:
+        data = getattr(probe, "data", None) or {}
+        if hasattr(data, "model_dump"):
+            data = data.model_dump()
+        result = list(data.get("additional_continuous_covariates", []) or [])
+    except Exception:
+        logger.debug("Chapkit default probe response parse failed", exc_info=True)
+        result = []
+
+    client.delete_config(str(probe.id))
+    return result
+
+
 def _sync_chapkit_configured_models(
     session_wrapper: SessionWrapper,
     template_id: int,
@@ -127,6 +161,13 @@ def _sync_chapkit_configured_models(
     Skips if the template already has configured models (only syncs
     on first discovery). Creates a default configured model if the
     service has no configs.
+
+    `additional_continuous_covariates` for each configured model is seeded
+    from the chapkit service's `BaseConfig` defaults via a one-time probe
+    against `/api/v1/configs`. This matches the legacy config-file-driven
+    behaviour where the overlay YAML supplied the same field, and it is
+    what the modeling app reads to render the model card's covariate count
+    and the data-mapping dialog slots.
     """
     existing = session_wrapper.session.exec(
         select(ConfiguredModelDB).where(ConfiguredModelDB.model_template_id == template_id)
@@ -141,10 +182,12 @@ def _sync_chapkit_configured_models(
         logger.debug("Could not fetch configs from %s, will retry next sync", service_url)
         return
 
+    default_additional = _resolve_chapkit_default_additional_covariates(client)
+
     if not configs:
         session_wrapper.add_configured_model(
             template_id,
-            ModelConfiguration(user_option_values={}, additional_continuous_covariates=[]),
+            ModelConfiguration(user_option_values={}, additional_continuous_covariates=default_additional),
             "default",
             uses_chapkit=True,
         )
@@ -153,9 +196,16 @@ def _sync_chapkit_configured_models(
     for cfg in configs:
         # Chapkit manages its own config data; chap-core stores the
         # configured model as a reference only, with empty user options.
+        # Carry over `additional_continuous_covariates` from the config's
+        # own data when present; otherwise fall back to the service-level
+        # default probed above.
+        cfg_data = getattr(cfg, "data", None) or {}
+        if hasattr(cfg_data, "model_dump"):
+            cfg_data = cfg_data.model_dump()
+        cfg_additional = list(cfg_data.get("additional_continuous_covariates", []) or []) or default_additional
         session_wrapper.add_configured_model(
             template_id,
-            ModelConfiguration(user_option_values={}, additional_continuous_covariates=[]),
+            ModelConfiguration(user_option_values={}, additional_continuous_covariates=cfg_additional),
             cfg.name,
             uses_chapkit=True,
         )

--- a/compose.ewars.yml
+++ b/compose.ewars.yml
@@ -1,0 +1,20 @@
+services:
+  ewars:
+    image: ghcr.io/chap-models/chapkit_ewars_template:latest
+    platform: linux/amd64
+    pull_policy: always
+    ports:
+      - "5002:8000"
+    environment:
+      SERVICEKIT_ORCHESTRATOR_URL: http://chap:8000/v2/services/$$register
+      # Uncomment if chap has SERVICEKIT_REGISTRATION_KEY set:
+      # SERVICEKIT_REGISTRATION_KEY: ${SERVICEKIT_REGISTRATION_KEY:-}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    depends_on:
+      chap:
+        condition: service_healthy

--- a/compose.ewars.yml
+++ b/compose.ewars.yml
@@ -10,7 +10,7 @@ services:
       # Uncomment if chap has SERVICEKIT_REGISTRATION_KEY set:
       # SERVICEKIT_REGISTRATION_KEY: ${SERVICEKIT_REGISTRATION_KEY:-}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status==200 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -1,3 +1,8 @@
+# Use this file INSTEAD OF compose.yml, not layered on top of it.
+# The two files define the same services -- compose.yml builds chap+worker
+# from the local source, compose.ghcr.yml pulls prebuilt images from GHCR.
+# Layering them breaks compose validation with duplicate security_opt /
+# cap_drop entries because compose appends list fields on overlay.
 services:
   chap:
     image: ghcr.io/dhis2-chap/chap-core:latest

--- a/compose.yml
+++ b/compose.yml
@@ -30,6 +30,12 @@ services:
       - "host.docker.internal:host-gateway"
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     depends_on:
       redis:
         condition: service_started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chap_core"
-version = "1.5.0.dev0"
+version = "1.5.0.dev1"
 description = "Climate Health Analysis Platform (CHAP)"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -342,7 +342,7 @@ wheels = [
 
 [[package]]
 name = "chap-core"
-version = "1.5.0.dev0"
+version = "1.5.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Wire the chapkit-based EWARS model (`ghcr.io/chap-models/chapkit_ewars_template`) into the chap-core docker stack as an opt-in overlay, and fix the chain of chap-core-side issues that surfaced while doing it. The overlay itself is one new file + two tiny compose/Makefile tweaks; the rest of the PR is the chap-core bugs that were blocking the chapkit EWARS model from behaving equivalently to the legacy MLflow-based `ewars_template` when invoked through the same pipeline.

Designed so a single `docker compose -f compose.yml -f compose.ewars.yml up -d` produces a chap-core stack with EWARS already self-registered, visible in the modeling app's Select Model dialog, and ready to run backtests end-to-end.

## What's in this PR

### The overlay itself

- `compose.ewars.yml` (new) — defines the `ewars` service, pinned to `linux/amd64`, exposed on host port `5002` for direct testing, self-registers against chap via `SERVICEKIT_ORCHESTRATOR_URL=http://chap:8000/v2/services/$$register`. Uses a Python-based healthcheck (the chapkit base image has no `curl`).
- `compose.yml` — `/health` healthcheck on `chap` so the ewars overlay can `depends_on: chap: condition: service_healthy` and avoid racing chap's startup. Registration now succeeds on attempt 1 instead of logging 2-3 `registration.attempt_failed` warnings per boot.
- `compose.ghcr.yml` — header comment clarifying it is an **alternative to** `compose.yml`, not layerable on top of it. Layering the two triggers `services.chap.security_opt items at 0 and 1 are equal` because compose appends list fields on overlay.
- `Makefile` — `force-restart` threaded through the ewars overlay; new `restart` target that does `down && up -d --build` without the `down -v` volume wipe.

### chap-core bugs fixed along the way

- `fix(chapkit)` **future-window filter in `external_chapkit_model.predict`** mirroring the legacy `ExternalCommandLineModel.predict` behaviour. Without it, any chapkit model whose predict script emits predictions for historic NA rows (EWARS does) crashes with `ValueError: Periods must be consecutive.` from `PeriodRange.from_strings`. ewars fails ~19s in every backtest before this fix.
- `fix(chapkit)` **strip empty `additional_continuous_covariates` from the chapkit config POST payload.** `dict(configured_model_db)` emits the SQLModel column default as an explicit `[]`, which would then override whatever default the chapkit service's own `BaseConfig` schema declares (e.g. ewars defaults to `["rainfall","mean_temperature"]`). Drop the key when empty so the service-side default applies. Without this the chapkit run was silently fitting a no-climate EWARS and scoring ~18-44% worse than legacy on CRPS/MAPE/RMSE.
- `fix(chapkit)` **seed `additional_continuous_covariates` on the configured-model row via a POST/read/DELETE probe** against the chapkit service during `_sync_chapkit_configured_models`. chapkit's `/api/v1/configs/$schema` endpoint omits `default_factory` values, so the only reliable way to learn the service's defaults is to materialize a config with empty `data: {}` and read the pydantic-populated result back. This is what makes the modeling app's "Select Model" card show "3 covariates" for the chapkit EWARS card and the data-mapping dialog surface all 4 slots (`disease_cases`, `population`, `rainfall`, `mean_temperature`) to the user.
- `fix(crud)` **expose `uses_chapkit` on the flat `/v1/crud/model-templates` response.** `ModelTemplateRead` inherited `ModelTemplateInformation` + `ModelTemplateMetaData` only; `uses_chapkit` lives on `ModelTemplateDB` itself, so `model_validate(t)` was silently dropping the field. Downstream filters on `uses_chapkit == true` would skip every chapkit model. The nested `/backtests/{id}/full` shape was already serialising it correctly — this just aligns the flat endpoint.

### Job type / naming plumbing

- `feat(rest-api)` **introduce a `JobType` StrEnum** in `chap_core/rest_api/celery_tasks.py` with `EVALUATION_LEGACY` / `EVALUATION` / `PREDICTION` / `DATASET` members. Values are intentionally kept as the original strings (`create_backtest`, `create_backtest_from_data`, `create_prediction`, `create_dataset`) because the modeling app at `apps/modeling-app/src/hooks/useJobs.ts:JOB_TYPES` uses those exact values for five things: (1) the i18n label map in `JobTypeCell.tsx`, (2) the filter dropdown in `JobsTableFilters.tsx`, (3) the row-click routing in `JobActionsMenu.tsx`, (4) the `jobType` prop on `RunningJobsIndicator` inside `PredictionsTable.tsx`, (5) same in `BacktestsTable.tsx`. Renaming the values in isolation would leave the Jobs page half-dark. The enum type-safety is the current win; a synchronised rename to nicer display values is tracked in TODO.md.
- `fix(crud)` **thread `JOB_NAME_KW` / `JOB_TYPE_KW` through `crud.create_backtest`.** The `POST /v1/crud/backtests/` endpoint wasn't passing them, so API-submitted backtests landed in the Jobs table with `name="Unnamed"` / `type="Unspecified"`. The analytics.py POSTs were doing it correctly — this brings `crud.py` into line and all four analytics.py call sites over to the enum in the same pass.

## Depends on

- `chap-models/chapkit_ewars_template@82536e7` — enables `.with_registration()` on `MLServiceBuilder` so the ewars container actually self-registers. Already merged + republished to GHCR.
- `chap-models/chapkit_ewars_template@4bcd8dd` — bakes `additional_continuous_covariates=["rainfall","mean_temperature"]` as the `EwarsConfig` default so the chapkit model is behaviourally equivalent to legacy. Already merged + republished.

## Usage

```bash
docker compose -f compose.yml -f compose.ewars.yml up -d
```

For future country-specific models, the same pattern applies: drop a `compose.override.yml` alongside with a new service that sets `SERVICEKIT_ORCHESTRATOR_URL=http://chap:8000/v2/services/$$register` and it auto-registers with chap-core on startup.

## Test plan

End-to-end manually verified today against a full chap-core + DHIS2 stack and the modeling app:

- [x] `docker compose -f compose.yml -f compose.ewars.yml up -d` — full stack boots, ewars registers on attempt 1.
- [x] `curl http://localhost:8000/v2/services` — returns `chapkit-ewars-template` with a recent `last_ping_at`.
- [x] `curl http://localhost:8000/v1/crud/model-templates` — returns `chapkit-ewars-template` with `usesChapkit: true` (verified via the new serializer fix) and `healthStatus: live`.
- [x] `curl http://localhost:8000/v1/crud/configured-models` — chapkit row has `covariates=[population, rainfall, mean_temperature]` after the sync probe fix.
- [x] `curl http://localhost:5002/health` — direct access works for debugging.
- [x] `uv run chap eval --model-name http://0.0.0.0:5002 --dataset-csv example_data/laos_subset.csv --output-file /tmp/chapkit_eval_test.nc` — completes end-to-end.
- [x] `uv run chapkit test --url http://localhost:5002` — default run passes; also verified with `--configs 2 --trainings 2 --predictions 2 --rows 300`, `--period-type weekly`, `--geo-type point`, and `--parallel 3` variants.
- [x] **DHIS2 modeling app**: logged in, navigated to `/evaluate/new`, selected `CHAP-EWARS Model (chapkit)` (card shows "3 covariates"), mapped all 4 data items via the data-mapping dialog, dry run valid for 18/18 provinces, import kicked off. Backtest succeeded in 2m31s. Jobs table shows correct `name="UI chapkit (via FE)"` and `type="Create evaluation"`. Result view renders Highcharts combination charts for every province with real cases + median prediction + 50% / 80% prediction intervals.
- [x] API-submitted backtest via `POST /v1/crud/backtests/` — job record now shows correct `name` and `type=create_backtest` instead of `Unnamed`/`Unspecified`.
- [x] Metric comparison legacy vs chapkit EWARS (same dataset, same 18 provinces, same 10 split periods): MAPE within noise on all three horizons after the covariate fix; CRPS/RMSE slightly higher, consistent with INLA sampling non-determinism and different commit pins on the ewars fork.

## Follow-ups tracked in TODO.md

- Non-lazy `sourceUrl` refresh on the worker backtest path — last correctness bug that bit us twice today when the ewars container was recreated between a sync and a run. Clean fix is in `database.get_configured_model_with_code()`.
- `aggregateMetrics` always empty on `/backtests/{id}/full` even though the Vega endpoints have the numbers — investigation.
- `/v1/visualization/metric-plots/{visualization_name}/{backtest_id}/{metric_id}` 404s for names the sibling listing endpoint advertises.
- Synchronised rename of the `JOB_TYPES` string values to the cleaner display form, coordinated with chap-frontend.
- Upstream in servicekit: fall back to `register_service()` from the keepalive loop when `/ping` returns 404, instead of logging warnings forever.