### PR TITLE
fix(backtest): populate aggregate_metrics on backtest completion

### DIFF
--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -126,6 +126,7 @@ def run_backtest(
     last_train_period = dataset.period_range[-1]
     evaluation = Evaluation.from_samples_with_truth(predictions_list, last_train_period, configured_model, info=info)
     backtest = evaluation.to_backtest()
+    backtest.model_db_id = configured_model.id
     session.add_backtest(backtest)
     # Populate the global aggregate metric values on the backtest row so that
     # GET /v1/crud/backtests/{id}/full can return CRPS/MAPE/RMSE/etc without


### PR DESCRIPTION
## Summary

`BackTest.model_db_id` (the integer FK to `ConfiguredModelDB`) was never set during `run_backtest()`. Both legacy and chapkit backtests had `modelDbId: null` in the API response, which prevented the FE evaluation list at `#/evaluate?modelId=<id>` from filtering by configured model.

One-line fix: `backtest.model_db_id = configured_model.id` after `evaluation.to_backtest()`.

## Test plan

- [x] `make lint` clean (ruff, mypy, pyright)
- [x] 27 passed, 2 skipped in existing test suite
- [x] Submit a fresh backtest and verify `modelDbId` is non-null in `GET /v1/crud/backtests`