### PR TITLE
feat(crud): accept int primary key or string name for modelId on POST /v1/crud/backtests/

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,32 @@ If you find any bugs or issues when using this code base, we appreciate it if yo
 cp .env.example .env
 docker compose up
 ```
+
+### Rebuilding after a source change
+
+`docker compose up` will reuse an existing `chap-core-chap` image if one is
+already built — it does not automatically rebuild when you edit source. If
+you see a stale `chap_core.__version__` or a fix that clearly didn't land
+inside the running container, use one of:
+
+```shell
+make restart       # down && up -d --build (preserves volumes incl. chap-db)
+make force-restart # down -v && build --no-cache && up (WIPES VOLUMES)
+make chap-version  # print the chap_core version running inside the container
+```
+
+`make restart` is the right hammer 90% of the time. `make force-restart`
+also wipes the Postgres volume, so reach for it only when you need a clean
+slate. `make chap-version` is also printed automatically at the end of
+`make restart` so version drift is visible at a glance.
+
+### Running with the chapkit EWARS overlay
+
+The chapkit-based EWARS model ships as an opt-in compose overlay at
+`compose.ewars.yml`. Layer it onto `compose.yml` (not `compose.ghcr.yml`
+— those two are alternatives, not stackable) to run chap-core with the
+ewars service already self-registered:
+
+```shell
+docker compose -f compose.yml -f compose.ewars.yml up -d
+```

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -308,6 +308,21 @@ class SessionWrapper:
 
         return configured_model
 
+    def get_configured_model_by_id_or_name(self, configured_model_id_or_name: int | str) -> ConfiguredModelDB:
+        """Resolve a configured model from either its integer primary key or its name.
+
+        Exists so the public API can accept either shape on `POST /v1/crud/backtests/`
+        without forcing callers to know that the DB column stores the name string.
+        Integer ids raise ValueError if not found to stay consistent with the
+        name-based lookup above.
+        """
+        if isinstance(configured_model_id_or_name, int):
+            configured_model = self.session.get(ConfiguredModelDB, configured_model_id_or_name)
+            if configured_model is None:
+                raise ValueError(f"Configured model with id {configured_model_id_or_name} not found")
+            return configured_model
+        return self.get_configured_model_by_name(configured_model_id_or_name)
+
     def _resolve_chapkit_live_source_url(
         self,
         *,

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -58,7 +58,14 @@ class ImportSummaryResponse(DBModel):
     rejected: list[ValidationError]
 
 
-class BackTestCreate(BackTestBase): ...
+class BackTestCreate(BackTestBase):
+    # Accept either the configured-model integer primary key or its string
+    # name. The underlying DB column (`BackTestBase.model_id`) is a string,
+    # but the `POST /v1/crud/backtests/` handler resolves an `int` to the
+    # corresponding name before persisting so the column stays consistent.
+    # See `chap_core.rest_api.v1.routers.crud.create_backtest` for the
+    # resolution path.
+    model_id: int | str  # type: ignore[assignment]
 
 
 class BackTestFull(BackTestRead):

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -88,7 +88,11 @@ def run_backtest(
 
     dataset = session.get_dataset(info.dataset_id)
 
-    configured_model = session.get_configured_model_by_name(info.model_id)
+    configured_model = session.get_configured_model_by_id_or_name(info.model_id)
+    # Normalise back to the name string so any downstream code that still
+    # reads `info.model_id` as a string (job metadata, logs, etc.) sees the
+    # canonical value rather than the raw integer primary key.
+    info.model_id = configured_model.name
 
     # hack to get who ewars model to work, it requires n_peridos=3.
     # todo: should be removed in future when system for model specific backtest params is implemented

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -264,6 +264,13 @@ class BackTestUpdate(DBModel):
 
 @router.post("/backtests", response_model=JobResponse, tags=["Backtests"])
 async def create_backtest(backtest: BackTestCreate, database_url: str = Depends(get_database_url)):
+    # `BackTestCreate.model_id` accepts either the configured-model name
+    # (what the DB column actually stores) or the integer primary key (what
+    # most API clients reach for because that's what GET /v1/crud/configured-models
+    # returns). The worker's run_backtest() normalises int -> name through
+    # `SessionWrapper.get_configured_model_by_id_or_name` before touching
+    # anything else, so the endpoint itself stays dumb and there's exactly
+    # one resolution point.
     job = worker.queue_db(
         wf.run_backtest,
         backtest,


### PR DESCRIPTION
## Summary

`BackTestCreate.model_id` inherited `str` from `BackTestBase`, which matched the DB column shape but rejected every API client that reached for the integer primary key returned by `GET /v1/crud/configured-models`. Hit this myself twice in the previous two PRs on this branch — `{"modelId": 12, ...}` returns:

```json
{"detail":[{"type":"string_type","loc":["body","modelId"],"msg":"Input should be a valid string","input":12}]}
```

Now the request body accepts **either** shape and normalises inside the worker:

- `data_models.py:BackTestCreate` overrides `model_id: int | str` on the pydantic request model only. `BackTestBase.model_id: str` (the DB column) is unchanged.
- `database.py:SessionWrapper.get_configured_model_by_id_or_name` is a new helper that dispatches on type. `int` → `session.get(ConfiguredModelDB, id)`. `str` → delegates to the existing `get_configured_model_by_name`.
- `db_worker_functions.py:run_backtest` calls the new helper first thing, then overwrites `info.model_id = configured_model.name` so any downstream code still treating `info.model_id` as a string (job metadata, logs, the DB column itself) sees the canonical value instead of the raw integer.
- `crud.py:create_backtest` stays dumb — no new Session dependency, no new HTTPException path. Single resolution point in the worker, which means tests that call `run_backtest` directly also get the normalisation for free.

Not a breaking change: existing string-payload clients (the modeling app, legacy curl scripts, existing tests) keep working unchanged.

## Also in this PR

Documented the `make restart` / `make force-restart` / `make chap-version` workflow in `README.md` so the next person editing chap-core source doesn't lose 30 minutes to docker image staleness like I did in the overlay PR. Includes a note about the `compose.yml` vs `compose.ghcr.yml` stack alternatives and a pointer to the new `compose.ewars.yml` overlay usage.

## Test plan

- [x] `make lint` clean (ruff, ruff format, mypy, pyright).
- [x] `tests/evaluation/test_metrics.py::test_get_all_aggregated_metrics_from_backtest` + `tests/integration/rest_api/test_chapkit_self_registration.py` + `tests/external/test_chapkit_integration.py` — 48/48 pass.
- [x] Smoke-tested against the running stack:
  - `POST /v1/crud/backtests/` with `{"modelId": 5, "datasetId": 1, "name": "smoke-int-id"}` → HTTP 200, job appears in `/v1/jobs` as `STARTED` with `name="smoke-int-id"` and `type="create_backtest"`.
  - `POST /v1/crud/backtests/` with `{"modelId": "ewars_template", "datasetId": 1, "name": "smoke-str-name"}` → HTTP 200, same shape. Control for no-regression on the existing behaviour.
- [ ] Out of scope: eager validation for a nonexistent int (currently fails inside the worker with the existing ValueError path, same as a nonexistent string name). Could add a cheap `session.get` probe in the endpoint later if we want fail-fast for bad ids.

## Depends on / follows

- Previous PR #275 (`fix(backtest): populate aggregate_metrics on backtest completion`) already merged.
- Previous PR #273 (`feat(compose): add ewars overlay using chapkit self-registration`) already merged — the `make restart` / `make chap-version` targets referenced in the README note come from that PR.