### PR TITLE
fix(backtest): populate aggregate_metrics on backtest completion

### DIFF
--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from chap_core.api_types import BackTestParams
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.forecast import forecast_ahead
+from chap_core.assessment.metrics import compute_all_aggregated_metrics_from_backtest
 from chap_core.assessment.prediction_evaluator import backtest as _backtest
 from chap_core.climate_predictor import QuickForecastFetcher
 from chap_core.data import DataSet as InMemoryDataSet
@@ -122,6 +123,19 @@ def run_backtest(
     evaluation = Evaluation.from_samples_with_truth(predictions_list, last_train_period, configured_model, info=info)
     backtest = evaluation.to_backtest()
     session.add_backtest(backtest)
+    # Populate the global aggregate metric values on the backtest row so that
+    # GET /v1/crud/backtests/{id}/full can return CRPS/MAPE/RMSE/etc without
+    # the caller needing to round-trip through /v1/visualization/metric-plots.
+    # Per-forecast samples on BackTestForecast remain the source of truth for
+    # the visualization path; a failure here must not tank the whole backtest.
+    # This runs AFTER add_backtest because compute_all_aggregated_metrics_from_backtest
+    # reads `backtest.dataset.observations` via the Evaluation abstraction, and the
+    # `dataset` relationship only resolves once the row is attached + committed.
+    try:
+        backtest.aggregate_metrics = compute_all_aggregated_metrics_from_backtest(backtest)
+        session.session.commit()
+    except Exception:
+        logger.warning("Failed to compute aggregate metrics for backtest; leaving empty", exc_info=True)
     db_id = backtest.id
     assert db_id is not None
     status_logger.info(f"Backtest completed successfully. Results saved with ID {db_id}")

--- a/tests/integration/test_chapkit_e2e.py
+++ b/tests/integration/test_chapkit_e2e.py
@@ -20,6 +20,7 @@ from sqlmodel import SQLModel
 import chap_core.database.tables  # noqa: F401 - register all table models
 from chap_core.database.database import SessionWrapper
 from chap_core.database.model_templates_and_config_tables import ModelConfiguration
+from chap_core.database.tables import BackTest
 from chap_core.models.external_chapkit_model import ml_service_info_to_model_template_config
 from chap_core.rest_api.data_models import BackTestCreate
 from chap_core.rest_api.db_worker_functions import run_backtest
@@ -179,3 +180,16 @@ def test_chapkit_backtest_via_worker_function(chapkit_service):
 
         assert backtest_id is not None
         assert isinstance(backtest_id, int)
+
+        # Regression: run_backtest should populate aggregate_metrics on the
+        # backtest row so the `GET /v1/crud/backtests/{id}/full` response
+        # includes global CRPS/MAPE/RMSE/etc without needing a round-trip
+        # through the Vega visualization endpoints.
+        fetched = session.session.get(BackTest, backtest_id)
+        assert fetched is not None
+        assert fetched.aggregate_metrics, (
+            f"expected non-empty aggregate_metrics on backtest {backtest_id}, got {fetched.aggregate_metrics!r}"
+        )
+        assert any(k.startswith("crps") for k in fetched.aggregate_metrics), (
+            f"expected at least one CRPS variant in aggregate_metrics, got keys {list(fetched.aggregate_metrics)}"
+        )


### PR DESCRIPTION
## Summary

Backtest rows land with `aggregateMetrics: {}` because `run_backtest()` never populates the column. The plumbing is all there: the `aggregate_metrics: dict[str, float]` column exists on `BackTest` (`tables.py:44`), `BackTestRead` already serializes it, and `chap_core.assessment.metrics.compute_all_aggregated_metrics_from_backtest` already returns a flat `dict[str, float]` of every canonical metric (CRPS variants, MAPE, MAE, RMSE, coverage, winkler variants, sample count, ratio-above-truth, example metric). Nothing was calling that helper from the backtest persist path.

Now `run_backtest()` in `chap_core/rest_api/db_worker_functions.py` calls `compute_all_aggregated_metrics_from_backtest(backtest)` right after `session.add_backtest(backtest)` and commits the new column value. Wrapped in `try/except` so a metric-compute failure doesn't tank the whole backtest — the per-forecast samples on `BackTestForecast` remain the source of truth for the visualization path.

### Why after `add_backtest` and not before

`compute_all_aggregated_metrics_from_backtest` walks the backtest through the `Evaluation` abstraction, which reads `backtest.dataset.observations`. The `dataset` relationship only resolves once the row is attached and committed. Calling it on an in-memory `BackTest` produced by `evaluation.to_backtest()` crashes with `AttributeError: 'NoneType' object has no attribute 'observations'` (hit this on the first attempt in this branch; moved the call in the second commit on the same branch).

## Test plan

- [x] `make lint` clean (ruff, ruff format, mypy, pyright).
- [x] Existing `tests/evaluation/test_metrics.py::test_get_all_aggregated_metrics_from_backtest` still passes — exercises the reusable helper directly.
- [x] Regression assertion added to the existing slow-gated e2e test `tests/integration/test_chapkit_e2e.py::test_chapkit_backtest_via_worker_function` — asserts the fetched `BackTest` row has a non-empty `aggregate_metrics` dict with at least one CRPS variant after `run_backtest` returns.
- [x] End-to-end verified against the live chap-core stack: submitted a fresh chapkit EWARS backtest and confirmed `GET /v1/crud/backtests/{id}/full` returns 15 populated metric keys with values in the same range the Vega endpoints already report.

Sample response for the verification backtest (backtest id 9):

```
coverage_10_90:            0.668
coverage_25_75:            0.439
crps:                     24.124
crps_log1p:                0.643
crps_norm:                 0.024
example_metric:        14596.000
mae:                      32.726
mape:                    252.258
ratio_above_truth:         0.513
rmse:                     63.108
sample_count:         446000.000
winkler_score_10_90:     165.468
winkler_score_10_90_log1p: 4.368
winkler_score_25_75:     107.754
winkler_score_25_75_log1p: 2.887
```

## Out of scope

- **Backfilling existing backtest rows.** Any backtest already in the DB when this lands keeps its empty `aggregate_metrics`. Fine for now; chap-core is still pre-1.0 and result history is disposable. Can become a one-off data migration or a `POST /v1/crud/backtests/{id}/recompute-metrics` endpoint later if needed.
- **The visualization endpoint 404 that was in TODO.md** turned out not to be a bug at all. There are two separate registries (`metric_plots_registry` hardcoded in `visualization.py:35-38` for `metric_by_horizon` / `metric_map`, and `_backtest_plots_registry` in `chap_core/plotting/backtest_plots/__init__.py` for `evaluation_plot` / `metrics_dashboard` / `predicted_vs_actual` / `horizon_location_grid` / `ratio_of_samples_above_truth`). Each listing endpoint correctly advertises its own registry and each parameterised endpoint correctly rejects names not in its own registry. The earlier "404" was API misuse — hitting `/metric-plots/metrics_dashboard/...` instead of `/backtest-plots/metrics_dashboard/...`. TODO.md updated to reflect this.