### PR TITLE
fix(chapkit): populate user_options from chapkit config schema

### DIFF
--- a/chap_core/models/external_chapkit_model.py
+++ b/chap_core/models/external_chapkit_model.py
@@ -21,6 +21,26 @@ def _chapkit_period_to_chap(chapkit_period_type) -> PeriodType:
     return PeriodType(_CHAPKIT_PERIOD_MAP.get(value, value))
 
 
+def _parse_user_options_from_config_schema(config_schema: dict) -> dict:
+    """Extract user-tuneable options from a chapkit config schema response.
+
+    Legacy MLflow-era models store the schema under ``$defs.ModelConfiguration.properties``;
+    chapkit services expose it at the top-level ``properties`` key. Filters out
+    BaseConfig-reserved fields (``prediction_periods``, ``additional_continuous_covariates``)
+    that chap-core handles separately.
+    """
+    user_options: dict = {}
+    if "$defs" in config_schema and "ModelConfiguration" in config_schema["$defs"]:
+        user_options = config_schema["$defs"]["ModelConfiguration"].get("properties", {})
+    elif "properties" in config_schema:
+        user_options = dict(config_schema["properties"])
+
+    for reserved in ("prediction_periods", "additional_continuous_covariates"):
+        user_options.pop(reserved, None)
+
+    return user_options
+
+
 def ml_service_info_to_model_template_config(
     info: "Any",
     rest_api_url: str,
@@ -270,21 +290,8 @@ class ExternalChapkitModelTemplate:
         assert self.rest_api_url is not None
         model_info = self.client.info()
 
-        # Get user options from config schema. Legacy MLflow-era models
-        # store the schema under $defs.ModelConfiguration.properties;
-        # chapkit services expose it at the top-level properties key.
         config_schema = self.client.get_config_schema()
-        user_options: dict = {}
-        if "$defs" in config_schema and "ModelConfiguration" in config_schema["$defs"]:
-            user_options = config_schema["$defs"]["ModelConfiguration"].get("properties", {})
-        elif "properties" in config_schema:
-            user_options = dict(config_schema["properties"])
-
-        # Filter out BaseConfig-reserved fields that chap-core handles
-        # separately (prediction_periods drives the backtest split logic,
-        # additional_continuous_covariates is surfaced as its own UI section).
-        for reserved in ("prediction_periods", "additional_continuous_covariates"):
-            user_options.pop(reserved, None)
+        user_options = _parse_user_options_from_config_schema(config_schema)
 
         return ml_service_info_to_model_template_config(model_info, self.rest_api_url, user_options)
 

--- a/chap_core/models/external_chapkit_model.py
+++ b/chap_core/models/external_chapkit_model.py
@@ -270,11 +270,21 @@ class ExternalChapkitModelTemplate:
         assert self.rest_api_url is not None
         model_info = self.client.info()
 
-        # Get user options from config schema
+        # Get user options from config schema. Legacy MLflow-era models
+        # store the schema under $defs.ModelConfiguration.properties;
+        # chapkit services expose it at the top-level properties key.
         config_schema = self.client.get_config_schema()
-        user_options = {}
+        user_options: dict = {}
         if "$defs" in config_schema and "ModelConfiguration" in config_schema["$defs"]:
             user_options = config_schema["$defs"]["ModelConfiguration"].get("properties", {})
+        elif "properties" in config_schema:
+            user_options = dict(config_schema["properties"])
+
+        # Filter out BaseConfig-reserved fields that chap-core handles
+        # separately (prediction_periods drives the backtest split logic,
+        # additional_continuous_covariates is surfaced as its own UI section).
+        for reserved in ("prediction_periods", "additional_continuous_covariates"):
+            user_options.pop(reserved, None)
 
         return ml_service_info_to_model_template_config(model_info, self.rest_api_url, user_options)
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -191,11 +191,25 @@ def _sync_chapkit_configured_models(
         return
 
     client = wrapper_cls(service_url, timeout=5)
-    try:
-        configs = client.list_configs()
-    except Exception:
-        logger.debug("Could not fetch configs from %s, will retry next sync", service_url)
-        return
+    configs = None
+    # The service may still be starting up — registration fires from the
+    # lifespan hook before all routes are fully mounted. Retry a few times
+    # with a short delay to cover the startup gap (~5-7s observed).
+    import time
+
+    for attempt in range(3):
+        try:
+            configs = client.list_configs()
+            break
+        except Exception:
+            if attempt < 2:
+                logger.debug("Config fetch from %s failed (attempt %d), retrying in 2s", service_url, attempt + 1)
+                time.sleep(2)
+            else:
+                logger.debug(
+                    "Could not fetch configs from %s after %d attempts, will retry next sync", service_url, attempt + 1
+                )
+                return
 
     default_additional = _resolve_chapkit_default_additional_covariates(client)
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -191,25 +191,11 @@ def _sync_chapkit_configured_models(
         return
 
     client = wrapper_cls(service_url, timeout=5)
-    configs = None
-    # The service may still be starting up — registration fires from the
-    # lifespan hook before all routes are fully mounted. Retry a few times
-    # with a short delay to cover the startup gap (~5-7s observed).
-    import time
-
-    for attempt in range(3):
-        try:
-            configs = client.list_configs()
-            break
-        except Exception:
-            if attempt < 2:
-                logger.debug("Config fetch from %s failed (attempt %d), retrying in 2s", service_url, attempt + 1)
-                time.sleep(2)
-            else:
-                logger.debug(
-                    "Could not fetch configs from %s after %d attempts, will retry next sync", service_url, attempt + 1
-                )
-                return
+    try:
+        configs = client.list_configs()
+    except Exception:
+        logger.debug("Could not fetch configs from %s, will retry next sync", service_url)
+        return
 
     default_additional = _resolve_chapkit_default_additional_covariates(client)
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -81,12 +81,27 @@ def _sync_live_chapkit_services(session: Session) -> set[str]:
 
     if service_list.count > 0:
         from chap_core.models.chapkit_rest_api_wrapper import CHAPKitRestAPIWrapper
-        from chap_core.models.external_chapkit_model import ml_service_info_to_model_template_config
+        from chap_core.models.external_chapkit_model import (
+            _parse_user_options_from_config_schema,
+            ml_service_info_to_model_template_config,
+        )
 
         session_wrapper = SessionWrapper(session=session)
         for service in service_list.services:
             try:
-                config = ml_service_info_to_model_template_config(service.info, service.url)
+                # Fetch the config schema so user_options (n_lags, precision, etc.)
+                # are populated on the template row — both on first discovery and
+                # on every subsequent sync so schema changes propagate without a
+                # DB wipe.
+                user_options: dict = {}
+                try:
+                    client = CHAPKitRestAPIWrapper(service.url, timeout=5)
+                    schema = client.get_config_schema()
+                    user_options = _parse_user_options_from_config_schema(schema)
+                except Exception:
+                    logger.debug("Could not fetch config schema from %s", service.url)
+
+                config = ml_service_info_to_model_template_config(service.info, service.url, user_options)
                 template_id = session_wrapper.add_model_template_from_yaml_config(config)
                 # Mark template as chapkit-originated for archival tracking
                 template = session.exec(select(ModelTemplateDB).where(ModelTemplateDB.id == template_id)).one()

--- a/compose.ewars.yml
+++ b/compose.ewars.yml
@@ -9,12 +9,6 @@ services:
       SERVICEKIT_ORCHESTRATOR_URL: http://chap:8000/v2/services/$$register
       # Uncomment if chap has SERVICEKIT_REGISTRATION_KEY set:
       # SERVICEKIT_REGISTRATION_KEY: ${SERVICEKIT_REGISTRATION_KEY:-}
-    healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status==200 else 1)"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
     depends_on:
       chap:
         condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chap_core"
-version = "1.5.0.dev1"
+version = "1.5.0.dev2"
 description = "Climate Health Analysis Platform (CHAP)"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "optuna>=4.5.0",
     "httpx>=0.28.1",
     "alembic>=1.14.0",
-    "chapkit>=0.17.0",
+    "chapkit>=0.17.1",
     "cryptography>=46.0.7",
 ]
 

--- a/tests/external/test_external_chapkit_model.py
+++ b/tests/external/test_external_chapkit_model.py
@@ -101,6 +101,93 @@ class TestChapkitServiceManager:
             _ = manager.url
 
 
+class TestGetModelTemplateConfig:
+    """Test that get_model_template_config extracts user_options from the chapkit config schema."""
+
+    def _make_template_with_schema(self, schema_response):
+        """Create a template with mocked client returning the given schema."""
+        from unittest.mock import MagicMock
+
+        from chap_core.rest_api.services.schemas import MLServiceInfo
+
+        template = ExternalChapkitModelTemplate("http://fake:8000")
+        template._is_url_mode = True
+        template.rest_api_url = "http://fake:8000"
+
+        mock_client = MagicMock()
+        mock_client.info.return_value = MLServiceInfo(
+            id="test-model",
+            display_name="Test Model",
+            version="1.0.0",
+            description="Test",
+            model_metadata={},
+            period_type="monthly",
+            required_covariates=["population"],
+        )
+        mock_client.get_config_schema.return_value = schema_response
+        template.client = mock_client
+        return template
+
+    def test_extracts_user_options_from_top_level_properties(self):
+        """Chapkit services expose config schema at the top level."""
+        schema = {
+            "properties": {
+                "prediction_periods": {"type": "integer", "default": 3},
+                "additional_continuous_covariates": {"type": "array", "items": {"type": "string"}},
+                "n_lags": {"type": "integer", "default": 3, "description": "Number of lags"},
+                "precision": {"type": "number", "default": 0.01, "description": "Precision"},
+            },
+            "title": "EwarsConfig",
+            "type": "object",
+        }
+        template = self._make_template_with_schema(schema)
+        config = template.get_model_template_config()
+        assert config.user_options is not None
+        assert "n_lags" in config.user_options
+        assert "precision" in config.user_options
+        assert config.user_options["n_lags"]["default"] == 3
+        assert config.user_options["precision"]["default"] == 0.01
+
+    def test_filters_reserved_fields(self):
+        """prediction_periods and additional_continuous_covariates are reserved."""
+        schema = {
+            "properties": {
+                "prediction_periods": {"type": "integer", "default": 3},
+                "additional_continuous_covariates": {"type": "array"},
+                "n_lags": {"type": "integer", "default": 3},
+            },
+            "type": "object",
+        }
+        template = self._make_template_with_schema(schema)
+        config = template.get_model_template_config()
+        assert config.user_options is not None
+        assert "prediction_periods" not in config.user_options
+        assert "additional_continuous_covariates" not in config.user_options
+        assert "n_lags" in config.user_options
+
+    def test_falls_back_to_defs_path(self):
+        """Legacy MLflow-era models store schema under $defs.ModelConfiguration."""
+        schema = {
+            "$defs": {
+                "ModelConfiguration": {
+                    "properties": {
+                        "max_epochs": {"type": "integer", "default": 10},
+                    }
+                }
+            }
+        }
+        template = self._make_template_with_schema(schema)
+        config = template.get_model_template_config()
+        assert config.user_options is not None
+        assert "max_epochs" in config.user_options
+
+    def test_empty_schema_returns_empty_user_options(self):
+        """No properties at all."""
+        template = self._make_template_with_schema({})
+        config = template.get_model_template_config()
+        assert config.user_options == {}
+
+
 class TestExternalChapkitModelTemplateDetection:
     def test_detects_url_mode(self):
         template = ExternalChapkitModelTemplate("http://localhost:8000")

--- a/uv.lock
+++ b/uv.lock
@@ -342,7 +342,7 @@ wheels = [
 
 [[package]]
 name = "chap-core"
-version = "1.5.0.dev1"
+version = "1.5.0.dev2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -436,7 +436,7 @@ requires-dist = [
     { name = "altair", specifier = ">=5.5.0" },
     { name = "bionumpy", specifier = ">=1.0.14" },
     { name = "celery", extras = ["pytest"], specifier = ">=5.6.3" },
-    { name = "chapkit", specifier = ">=0.17.0" },
+    { name = "chapkit", specifier = ">=0.17.1" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "cyclopts", specifier = ">=4.10.1" },
     { name = "diskcache", specifier = ">=5.6.3" },
@@ -518,7 +518,7 @@ dev = [
 
 [[package]]
 name = "chapkit"
-version = "0.17.0"
+version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "geojson-pydantic" },
@@ -527,9 +527,9 @@ dependencies = [
     { name = "servicekit" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/59/bcb77b997e32d164266455969234342f47772fc993313a1e8e3b8e84ebb4/chapkit-0.17.0.tar.gz", hash = "sha256:2c79fd056f2a808c3895b9a8b2cd2a7774e3b029de66ed0f639a53998bb9fd41", size = 76392, upload-time = "2026-04-13T09:48:53.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/8c/9da0d849c360cb6b63c08905788314374d96107d003ccfe0e3dcd7024903/chapkit-0.17.1.tar.gz", hash = "sha256:f5419605209633e8ef33f61e5781a89fae41a38980ec72c8f4927749e3ff25ce", size = 76376, upload-time = "2026-04-13T11:31:33.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/42/eb40cf9e0de39e94df5018513156af4a5e67fdf994465fce86b0648da140/chapkit-0.17.0-py3-none-any.whl", hash = "sha256:12f40f4b2d211185caf230480216db73d740e88ecd2e5761056f48bf76abcbe5", size = 104696, upload-time = "2026-04-13T09:48:52.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/cf/5742b38f21559cc401db55fa42bd07242e6fa2dce17f206b069d6e19fc00/chapkit-0.17.1-py3-none-any.whl", hash = "sha256:eacbad1293166cd09e480396c6555ec8b7a57678da54f228a17669547c90f7bb", size = 104698, upload-time = "2026-04-13T11:31:31.928Z" },
 ]
 
 [[package]]
@@ -3097,7 +3097,7 @@ wheels = [
 
 [[package]]
 name = "servicekit"
-version = "0.9.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -3114,9 +3114,9 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/13/e012c4fbb325164b6cde7ab9650f4e582526be43c7da40a887560d799f1d/servicekit-0.9.0.tar.gz", hash = "sha256:99f0c6696e56daf65bd2ccbc6b0095e6833a4e36671c61cde1cccac1dd36e518", size = 41966, upload-time = "2026-04-13T09:46:58.943Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/2b/2d930fd244a08ca692f1ca3b46b28693742932aef9e17bcaf932a85ebb52/servicekit-0.10.0.tar.gz", hash = "sha256:bb8ea27a8e33d09d08537446eba678f1711a5be4950b6bbf0abc1a381eec5202", size = 43061, upload-time = "2026-04-13T11:28:49.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/a1/7bebd16c944b63dfefe14b008be86b41adf06d14187f1c6aa4f147207b75/servicekit-0.9.0-py3-none-any.whl", hash = "sha256:e39b8291f87578c16336bc651b88ebb533ee6753ff724803004cad8a13e2858d", size = 54196, upload-time = "2026-04-13T09:47:00.262Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/d3/e61c9e0523844d3460db67cabcc5bace402fcd25822d291436d52527882c/servicekit-0.10.0-py3-none-any.whl", hash = "sha256:e2e5eb40b41b92b4323a56c2a4107d80f94916d10523b6bf114c64c53501672d", size = 55336, upload-time = "2026-04-13T11:28:47.897Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Multiple fixes to the chapkit model template sync path, accumulated during the EWARS overlay integration session.

### user_options from config schema
`get_model_template_config()` was looking for config schema properties under `$defs.ModelConfiguration.properties` (the legacy MLflow-era structure), but chapkit services expose them at the top-level `properties` key. The `$defs` path never matched, so `user_options` stayed `{}` and the "New model" form showed no tuneable fields for chapkit models.

Now falls back to `config_schema["properties"]` and filters out BaseConfig-reserved fields (`prediction_periods`, `additional_continuous_covariates`). Extracted `_parse_user_options_from_config_schema` as a shared helper.

### Sync user_options on every upsert
`_sync_live_chapkit_services` was calling `ml_service_info_to_model_template_config` without `user_options`, so templates always got `user_options: {}` on the initial sync. Now fetches the config schema from the chapkit service on every sync tick and passes the parsed user_options to the template upsert. Schema changes propagate without a DB wipe.

### Compose healthcheck cleanup
Removed the `healthcheck` override from `compose.ewars.yml` since the EWARS Dockerfile now bakes the `HEALTHCHECK` instruction directly.

### chapkit 0.17.1
Bumps chapkit from `>=0.17.0` to `>=0.17.1`, pulling in servicekit 0.10.0 which registers after the app is fully started (not during lifespan startup). This fixes the race condition where the inline sync's config fetch failed because the chapkit service's own routes weren't mounted yet.

## Test plan

- [x] `make lint` clean (ruff, mypy, pyright)
- [x] 4 new tests in `tests/external/test_external_chapkit_model.py:TestGetModelTemplateConfig` — top-level properties, reserved-field filtering, `$defs` fallback, empty schema
- [x] 31 existing tests pass (17 external + 14 self-registration)
- [x] `make force-restart` produces 12 configured models on first boot without any manual sync trigger
- [x] Modeling app Select Model dialog shows `CHAP-EWARS Model (chapkit)` on first load — **no hard refresh needed**
- [x] "New model" form shows `n_lags=3`, `precision=0.01`, `region_seasonal=false` for the chapkit template (matching legacy parity)
- [x] `usesChapkit: true` and `healthStatus: live` on the flat `/v1/crud/model-templates` response