### PR TITLE
feat: update documentation about how to ensure Chap is installed (CLIM-551)

### DIFF
--- a/docs/chap-cli/minimalist-example.md
+++ b/docs/chap-cli/minimalist-example.md
@@ -1,7 +1,23 @@
-# Run minimalist example
+# Run a simple evaluation
 
-At this stage, you have installed Chap Core and want to test whether chap works by running the minimalist example repo.
+At this stage, you have installed Chap Core and want to verify that Chap can fetch a model, prepare data, and run a backtest end-to-end. You can do this with a single `chap eval` command.
 
-Ensure you are able to run this model: [https://github.com/dhis2-chap/minimalist_example_uv](https://github.com/dhis2-chap/minimalist_example_uv)
+## One-liner
+
+Run an evaluation against the minimalist example model, using an example dataset hosted on GitHub. Pass `--plot` to generate an HTML visualization alongside the NetCDF output:
+
+```bash
+chap eval \
+    --model-name https://github.com/dhis2-chap/minimalist_example_uv \
+    --dataset-csv https://raw.githubusercontent.com/dhis2-chap/chap-core/master/example_data/laos_subset.csv \
+    --output-file eval.nc \
+    --backtest-params.n-splits 2 \
+    --backtest-params.n-periods 1 \
+    --plot
+```
+
+## Verification
+
+If the command completes and writes `eval.nc` and `eval.html`, your Chap installation is working: it can resolve a GitHub-hosted model, set up its environment, run a rolling-origin backtest on a remote dataset, and plot the results.
 
 The next step is to integrate your own model into Chap.


### PR DESCRIPTION
## Summary

Update the minimalist example documentation page to instead describe how to run a simple evaluation with a one-liner.

Reference: https://chap.dhis2.org/chap-modeling-platform/chap-cli/minimalist-example/

Jira: CLIM-551