### PR TITLE
feat: add alembic migration chain tests (CLIM-349)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dev = [
     "types-psycopg2>=2.9.21.20260408",
     "types-shapely>=2.1.0.20260408",
     "types-geopandas>=1.1.3.20260408",
+    "testcontainers[postgres]>=4.10.0",
 ]
 
 [project.urls]

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -102,6 +102,7 @@ def _create_baseline_schema(engine):
         conn.commit()
 
 
+@pytest.mark.slow
 class TestAlembicMigrations:
     """Test the full alembic migration chain against a real PostgreSQL database."""
 

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -51,7 +51,7 @@ def _pg_container():
         pytest.skip("testcontainers[postgres] not installed")
 
     try:
-        container = PostgresContainer("postgres:16-alpine")
+        container = PostgresContainer("postgres:17-alpine")
         container.start()
         return container
     except Exception as e:

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -1,0 +1,188 @@
+"""
+Tests for alembic migration chain (CLIM-349).
+
+Spins up a real PostgreSQL container via testcontainers, creates the baseline
+schema (as it existed before alembic), then runs the full upgrade/downgrade cycle.
+
+Requires Docker to be available. Skips automatically if Docker is not running.
+
+New migrations are automatically tested since upgrade always targets "head".
+"""
+
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from sqlmodel import SQLModel
+
+# Import all models so SQLModel.metadata is fully populated
+from chap_core.database.dataset_tables import DataSet, Observation  # noqa: F401
+from chap_core.database.debug import DebugEntry  # noqa: F401
+from chap_core.database.feature_tables import FeatureSource, FeatureType  # noqa: F401
+from chap_core.database.model_spec_tables import ModelFeatureLink, ModelSpec  # noqa: F401
+from chap_core.database.model_templates_and_config_tables import (  # noqa: F401
+    ConfiguredModelDB,
+    ModelTemplateDB,
+)
+from chap_core.database.tables import (  # noqa: F401
+    BackTest,
+    BackTestForecast,
+    BackTestMetric,
+    Prediction,
+    PredictionSamplesEntry,
+)
+
+PROJECT_ROOT = Path(__file__).parent.parent
+ALEMBIC_INI = PROJECT_ROOT / "alembic.ini"
+
+# Columns added by alembic migrations (not in the baseline schema).
+# When simulating a pre-alembic database we create all tables from
+# SQLModel metadata then drop these columns so the migration can re-add them.
+_COLUMNS_ADDED_BY_MIGRATIONS = [
+    ("modeltemplatedb", "archived"),
+]
+
+
+def _pg_container():
+    """Create and start a PostgreSQL testcontainer."""
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        pytest.skip("testcontainers[postgres] not installed")
+
+    try:
+        container = PostgresContainer("postgres:16-alpine")
+        container.start()
+        return container
+    except Exception as e:
+        pytest.skip(f"Docker not available: {e}")
+
+
+@pytest.fixture(scope="module")
+def pg():
+    """Module-scoped PostgreSQL container fixture."""
+    container = _pg_container()
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def engine(pg):
+    """SQLAlchemy engine connected to the test PostgreSQL database."""
+    eng = sa.create_engine(pg.get_connection_url())
+    yield eng
+    eng.dispose()
+
+
+def _make_alembic_cfg(engine):
+    """Create an Alembic config that passes the engine connection directly.
+
+    This bypasses env.py's CHAP_DATABASE_URL override by providing the
+    connection via config.attributes, which env.py checks first.
+    """
+    from alembic.config import Config
+
+    cfg = Config(str(ALEMBIC_INI))
+    cfg.attributes["connection"] = engine
+    return cfg
+
+
+def _create_baseline_schema(engine):
+    """Create the database schema as it existed at the alembic baseline.
+
+    Creates all tables from SQLModel metadata, then drops columns that
+    were added by subsequent alembic migrations. This simulates the state
+    of a database before alembic migrations were applied.
+    """
+    SQLModel.metadata.create_all(engine)
+
+    with engine.connect() as conn:
+        for table, column in _COLUMNS_ADDED_BY_MIGRATIONS:
+            conn.execute(sa.text(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {column}"))
+        conn.commit()
+
+
+class TestAlembicMigrations:
+    """Test the full alembic migration chain against a real PostgreSQL database."""
+
+    def test_upgrade_to_head(self, engine):
+        """
+        Simulate a pre-alembic database, stamp baseline, then upgrade to head.
+        """
+        from alembic import command
+        from alembic.script import ScriptDirectory
+
+        alembic_cfg = _make_alembic_cfg(engine)
+
+        # Create baseline schema (tables without columns added by migrations)
+        _create_baseline_schema(engine)
+
+        # Stamp the baseline revision so alembic knows where we are
+        command.stamp(alembic_cfg, "fe59a33965ed")
+
+        # Upgrade to head (applies all migrations after baseline)
+        command.upgrade(alembic_cfg, "head")
+
+        # Verify we are at head
+        script = ScriptDirectory.from_config(alembic_cfg)
+        head_rev = script.get_current_head()
+
+        with engine.connect() as conn:
+            result = conn.execute(sa.text("SELECT version_num FROM alembic_version"))
+            current = result.scalar_one()
+            assert current == head_rev, f"Expected head {head_rev}, got {current}"
+
+    def test_downgrade_to_base_and_upgrade_again(self, engine):
+        """
+        After upgrading, downgrade back to baseline then upgrade again.
+        Verifies downgrade() functions work correctly.
+        """
+        from alembic import command
+        from alembic.script import ScriptDirectory
+
+        alembic_cfg = _make_alembic_cfg(engine)
+
+        # Downgrade to baseline
+        command.downgrade(alembic_cfg, "fe59a33965ed")
+
+        with engine.connect() as conn:
+            result = conn.execute(sa.text("SELECT version_num FROM alembic_version"))
+            current = result.scalar_one()
+            assert current == "fe59a33965ed"
+
+        # Upgrade back to head
+        command.upgrade(alembic_cfg, "head")
+
+        script = ScriptDirectory.from_config(alembic_cfg)
+        head_rev = script.get_current_head()
+
+        with engine.connect() as conn:
+            result = conn.execute(sa.text("SELECT version_num FROM alembic_version"))
+            current = result.scalar_one()
+            assert current == head_rev
+
+    def test_all_revisions_have_downgrade(self):
+        """Verify every migration revision defines a non-empty downgrade."""
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+
+        cfg = Config(str(ALEMBIC_INI))
+        script = ScriptDirectory.from_config(cfg)
+
+        for rev in script.walk_revisions():
+            module = rev.module
+            downgrade_fn = getattr(module, "downgrade", None)
+            assert downgrade_fn is not None, f"Revision {rev.revision} missing downgrade()"
+
+    def test_migration_history_is_linear(self):
+        """Verify no branch points exist in the migration chain."""
+        from alembic.config import Config
+        from alembic.script import ScriptDirectory
+
+        cfg = Config(str(ALEMBIC_INI))
+        script = ScriptDirectory.from_config(cfg)
+        branches = list(script.get_bases())
+        assert len(branches) == 1, f"Expected 1 base, found {len(branches)}: {branches}"
+
+        heads = list(script.get_heads())
+        assert len(heads) == 1, f"Expected 1 head, found {len(heads)}: {heads}"

--- a/uv.lock
+++ b/uv.lock
@@ -419,6 +419,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "ruff" },
     { name = "tabulate" },
+    { name = "testcontainers" },
     { name = "types-geopandas" },
     { name = "types-jsonschema" },
     { name = "types-psycopg2" },
@@ -505,6 +506,7 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.15.9" },
     { name = "tabulate", specifier = ">=0.9" },
+    { name = "testcontainers", extras = ["postgres"], specifier = ">=4.10.0" },
     { name = "types-geopandas", specifier = ">=1.1.3.20260408" },
     { name = "types-jsonschema", specifier = ">=4.26.0.20260408" },
     { name = "types-psycopg2", specifier = ">=2.9.21.20260408" },
@@ -3296,6 +3298,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds tests that verify the full alembic migration chain (upgrade and downgrade) against a real PostgreSQL database using testcontainers
- Tests automatically cover any new migrations added in the future since they always target `head`
- Adds `testcontainers[postgres]` as a dev dependency

## What is tested
1. **Upgrade to head**: Creates baseline schema, stamps alembic baseline, upgrades to head
2. **Downgrade and re-upgrade**: Downgrades to baseline, then upgrades again to verify downgrade functions
3. **All revisions have downgrade**: Structural check that every migration file defines a downgrade
4. **Linear history**: Verifies no branch points or multiple heads exist

## Notes
- Requires Docker to be available; tests skip gracefully if Docker is not running
- CI does not currently have Docker support, so these tests will skip in CI for now (can be enabled when a Docker-enabled CI job is added, ref CLIM-565)
- Uses `testcontainers[postgres]` to spin up an ephemeral PostgreSQL 16 container

Closes CLIM-349