### PR TITLE
feat: add model_information property to ConfiguredModel (CLIM-571)

### DIFF
--- a/chap_core/external/ExtendedPredictor.py
+++ b/chap_core/external/ExtendedPredictor.py
@@ -10,6 +10,10 @@ class ExtendedPredictor(ConfiguredModel):
         self._config_model = configured_model
         self._desired_scope = desired_scope
 
+    @property
+    def model_information(self):
+        return self._config_model.model_information
+
     def train(self, train_data: DataSet, extra_args=None):
         self._config_model.train(train_data, extra_args)
         return self
@@ -25,13 +29,15 @@ class ExtendedPredictor(ConfiguredModel):
         if "parent" in future_df.columns:
             future_df = future_df.drop(columns=["parent"])
 
-        model_information = self._config_model.model_information  # type: ignore[attr-defined]
+        model_information = self._config_model.model_information
 
         assert model_information is not None
 
         min_pred_length = model_information.min_prediction_length
         max_pred_length = model_information.max_prediction_length
 
+        assert min_pred_length is not None
+        assert max_pred_length is not None
         assert self._desired_scope >= min_pred_length
 
         remaining_time_periods = self._desired_scope

--- a/chap_core/external/ExtendedPredictor.py
+++ b/chap_core/external/ExtendedPredictor.py
@@ -1,3 +1,5 @@
+import copy
+
 import pandas as pd
 
 from chap_core.datatypes import Samples
@@ -12,7 +14,12 @@ class ExtendedPredictor(ConfiguredModel):
 
     @property
     def model_information(self):
-        return self._config_model.model_information
+        inner = self._config_model.model_information
+        if inner is None:
+            return None
+        adapted = copy.copy(inner)
+        adapted.max_prediction_length = self._desired_scope
+        return adapted
 
     def train(self, train_data: DataSet, extra_args=None):
         self._config_model.train(train_data, extra_args)

--- a/chap_core/models/configured_model.py
+++ b/chap_core/models/configured_model.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import abc
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+if TYPE_CHECKING:
+    from chap_core.database.model_templates_and_config_tables import ModelTemplateInformation
+    from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 
 
 class ConfiguredModel(abc.ABC):
@@ -12,6 +17,10 @@ class ConfiguredModel(abc.ABC):
     and/or other choices. While a ModelTemplate is flexible with choices, a ConfiguredModel has fixed choices
     and parameters. See ExternalModel for an example of a ConfiguredModel.
     """
+
+    @property
+    @abc.abstractmethod
+    def model_information(self) -> ModelTemplateInformation | None: ...
 
     @abc.abstractmethod
     def train(self, train_data: DataSet, extra_args=None):

--- a/chap_core/models/external_web_model.py
+++ b/chap_core/models/external_web_model.py
@@ -71,6 +71,10 @@ class ExternalWebModel(ExternalModelBase):
         return self._name
 
     @property
+    def model_information(self):
+        return None
+
+    @property
     def configuration(self):
         return self._configuration
 

--- a/chap_core/models/model_template_interface.py
+++ b/chap_core/models/model_template_interface.py
@@ -6,6 +6,10 @@ from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 
 
 class ConfiguredModel(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def model_information(self) -> ModelTemplateInformation | None: ...
+
     @abc.abstractmethod
     def train(self, train_data: DataSet, extra_args=None):
         pass

--- a/tests/external/test_extended_predictor.py
+++ b/tests/external/test_extended_predictor.py
@@ -12,11 +12,15 @@ class MockModel(ConfiguredModel):
     """Mock model that returns simple predictions for testing."""
 
     def __init__(self, min_pred_length=2, max_pred_length=4):
-        self.model_information = ModelTemplateConfigV2(
+        self._model_information = ModelTemplateConfigV2(
             name="mock_model", min_prediction_length=min_pred_length, max_prediction_length=max_pred_length
         )
         self.trained = False
         self.predict_call_count = 0
+
+    @property
+    def model_information(self):
+        return self._model_information
 
     def train(self, train_data: DataSet, extra_args=None):
         self.trained = True
@@ -46,7 +50,7 @@ class TrackingMockModel(ConfiguredModel):
     """
 
     def __init__(self, locations, future_periods, min_pred_length=2, max_pred_length=3):
-        self.model_information = ModelTemplateConfigV2(
+        self._model_information = ModelTemplateConfigV2(
             name="tracking_mock",
             min_prediction_length=min_pred_length,
             max_prediction_length=max_pred_length,
@@ -54,6 +58,10 @@ class TrackingMockModel(ConfiguredModel):
         self.locations = locations
         self.future_periods = future_periods
         self.call_history = []
+
+    @property
+    def model_information(self):
+        return self._model_information
 
     def train(self, train_data: DataSet, extra_args=None):
         return self

--- a/tests/external/test_extended_predictor.py
+++ b/tests/external/test_extended_predictor.py
@@ -175,6 +175,16 @@ def test_extended_predictor_adapts_model_information():
     assert mock_model.model_information.max_prediction_length == 4
 
 
+def test_extended_predictor_returns_none_when_inner_model_information_is_none():
+    """Test that model_information returns None when the inner model has no info."""
+    mock_model = Mock(spec=ConfiguredModel)
+    mock_model.model_information = None
+
+    extended_predictor = ExtendedPredictor(mock_model, desired_scope=6)
+
+    assert extended_predictor.model_information is None
+
+
 def test_extended_predictor_train():
     """Test that training is delegated to the underlying model and returns self."""
     mock_model = MockModel()

--- a/tests/external/test_extended_predictor.py
+++ b/tests/external/test_extended_predictor.py
@@ -161,6 +161,20 @@ def test_extended_predictor_initialization():
     assert extended_predictor._desired_scope == desired_scope
 
 
+def test_extended_predictor_adapts_model_information():
+    """Test that model_information reflects the extended prediction capability."""
+    mock_model = MockModel(min_pred_length=2, max_pred_length=4)
+    desired_scope = 10
+
+    extended_predictor = ExtendedPredictor(mock_model, desired_scope)
+    info = extended_predictor.model_information
+
+    assert info.max_prediction_length == desired_scope
+    assert info.min_prediction_length == 2
+    # Inner model's information should be unchanged
+    assert mock_model.model_information.max_prediction_length == 4
+
+
 def test_extended_predictor_train():
     """Test that training is delegated to the underlying model and returns self."""
     mock_model = MockModel()

--- a/tests/external/test_extended_predictor.py
+++ b/tests/external/test_extended_predictor.py
@@ -218,8 +218,11 @@ def test_extended_predictor_with_external_model_interface():
 
     assert extended_predictor._config_model == external_model
     assert extended_predictor._desired_scope == 6
-    assert extended_predictor._config_model.model_information.min_prediction_length == 2  # type: ignore[reportAttributeAccessIssue]
-    assert extended_predictor._config_model.model_information.max_prediction_length == 4  # type: ignore[reportAttributeAccessIssue]
+    # Wrapper adapts max_prediction_length to desired_scope
+    assert extended_predictor.model_information.max_prediction_length == 6
+    assert extended_predictor.model_information.min_prediction_length == 2
+    # Inner model is unchanged
+    assert external_model.model_information.max_prediction_length == 4
 
 
 def test_update_historic_data_includes_all_locations():

--- a/tests/test_command_line_interface_adaptor.py
+++ b/tests/test_command_line_interface_adaptor.py
@@ -21,6 +21,10 @@ class DummyConfig(BaseModel):
 class DummyModel(ConfiguredModel):
     covariate_names: list[str] = ["rainfall", "mean_temperature", "population"]
 
+    @property
+    def model_information(self):
+        return None
+
     def __init__(self, config: ModelConfiguration):
         self._config = DummyConfig.model_validate(config.user_option_values)
 

--- a/tests/test_external_web_model.py
+++ b/tests/test_external_web_model.py
@@ -1,0 +1,6 @@
+from chap_core.models.external_web_model import ExternalWebModel
+
+
+def test_model_information_is_none():
+    model = ExternalWebModel(api_url="http://localhost:8000", name="test")
+    assert model.model_information is None


### PR DESCRIPTION
## Summary

Adds a formal `model_information` abstract property to `ConfiguredModel`, typed as `ModelTemplateInformation | None`. This formalizes a contract that was already implemented by three concrete subclasses but not declared on the base ABC.

Resolves [CLIM-571](https://dhis2.atlassian.net/browse/CLIM-571).

## Changes

### `chap_core/models/configured_model.py`
- Added `model_information` as an abstract property on the `ConfiguredModel` ABC
- Return type is `ModelTemplateInformation | None`
- Moved `DataSet` import into `TYPE_CHECKING` block (required by ruff after adding `from __future__ import annotations`)

### `chap_core/external/ExtendedPredictor.py`
- Added `model_information` property that adapts the wrapped model's metadata: `max_prediction_length` is set to `desired_scope` since the wrapper's purpose is to support longer predictions than the inner model
- Removed `# type: ignore[attr-defined]` suppression (no longer needed)
- Added assertions that `min_prediction_length` and `max_prediction_length` are not `None` before arithmetic (fixes a real type-safety gap that mypy now catches with the typed property)

### `chap_core/models/external_web_model.py`
- Added `model_information` property returning `None` (web models don't have template info)

### `chap_core/models/model_template_interface.py`
- Added `model_information` abstract property to the duplicate `ConfiguredModel` definition for consistency

### `chap_core/hpo/hpoModelInterface.py`
- No changes needed - `HpoModel` already implements `model_information`

### Test updates
- `tests/external/test_extended_predictor.py`: Converted `MockModel` and `TrackingMockModel` from instance attribute to property pattern (required by ABC). Added test verifying `ExtendedPredictor` adapts `max_prediction_length` to `desired_scope` and leaves the inner model unchanged.
- `tests/test_command_line_interface_adaptor.py`: Added `model_information` property to `DummyModel`

## Test plan
- [x] All existing tests pass (572 passed)
- [x] `make lint` passes (ruff, mypy, pyright)
- [x] New test verifies ExtendedPredictor adapts model_information correctly
- [x] New test verifies inner model's metadata is not mutated

[CLIM-571]: https://dhis2.atlassian.net/browse/CLIM-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ