### PR TITLE
feat: add endpoint to download backtest metrics as CSV [CLIM-598]

### DIFF
--- a/chap_core/assessment/metrics/__init__.py
+++ b/chap_core/assessment/metrics/__init__.py
@@ -203,18 +203,15 @@ def compute_all_aggregated_metrics_from_backtest(backtest: BackTest) -> dict[str
     return results
 
 
-def compute_all_detailed_metrics_from_backtest(backtest: BackTest) -> pd.DataFrame:
+def compute_all_detailed_metrics(evaluation: Evaluation) -> pd.DataFrame:
     """
-    Compute all applicable metrics at detailed resolution for a backtest.
+    Compute all applicable metrics at detailed resolution for an evaluation.
 
     Returns a long-format DataFrame with one row per
     (metric_id, location, time_period, horizon_distance). Metrics that
     are not applicable or fail to compute are skipped so a single broken
     metric doesn't take down the whole export.
     """
-    logger.info(f"Computing detailed metrics for backtest {backtest.id}")
-
-    evaluation = Evaluation.from_backtest(backtest)
     flat_data = evaluation.to_flat()
 
     historical_obs = flat_data.historical_observations
@@ -230,7 +227,7 @@ def compute_all_detailed_metrics_from_backtest(backtest: BackTest) -> pd.DataFra
         try:
             detailed = metric.get_detailed_metric(flat_data.observations, flat_data.forecasts)
         except Exception:
-            logger.exception("Failed to compute detailed metric %s for backtest %s", metric_id, backtest.id)
+            logger.exception("Failed to compute detailed metric %s", metric_id)
             continue
         detailed = detailed.copy()
         detailed.insert(0, "metric_id", metric_id)

--- a/chap_core/assessment/metrics/__init__.py
+++ b/chap_core/assessment/metrics/__init__.py
@@ -203,6 +203,44 @@ def compute_all_aggregated_metrics_from_backtest(backtest: BackTest) -> dict[str
     return results
 
 
+def compute_all_detailed_metrics_from_backtest(backtest: BackTest) -> pd.DataFrame:
+    """
+    Compute all applicable metrics at detailed resolution for a backtest.
+
+    Returns a long-format DataFrame with one row per
+    (metric_id, location, time_period, horizon_distance). Metrics that
+    are not applicable or fail to compute are skipped so a single broken
+    metric doesn't take down the whole export.
+    """
+    logger.info(f"Computing detailed metrics for backtest {backtest.id}")
+
+    evaluation = Evaluation.from_backtest(backtest)
+    flat_data = evaluation.to_flat()
+
+    historical_obs = flat_data.historical_observations
+    historical_df: pd.DataFrame | None = (
+        pd.DataFrame(cast("pd.DataFrame", historical_obs)) if historical_obs is not None else None
+    )
+
+    frames: list[pd.DataFrame] = []
+    for metric_id, metric_factory in available_metrics.items():
+        metric = metric_factory(historical_observations=historical_df)
+        if not metric.is_applicable(flat_data.observations):
+            continue
+        try:
+            detailed = metric.get_detailed_metric(flat_data.observations, flat_data.forecasts)
+        except Exception:
+            logger.exception("Failed to compute detailed metric %s for backtest %s", metric_id, backtest.id)
+            continue
+        detailed = detailed.copy()
+        detailed.insert(0, "metric_id", metric_id)
+        frames.append(detailed)
+
+    if not frames:
+        return pd.DataFrame(columns=["metric_id", "location", "time_period", "horizon_distance", "metric"])
+    return pd.concat(frames, ignore_index=True)
+
+
 def calculate_metrics(
     evaluation: Evaluation,
     metric_ids: list[str],

--- a/chap_core/rest_api/app.py
+++ b/chap_core/rest_api/app.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 openapi_tags = [
     {"name": "System", "description": "Health checks and system information"},
     {"name": "Backtests", "description": "Create, manage, and query backtests and evaluation results"},
+    {"name": "Metrics", "description": "Compute and export evaluation metrics"},
     {"name": "Predictions", "description": "Create, manage, and query predictions"},
     {"name": "Datasets", "description": "Create, manage, and export datasets"},
     {"name": "Models", "description": "Model templates and configured models"},

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -27,6 +27,7 @@ from starlette.responses import StreamingResponse
 
 import chap_core.rest_api.db_worker_functions as wf
 from chap_core.api_types import FeatureCollectionModel
+from chap_core.assessment.metrics import compute_all_detailed_metrics_from_backtest
 from chap_core.data import DataSet as InMemoryDataSet
 from chap_core.database.base_tables import DBModel
 from chap_core.database.database import SessionWrapper
@@ -271,6 +272,31 @@ def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], ses
     if backtest is None:
         raise HTTPException(status_code=404, detail="BackTest not found")
     return backtest
+
+
+@router.get("/backtests/{backtestId}/metrics/csv", tags=["Backtests"])
+async def get_backtest_metrics_csv(
+    backtest_id: Annotated[int, Path(alias="backtestId")],
+    session: Session = Depends(get_session),
+):
+    """
+    Download per-location / per-time_period / per-horizon metric values for a
+    backtest as a long-format CSV. Every applicable metric in
+    `chap_core.assessment.metrics.available_metrics` is included as rows.
+    """
+    backtest = session.get(BackTest, backtest_id)
+    if backtest is None:
+        raise HTTPException(status_code=404, detail="BackTest not found")
+
+    df = compute_all_detailed_metrics_from_backtest(backtest)
+    df["time_period"] = df["time_period"].astype(str)
+
+    csv_content = df.to_csv(index=False)
+    return StreamingResponse(
+        iter([csv_content]),
+        media_type="text/csv",
+        headers={"Content-Disposition": f"attachment; filename=backtest_{backtest_id}_metrics.csv"},
+    )
 
 
 class BackTestUpdate(DBModel):

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -27,7 +27,8 @@ from starlette.responses import StreamingResponse
 
 import chap_core.rest_api.db_worker_functions as wf
 from chap_core.api_types import FeatureCollectionModel
-from chap_core.assessment.metrics import compute_all_detailed_metrics_from_backtest
+from chap_core.assessment.evaluation import Evaluation
+from chap_core.assessment.metrics import compute_all_detailed_metrics
 from chap_core.data import DataSet as InMemoryDataSet
 from chap_core.database.base_tables import DBModel
 from chap_core.database.database import SessionWrapper
@@ -274,21 +275,26 @@ def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], ses
     return backtest
 
 
-@router.get("/backtests/{backtestId}/metrics/csv", tags=["Backtests"])
-async def get_backtest_metrics_csv(
-    backtest_id: Annotated[int, Path(alias="backtestId")],
+@router.get("/metric/csv", tags=["Metrics"])
+async def get_metrics_csv(
+    backtest_id: Annotated[int, Query(alias="backtestId")],
     session: Session = Depends(get_session),
 ):
     """
-    Download per-location / per-time_period / per-horizon metric values for a
-    backtest as a long-format CSV. Every applicable metric in
+    Download per-location / per-time_period / per-horizon metric values as a
+    long-format CSV. Every applicable metric in
     `chap_core.assessment.metrics.available_metrics` is included as rows.
+
+    Currently takes a single backtest via the `backtestId` query parameter; the
+    path is scoped to `/metric/` so it can be extended to accept multiple
+    evaluations later without a breaking change.
     """
     backtest = session.get(BackTest, backtest_id)
     if backtest is None:
         raise HTTPException(status_code=404, detail="BackTest not found")
 
-    df = compute_all_detailed_metrics_from_backtest(backtest)
+    evaluation = Evaluation.from_backtest(backtest)
+    df = compute_all_detailed_metrics(evaluation)
     df["time_period"] = df["time_period"].astype(str)
 
     csv_content = df.to_csv(index=False)

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -20,8 +20,9 @@ from chap_core.assessment.metrics import (
     WinklerScore25_75Metric,
     DataDimension,
     compute_all_aggregated_metrics_from_backtest,
-    compute_all_detailed_metrics_from_backtest,
+    compute_all_detailed_metrics,
 )
+from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metrics.peak_diff import PeakValueDiffMetric, PeakPeriodLagMetric
 from chap_core.assessment.flat_representations import FlatForecasts, FlatObserved
 import pytest
@@ -206,9 +207,10 @@ def test_get_all_aggregated_metrics_from_backtest(backtest_weeks):
     assert metrics["sample_count"] == 24.0
 
 
-def test_compute_all_detailed_metrics_from_backtest(backtest_weeks):
-    """Test compute_all_detailed_metrics_from_backtest returns a long-format DataFrame."""
-    df = compute_all_detailed_metrics_from_backtest(backtest_weeks)
+def test_compute_all_detailed_metrics(backtest_weeks):
+    """Test compute_all_detailed_metrics returns a long-format DataFrame."""
+    evaluation = Evaluation.from_backtest(backtest_weeks)
+    df = compute_all_detailed_metrics(evaluation)
     assert list(df.columns) == ["metric_id", "location", "time_period", "horizon_distance", "metric"]
     assert len(df) > 0
     assert "sample_count" in set(df["metric_id"])

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -20,6 +20,7 @@ from chap_core.assessment.metrics import (
     WinklerScore25_75Metric,
     DataDimension,
     compute_all_aggregated_metrics_from_backtest,
+    compute_all_detailed_metrics_from_backtest,
 )
 from chap_core.assessment.metrics.peak_diff import PeakValueDiffMetric, PeakPeriodLagMetric
 from chap_core.assessment.flat_representations import FlatForecasts, FlatObserved
@@ -203,6 +204,14 @@ def test_get_all_aggregated_metrics_from_backtest(backtest_weeks):
     metrics = compute_all_aggregated_metrics_from_backtest(backtest_weeks)
     assert "sample_count" in metrics
     assert metrics["sample_count"] == 24.0
+
+
+def test_compute_all_detailed_metrics_from_backtest(backtest_weeks):
+    """Test compute_all_detailed_metrics_from_backtest returns a long-format DataFrame."""
+    df = compute_all_detailed_metrics_from_backtest(backtest_weeks)
+    assert list(df.columns) == ["metric_id", "location", "time_period", "horizon_distance", "metric"]
+    assert len(df) > 0
+    assert "sample_count" in set(df["metric_id"])
 
 
 @pytest.fixture

--- a/tests/integration/rest_api/test_app_mounting.py
+++ b/tests/integration/rest_api/test_app_mounting.py
@@ -99,6 +99,7 @@ class TestOpenAPITags:
         expected = [
             "System",
             "Backtests",
+            "Metrics",
             "Predictions",
             "Datasets",
             "Models",

--- a/tests/integration/rest_api/test_from_seeded_engine.py
+++ b/tests/integration/rest_api/test_from_seeded_engine.py
@@ -88,8 +88,8 @@ def test_dataset_df(override_session):
     # assert "cases" in df[0], df[0].keys()
 
 
-def test_backtest_metrics_csv(override_session):
-    response = client.get("/v1/crud/backtests/1/metrics/csv")
+def test_metrics_csv(override_session):
+    response = client.get("/v1/crud/metric/csv", params={"backtestId": 1})
     assert response.status_code == 200, response.text
     assert response.headers["content-type"].startswith("text/csv")
     lines = response.text.strip().splitlines()
@@ -99,8 +99,8 @@ def test_backtest_metrics_csv(override_session):
     assert {"crps", "mae", "rmse"}.issubset(metric_ids)
 
 
-def test_backtest_metrics_csv_missing(override_session):
-    response = client.get("/v1/crud/backtests/9999/metrics/csv")
+def test_metrics_csv_missing(override_session):
+    response = client.get("/v1/crud/metric/csv", params={"backtestId": 9999})
     assert response.status_code == 404
 
 

--- a/tests/integration/rest_api/test_from_seeded_engine.py
+++ b/tests/integration/rest_api/test_from_seeded_engine.py
@@ -88,6 +88,22 @@ def test_dataset_df(override_session):
     # assert "cases" in df[0], df[0].keys()
 
 
+def test_backtest_metrics_csv(override_session):
+    response = client.get("/v1/crud/backtests/1/metrics/csv")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].startswith("text/csv")
+    lines = response.text.strip().splitlines()
+    assert lines[0] == "metric_id,location,time_period,horizon_distance,metric"
+    assert len(lines) > 1
+    metric_ids = {line.split(",", 1)[0] for line in lines[1:]}
+    assert {"crps", "mae", "rmse"}.issubset(metric_ids)
+
+
+def test_backtest_metrics_csv_missing(override_session):
+    response = client.get("/v1/crud/backtests/9999/metrics/csv")
+    assert response.status_code == 404
+
+
 def test_backtest_plot(override_session, tmp_path):
     response = client.get("/v1/visualization/backtest-plots/evaluation_plot/1")
     assert response.status_code == 200, response.json()


### PR DESCRIPTION
## Summary
- Adds `GET /v1/crud/backtests/{backtestId}/metrics/csv` returning a long-format CSV with per-location / per-time_period / per-horizon values for every applicable metric in `available_metrics`.
- Introduces `compute_all_detailed_metrics_from_backtest` in `chap_core.assessment.metrics`, which iterates the registered metrics, skips those that aren't applicable, and tolerates individual metric failures so one broken metric doesn't take down the whole export.

## Test plan
- [x] `uv run pytest tests/evaluation/test_metrics.py::test_compute_all_detailed_metrics_from_backtest`
- [x] `uv run pytest tests/integration/rest_api/test_from_seeded_engine.py::test_backtest_metrics_csv tests/integration/rest_api/test_from_seeded_engine.py::test_backtest_metrics_csv_missing`


Demo: 

https://github.com/user-attachments/assets/ed40c0ec-a914-43e6-8469-a69218bc88eb

