### PR TITLE
fix: raise clear error when URL model name fails chapkit detection (CLIM-559)

### DIFF
--- a/chap_core/models/utils.py
+++ b/chap_core/models/utils.py
@@ -167,6 +167,13 @@ def get_model_template_from_directory_or_github_url(
             assert template.name is not None, template
         return template
 
+    if is_url(model_template_path) and not model_template_path.startswith("https://github.com"):
+        raise ValueError(
+            f"URL {model_template_path} was provided but could not be reached as a chapkit service. "
+            "Ensure the server is running and exposes /api/v1/info, "
+            "or use --run-config.is-chapkit-model to skip auto-detection."
+        )
+
     logger.debug(
         f"Getting model template from {model_template_path}. Ignore env: {ignore_env}. Base working dir: {base_working_dir}. Run dir type: {run_dir_type}"
     )

--- a/tests/external/test_external_chapkit_model.py
+++ b/tests/external/test_external_chapkit_model.py
@@ -12,6 +12,7 @@ from chap_core.models.chapkit_service_manager import (
     is_url,
 )
 from chap_core.models.external_chapkit_model import ExternalChapkitModelTemplate
+from chap_core.models.utils import get_model_template_from_directory_or_github_url
 
 model_url = "http://localhost:8003"
 
@@ -60,6 +61,18 @@ def test_chapkit_model_wrapping(service_available):
     template = ExternalChapkitModelTemplate(service_available)
     config = template.get_model_template_config()
     print(config)
+
+
+class TestUrlModelNameFallback:
+    """CLIM-559: URL model name should not fall back to filesystem path handling."""
+
+    def test_unreachable_url_raises_clear_error(self):
+        with pytest.raises(ValueError, match="could not be reached as a chapkit service"):
+            get_model_template_from_directory_or_github_url("http://127.0.0.1:19999")
+
+    def test_unreachable_https_url_raises_clear_error(self):
+        with pytest.raises(ValueError, match="could not be reached as a chapkit service"):
+            get_model_template_from_directory_or_github_url("https://nonexistent.example.com:9999")
 
 
 class TestIsUrl:


### PR DESCRIPTION
## Summary

Fixes [CLIM-559](https://dhis2.atlassian.net/browse/CLIM-559).

When a URL like `http://127.0.0.1:8000` is passed as `--model-name` to `chap eval` and the chapkit auto-detection probe (`_is_chapkit_url()`) fails (e.g. server not running or missing `/api/v1/info` endpoint), the code in `get_model_template_from_directory_or_github_url` falls through to `_get_model_code_base`, which treats the URL as a local directory path. This produces a confusing `FileNotFoundError` from `shutil.copytree`.

**Before:**
```
FileNotFoundError: [Errno 2] No such file or directory: 'http://127.0.0.1:8000'
```

**After:**
```
ValueError: URL http://127.0.0.1:8000 was provided but could not be reached as a chapkit service.
Ensure the server is running and exposes /api/v1/info, or use --run-config.is-chapkit-model to skip auto-detection.
```

GitHub URLs (`https://github.com/org/repo@hash`) are excluded from the guard since they are valid model paths handled by the git-clone path in `_get_model_code_base`.

## Changes

- `chap_core/models/utils.py` — add `is_url()` guard (excluding GitHub URLs) after the chapkit detection block, before falling through to filesystem handling.
- `tests/external/test_external_chapkit_model.py` — two tests: unreachable HTTP and HTTPS URLs both raise `ValueError` with the expected message.

## Test plan

- [x] `make lint` clean (ruff, mypy, pyright)
- [x] 19 passed, 2 skipped in `tests/external/test_external_chapkit_model.py`
- [x] GitHub URL model paths (`https://github.com/sandvelab/monthly_ar_model@hash`) still pass through to the git-clone path (not caught by the guard)

[CLIM-559]: https://dhis2.atlassian.net/browse/CLIM-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ