### PR TITLE
feat: add report endpoint for model-produced PDF reports (CLIM-179)

### DIFF
--- a/chap_core/cli.py
+++ b/chap_core/cli.py
@@ -17,6 +17,7 @@ from chap_core.cli_endpoints import (
     forecast,
     generate_modelcard,
     preference_learn,
+    report,
     utils,
     validate,
 )
@@ -35,6 +36,7 @@ evaluate.register_commands(app)
 explain.register_commands(app)
 forecast.register_commands(app)
 preference_learn.register_commands(app)
+report.register_commands(app)
 utils.register_commands(app)
 validate.register_commands(app)
 generate_modelcard.register_commands(app)

--- a/chap_core/cli_endpoints/report.py
+++ b/chap_core/cli_endpoints/report.py
@@ -1,0 +1,59 @@
+"""Report generation command for CHAP CLI."""
+
+import logging
+from pathlib import Path
+from typing import Annotated
+
+import yaml
+from cyclopts import Parameter
+
+from chap_core.api_types import RunConfig
+from chap_core.cli_endpoints._common import discover_geojson, load_dataset_from_csv
+from chap_core.database.model_templates_and_config_tables import ModelConfiguration
+from chap_core.log_config import initialize_logging
+from chap_core.models.model_template import ModelTemplate
+
+logger = logging.getLogger(__name__)
+
+
+def report(
+    model_path: Annotated[Path, Parameter(help="Path to an MLProject directory or GitHub URL")],
+    model_artifact: Annotated[Path, Parameter(help="Path to the pre-trained model artifact")],
+    dataset_csv: Annotated[Path, Parameter(help="Path to CSV file with historic data")],
+    out_file: Annotated[Path, Parameter(help="Output path for the generated PDF report")],
+    run_config: Annotated[RunConfig, Parameter(help="Model execution configuration")] = RunConfig(),
+    model_configuration_yaml: Annotated[
+        Path | None,
+        Parameter(help="Path to YAML file with model configuration"),
+    ] = None,
+):
+    """Generate a PDF report from a trained MLProject model via its ``report`` entry point."""
+    initialize_logging(run_config.debug, run_config.log_file)
+
+    geojson_path = discover_geojson(dataset_csv)
+    dataset = load_dataset_from_csv(dataset_csv, geojson_path)
+
+    configuration = None
+    if model_configuration_yaml is not None:
+        logger.info(f"Loading model configuration from {model_configuration_yaml}")
+        configuration = ModelConfiguration.model_validate(yaml.safe_load(open(model_configuration_yaml)))
+
+    logger.info(f"Loading model template from {model_path}")
+    template = ModelTemplate.from_directory_or_github_url(
+        model_path,
+        ignore_env=run_config.ignore_environment,
+        run_dir_type=run_config.run_directory_type,
+    )
+
+    with template:
+        model = template.get_model(configuration)  # type: ignore[arg-type]
+        estimator = model()
+        logger.info(f"Generating report for model artifact {model_artifact}")
+        estimator.report(dataset, out_file, model_artifact=model_artifact)
+
+    logger.info(f"Report written to {out_file}")
+
+
+def register_commands(app):
+    """Register report commands with the CLI app."""
+    app.command()(report)

--- a/chap_core/cli_endpoints/report.py
+++ b/chap_core/cli_endpoints/report.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 
 def report(
     model_path: Annotated[Path, Parameter(help="Path to an MLProject directory or GitHub URL")],
-    model_artifact: Annotated[Path, Parameter(help="Path to the pre-trained model artifact")],
     dataset_csv: Annotated[Path, Parameter(help="Path to CSV file with historic data")],
     out_file: Annotated[Path, Parameter(help="Output path for the generated PDF report")],
     run_config: Annotated[RunConfig, Parameter(help="Model execution configuration")] = RunConfig(),
@@ -27,7 +26,7 @@ def report(
         Parameter(help="Path to YAML file with model configuration"),
     ] = None,
 ):
-    """Generate a PDF report from a trained MLProject model via its ``report`` entry point."""
+    """Train an MLProject model on the supplied dataset and generate a PDF report via its ``report`` entry point."""
     initialize_logging(run_config.debug, run_config.log_file)
 
     geojson_path = discover_geojson(dataset_csv)
@@ -48,8 +47,10 @@ def report(
     with template:
         model = template.get_model(configuration)  # type: ignore[arg-type]
         estimator = model()
-        logger.info(f"Generating report for model artifact {model_artifact}")
-        estimator.report(dataset, out_file, model_artifact=model_artifact)
+        logger.info("Training model before generating report")
+        estimator.train(dataset)
+        logger.info("Generating report")
+        estimator.report(dataset, out_file)
 
     logger.info(f"Report written to {out_file}")
 

--- a/chap_core/external/model_configuration.py
+++ b/chap_core/external/model_configuration.py
@@ -15,6 +15,7 @@ class CommandConfig(BaseModel):
 class EntryPointConfig(BaseModel):
     train: CommandConfig
     predict: CommandConfig
+    report: CommandConfig | None = None
 
 
 class RunnerConfig(BaseModel, extra="forbid"):  # pydantic-specific config to forbid extra fields):

--- a/chap_core/models/external_model.py
+++ b/chap_core/models/external_model.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from chap_core.database.model_templates_and_config_tables import ModelConfiguration
 from chap_core.datatypes import HealthData, Samples
-from chap_core.exceptions import CommandLineException, ModelFailedException, NoPredictionsError
+from chap_core.exceptions import CommandLineException, InvalidModelException, ModelFailedException, NoPredictionsError
 from chap_core.external.model_configuration import ModelTemplateConfigV2
 from chap_core.geometry import Polygons
 from chap_core.models.configured_model import ConfiguredModel
@@ -303,3 +303,40 @@ class ExternalModel(ExternalModelBase):
             raise ModelFailedException(f"Error while parsing predictions: {e}") from e
 
         return d
+
+    def report(
+        self,
+        historic_data: DataSet,
+        out_file: Path,
+        model_artifact: Path | None = None,
+    ) -> None:
+        """Generate a PDF report using the model's report entry point.
+
+        If ``model_artifact`` is provided, that path is passed as the ``{model}``
+        parameter. Otherwise the in-memory model file from a prior ``train()`` call is used.
+        """
+        if self._model_information is None or self._model_information.entry_points is None:
+            raise InvalidModelException("Model has no entry points configured; cannot generate report")
+        if self._model_information.entry_points.report is None:
+            raise InvalidModelException(f"Model '{self._name}' does not define a 'report' entry point")
+
+        historic_data = self._apply_generated_features(historic_data)
+
+        historic_data_name = Path(self._working_dir) / "report_historic_data.csv"
+        adapted = self._adapt_data(historic_data.to_pandas(), frequency=self._get_frequency(historic_data))
+        adapted.to_csv(historic_data_name)
+
+        model_path_arg = str(model_artifact) if model_artifact is not None else self._model_file_name
+
+        try:
+            self._runner.report(
+                model_path_arg,
+                "report_historic_data.csv",
+                str(out_file),
+                "polygons.geojson" if self._polygons_file_name is not None else None,
+            )
+        except CommandLineException as e:
+            logger.error("Error generating report, command failed")
+            raise ModelFailedException(str(e)) from e
+
+        self._runner.teardown()

--- a/chap_core/models/external_model.py
+++ b/chap_core/models/external_model.py
@@ -304,16 +304,10 @@ class ExternalModel(ExternalModelBase):
 
         return d
 
-    def report(
-        self,
-        historic_data: DataSet,
-        out_file: Path,
-        model_artifact: Path | None = None,
-    ) -> None:
+    def report(self, historic_data: DataSet, out_file: Path) -> None:
         """Generate a PDF report using the model's report entry point.
 
-        If ``model_artifact`` is provided, that path is passed as the ``{model}``
-        parameter. Otherwise the in-memory model file from a prior ``train()`` call is used.
+        Uses the in-memory model file written by a prior ``train()`` call.
         """
         if self._model_information is None or self._model_information.entry_points is None:
             raise InvalidModelException("Model has no entry points configured; cannot generate report")
@@ -326,11 +320,9 @@ class ExternalModel(ExternalModelBase):
         adapted = self._adapt_data(historic_data.to_pandas(), frequency=self._get_frequency(historic_data))
         adapted.to_csv(historic_data_name)
 
-        model_path_arg = str(model_artifact) if model_artifact is not None else self._model_file_name
-
         try:
             self._runner.report(
-                model_path_arg,
+                self._model_file_name,
                 "report_historic_data.csv",
                 str(out_file),
                 "polygons.geojson" if self._polygons_file_name is not None else None,

--- a/chap_core/runners/mlflow_runner.py
+++ b/chap_core/runners/mlflow_runner.py
@@ -69,3 +69,29 @@ class MlFlowTrainPredictRunner(TrainPredictRunner):
             entry_point="predict",
             parameters=params,
         )
+
+    def report(self, model_file_name, historic_data, output_file, polygons_file_name=None):
+        logging.debug(f"Running report with output to {output_file}")
+        params = {
+            "historic_data": str(historic_data),
+            "model": str(model_file_name),
+            "out_file": str(output_file),
+        }
+        extra_params = {
+            "model_config": str(self.model_configuration_filename) if self.model_configuration_filename else None,
+        }
+        params.update({key: val for key, val in extra_params.items() if key in self.extra_params and val is not None})
+        try:
+            return mlflow.projects.run(
+                str(self.model_path),
+                entry_point="report",
+                parameters=params,
+            )
+        except ShellCommandException as e:
+            logger.error(
+                "Error running mlflow project, might be due to missing pyenv (See: https://github.com/pyenv/pyenv#installation)"
+            )
+            raise ModelFailedException(str(e)) from e
+        except mlflow.exceptions.ExecutionException as e:
+            logger.error("Execution of model failed for some reason. Check the logs for more information")
+            raise ModelFailedException(str(e)) from e

--- a/chap_core/runners/runner.py
+++ b/chap_core/runners/runner.py
@@ -46,5 +46,14 @@ class TrainPredictRunner(abc.ABC):
         polygons_file_name: str | None,
     ): ...
 
+    def report(
+        self,
+        model_file_name: str,
+        historic_data: str,
+        output_file: str,
+        polygons_file_name: str | None = None,
+    ):
+        raise NotImplementedError("This runner does not support report generation")
+
     def teardown(self):  # noqa: B027
         ...

--- a/docs/chap-cli/index.md
+++ b/docs/chap-cli/index.md
@@ -20,3 +20,4 @@ See the [Evaluation Workflow](evaluation-workflow.md) guide for detailed usage a
 ## Command Reference
 
 - [eval](eval-reference.md) - Full reference for the eval command with all parameters
+- [report](report-reference.md) - Generate a PDF report from a trained model

--- a/docs/chap-cli/report-reference.md
+++ b/docs/chap-cli/report-reference.md
@@ -1,0 +1,77 @@
+# report Command Reference
+
+The `report` command runs a model's optional `report` entry point to produce a PDF document describing the trained model (diagnostics, fitted-effect plots, posterior summaries, or whatever the model author chooses to emit).
+
+## Synopsis
+
+```console
+chap report <MODEL_PATH> <MODEL_ARTIFACT> <DATASET_CSV> <OUT_FILE> [OPTIONS]
+```
+
+## Description
+
+`chap report`:
+
+1. Loads the model template from a local MLProject directory or a GitHub URL.
+2. Loads historic data from a CSV file (auto-discovering the matching `.geojson` if present).
+3. Invokes the MLProject's `report` entry point with the supplied trained-model artifact and the historic data.
+4. Writes the resulting PDF to `out_file`.
+
+The model must declare a `report` entry point in its `MLproject` file. See [Additional Configuration → Report Entry Point](../external_models/additional_configuration.md#report-entry-point). Models that do not define `report` will fail with an explicit error.
+
+## Required Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `model_path` | Path to an MLProject directory or a GitHub URL pointing to one |
+| `model_artifact` | Path to a previously trained model artifact (the file `train` wrote) |
+| `dataset_csv` | Path to a CSV file with historic data in the standard Chap format |
+| `out_file` | Output path for the generated PDF report |
+
+A GeoJSON file with the same base name as `dataset_csv` is auto-discovered if present.
+
+## Run Configuration
+
+The same `--run-config.*` flags as on `chap eval` are available — most relevant here:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `--run-config.ignore-environment` | Skip automatic environment setup | false |
+| `--run-config.debug` | Enable verbose debug logging | false |
+| `--run-config.log-file` | Path to write log output | None |
+| `--run-config.run-directory-type` | Directory handling: `latest`, `timestamp`, or `use_existing` | timestamp |
+
+## Additional Options
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `--model-configuration-yaml` | Path to a YAML file with model-specific parameter values | None |
+
+If the model declares `user_options` and the `report` entry point lists `model_config` as a parameter, the YAML file is forwarded to the report script the same way it is for `train` and `predict`.
+
+## Example
+
+```console
+chap report \
+    ./my_model \
+    ./runs/my_model/latest/model \
+    ./data/vietnam.csv \
+    ./reports/vietnam_report.pdf
+```
+
+With debug logging:
+
+```console
+chap report \
+    https://github.com/dhis2-chap/my_model \
+    ./model_artifact \
+    ./data.csv \
+    ./report.pdf \
+    --run-config.debug \
+    --run-config.log-file ./report.log
+```
+
+## See Also
+
+- [Additional Configuration → Report Entry Point](../external_models/additional_configuration.md#report-entry-point) — defining the entry point in `MLproject`
+- [eval Reference](eval-reference.md) — sibling command that produces the trained-model artifact during backtesting

--- a/docs/chap-cli/report-reference.md
+++ b/docs/chap-cli/report-reference.md
@@ -1,11 +1,11 @@
 # report Command Reference
 
-The `report` command runs a model's optional `report` entry point to produce a PDF document describing the trained model (diagnostics, fitted-effect plots, posterior summaries, or whatever the model author chooses to emit).
+The `report` command trains a model on a dataset and runs the model's optional `report` entry point to produce a PDF document describing the trained model (diagnostics, fitted-effect plots, posterior summaries, or whatever the model author chooses to emit).
 
 ## Synopsis
 
 ```console
-chap report <MODEL_PATH> <MODEL_ARTIFACT> <DATASET_CSV> <OUT_FILE> [OPTIONS]
+chap report <MODEL_PATH> <DATASET_CSV> <OUT_FILE> [OPTIONS]
 ```
 
 ## Description
@@ -14,8 +14,9 @@ chap report <MODEL_PATH> <MODEL_ARTIFACT> <DATASET_CSV> <OUT_FILE> [OPTIONS]
 
 1. Loads the model template from a local MLProject directory or a GitHub URL.
 2. Loads historic data from a CSV file (auto-discovering the matching `.geojson` if present).
-3. Invokes the MLProject's `report` entry point with the supplied trained-model artifact and the historic data.
-4. Writes the resulting PDF to `out_file`.
+3. Trains the model on the dataset by invoking the MLProject's `train` entry point.
+4. Invokes the MLProject's `report` entry point with the freshly trained model and the same historic data.
+5. Writes the resulting PDF to `out_file`.
 
 The model must declare a `report` entry point in its `MLproject` file. See [Additional Configuration → Report Entry Point](../external_models/additional_configuration.md#report-entry-point). Models that do not define `report` will fail with an explicit error.
 
@@ -24,7 +25,6 @@ The model must declare a `report` entry point in its `MLproject` file. See [Addi
 | Parameter | Description |
 |-----------|-------------|
 | `model_path` | Path to an MLProject directory or a GitHub URL pointing to one |
-| `model_artifact` | Path to a previously trained model artifact (the file `train` wrote) |
 | `dataset_csv` | Path to a CSV file with historic data in the standard Chap format |
 | `out_file` | Output path for the generated PDF report |
 
@@ -54,7 +54,6 @@ If the model declares `user_options` and the `report` entry point lists `model_c
 ```console
 chap report \
     ./my_model \
-    ./runs/my_model/latest/model \
     ./data/vietnam.csv \
     ./reports/vietnam_report.pdf
 ```
@@ -64,7 +63,6 @@ With debug logging:
 ```console
 chap report \
     https://github.com/dhis2-chap/my_model \
-    ./model_artifact \
     ./data.csv \
     ./report.pdf \
     --run-config.debug \
@@ -74,4 +72,4 @@ chap report \
 ## See Also
 
 - [Additional Configuration → Report Entry Point](../external_models/additional_configuration.md#report-entry-point) — defining the entry point in `MLproject`
-- [eval Reference](eval-reference.md) — sibling command that produces the trained-model artifact during backtesting
+- [eval Reference](eval-reference.md) — sibling command for rolling-origin backtest evaluation

--- a/docs/external_models/additional_configuration.md
+++ b/docs/external_models/additional_configuration.md
@@ -79,3 +79,44 @@ See the following examples that use `user_options`:
 
 - [naive_python_model_with_mlproject_file_and_docker](https://github.com/dhis2-chap/chap-core/tree/master/external_models/naive_python_model_with_mlproject_file_and_docker)
 - [web_based_model](https://github.com/dhis2-chap/chap-core/tree/master/external_models/web_based_model)
+
+## Report Entry Point
+
+In addition to the required `train` and `predict` entry points, a model may declare an optional `report` entry point that produces a PDF document describing the trained model (diagnostics, fitted-effect plots, posterior summaries, etc.). When defined, users can invoke it via the `chap report` CLI command.
+
+### Adding a `report` entry point
+
+Add a third entry to `entry_points` in `MLproject`. The entry point receives the same `historic_data` and `model` files as `predict`, plus an `out_file` path the model must write the PDF to:
+
+```yaml
+entry_points:
+  train:
+    parameters:
+      train_data: str
+      model: str
+    command: "python train.py {train_data} {model}"
+  predict:
+    parameters:
+      historic_data: str
+      future_data: str
+      model: str
+      out_file: str
+    command: "python predict.py {model} {historic_data} {future_data} {out_file}"
+  report:
+    parameters:
+      historic_data: str
+      model: str
+      out_file: str
+    command: "python report.py {model} {historic_data} {out_file}"
+```
+
+If the model has user options, declare `model_config: str` in the `report` parameters too — it is forwarded the same way as for `train`/`predict`.
+
+### Contract
+
+- The `model` parameter is the trained-model artifact written by `train`.
+- The `historic_data` parameter is a CSV in the standard Chap format.
+- The script must write a PDF to `out_file`. Chap does not validate the contents.
+- `polygons.geojson` is not passed to `report`.
+
+Models without a `report` entry point are still valid — `chap report` will return an error message naming the model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
           - Overview: chap-cli/index.md
           
           - eval Reference: chap-cli/eval-reference.md
+          - report Reference: chap-cli/report-reference.md
 
   #- Modeling App:
   #  - '!import https://github.com/dhis2-chap/chap-frontend?branch=main&docs_dir=apps/modeling-app/docs'

--- a/tests/external/test_external_models.py
+++ b/tests/external/test_external_models.py
@@ -1,10 +1,18 @@
+from unittest.mock import Mock
+
 import pytest
 
 from chap_core import get_temp_dir
 from chap_core.assessment.prediction_evaluator import evaluate_model
 from chap_core.exceptions import InvalidModelException, ModelFailedException
+from chap_core.external.model_configuration import (
+    CommandConfig,
+    EntryPointConfig,
+    ModelTemplateConfigV2,
+)
 from chap_core.file_io.example_data_set import datasets
 from chap_core.geometry import Polygons
+from chap_core.models.external_model import ExternalModel
 from chap_core.models.utils import get_model_template_from_directory_or_github_url
 from chap_core.testing.external_model import sanity_check_external_model
 from chap_core.util import docker_available, pyenv_available, uv_available
@@ -82,3 +90,49 @@ def test_that_polygons_are_sent_to_runners_through_external_model(data_path, dat
     # inspect the commands
     polygons = Polygons.from_file(data_path / "example_polygons.geojson").data
     # dataset.set_polygons(polygons)
+
+
+def _report_model_template_config(with_report: bool) -> ModelTemplateConfigV2:
+    report = CommandConfig(command="python report.py {model} {historic_data} {out_file}") if with_report else None
+    return ModelTemplateConfigV2(
+        name="test_report_model",
+        entry_points=EntryPointConfig(
+            train=CommandConfig(command="python train.py {train_data} {model}"),
+            predict=CommandConfig(command="python predict.py {model} {historic_data} {future_data} {out_file}"),
+            report=report,
+        ),
+    )
+
+
+def test_external_model_report_invokes_runner(weekly_full_data, tmp_path):
+    runner = Mock()
+    model = ExternalModel(
+        runner=runner,
+        name="test_report_model",
+        working_dir=str(tmp_path),
+        model_information=_report_model_template_config(with_report=True),
+    )
+    out_file = tmp_path / "report.pdf"
+    model_artifact = tmp_path / "trained_model"
+
+    model.report(weekly_full_data, out_file, model_artifact=model_artifact)
+
+    runner.report.assert_called_once()
+    args, _ = runner.report.call_args
+    assert args[0] == str(model_artifact)
+    assert args[1] == "report_historic_data.csv"
+    assert args[2] == str(out_file)
+    assert (tmp_path / "report_historic_data.csv").exists()
+
+
+def test_external_model_report_without_entry_point_raises(weekly_full_data, tmp_path):
+    runner = Mock()
+    model = ExternalModel(
+        runner=runner,
+        name="test_report_model",
+        working_dir=str(tmp_path),
+        model_information=_report_model_template_config(with_report=False),
+    )
+    with pytest.raises(InvalidModelException):
+        model.report(weekly_full_data, tmp_path / "report.pdf")
+    runner.report.assert_not_called()

--- a/tests/external/test_external_models.py
+++ b/tests/external/test_external_models.py
@@ -113,13 +113,12 @@ def test_external_model_report_invokes_runner(weekly_full_data, tmp_path):
         model_information=_report_model_template_config(with_report=True),
     )
     out_file = tmp_path / "report.pdf"
-    model_artifact = tmp_path / "trained_model"
 
-    model.report(weekly_full_data, out_file, model_artifact=model_artifact)
+    model.report(weekly_full_data, out_file)
 
     runner.report.assert_called_once()
     args, _ = runner.report.call_args
-    assert args[0] == str(model_artifact)
+    assert args[0] == "model"
     assert args[1] == "report_historic_data.csv"
     assert args[2] == str(out_file)
     assert (tmp_path / "report_historic_data.csv").exists()

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 from unittest.mock import patch, MagicMock, ANY
 
-from chap_core.exceptions import CommandLineException
+from chap_core.exceptions import CommandLineException, ModelFailedException
 from chap_core.runners.command_line_runner import CommandLineRunner
 from chap_core.runners.docker_runner import DockerRunner
+from chap_core.runners.mlflow_runner import MlFlowTrainPredictRunner
 from chap_core.runners.uv_runner import UvRunner, UvTrainPredictRunner
 from chap_core.runners.renv_runner import RenvRunner, RenvTrainPredictRunner
 from chap_core.runners.conda_runner import CondaRunner, CondaTrainPredictRunner
@@ -235,6 +236,34 @@ def test_conda_runner_fails_without_env_file(tmp_path):
     runner = CondaRunner(tmp_path, "environment.yaml")
     with pytest.raises(FileNotFoundError, match="environment.yaml"):
         runner.run_command("python main.py train data.csv model.pkl")
+
+
+def test_mlflow_runner_report_invokes_report_entry_point(tmp_path):
+    runner = MlFlowTrainPredictRunner(model_path=tmp_path)
+    with patch("mlflow.projects.run") as mock_run:
+        mock_run.return_value = MagicMock()
+        runner.report(
+            model_file_name="/abs/path/to/model",
+            historic_data="historic.csv",
+            output_file="/abs/out/report.pdf",
+        )
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["entry_point"] == "report"
+        assert kwargs["parameters"] == {
+            "model": "/abs/path/to/model",
+            "historic_data": "historic.csv",
+            "out_file": "/abs/out/report.pdf",
+        }
+
+
+def test_mlflow_runner_report_wraps_execution_errors(tmp_path):
+    import mlflow.exceptions
+
+    runner = MlFlowTrainPredictRunner(model_path=tmp_path)
+    with patch("mlflow.projects.run", side_effect=mlflow.exceptions.ExecutionException("boom")):
+        with pytest.raises(ModelFailedException):
+            runner.report("model", "historic.csv", "out.pdf")
 
 
 def test_runner_selection_with_conda_env(tmp_path):

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -1,0 +1,37 @@
+"""Tests for the report CLI command."""
+
+from unittest.mock import MagicMock, patch
+
+from chap_core.cli_endpoints.report import report
+
+
+def test_report_cli_invokes_model_report(dumped_weekly_data_paths, tmp_path):
+    _, historic_path, _ = dumped_weekly_data_paths
+    out_file = tmp_path / "report.pdf"
+    model_artifact = tmp_path / "trained_model"
+    model_artifact.write_bytes(b"fake-model-bytes")
+
+    mock_estimator = MagicMock()
+    mock_template = MagicMock()
+    mock_template.__enter__.return_value = mock_template
+    mock_template.__exit__.return_value = False
+    mock_template.get_model.return_value = lambda: mock_estimator
+
+    with patch(
+        "chap_core.cli_endpoints.report.ModelTemplate.from_directory_or_github_url",
+        return_value=mock_template,
+    ) as mock_from:
+        report(
+            model_path=tmp_path / "fake_mlproject",
+            model_artifact=model_artifact,
+            dataset_csv=historic_path,
+            out_file=out_file,
+        )
+
+    mock_from.assert_called_once()
+    mock_estimator.report.assert_called_once()
+    _, kwargs = mock_estimator.report.call_args
+    assert kwargs["model_artifact"] == model_artifact
+    # positional args: (dataset, out_file)
+    args, _ = mock_estimator.report.call_args
+    assert args[1] == out_file

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -36,6 +36,5 @@ def test_report_cli_trains_then_reports(dumped_weekly_data_paths, tmp_path):
         next(c for c in mock_estimator.method_calls if c[0] == "report")
     )
     assert train_call_index < report_call_index
-    args, kwargs = mock_estimator.report.call_args
+    args, _ = mock_estimator.report.call_args
     assert args[1] == out_file
-    assert "model_artifact" not in kwargs

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -5,11 +5,9 @@ from unittest.mock import MagicMock, patch
 from chap_core.cli_endpoints.report import report
 
 
-def test_report_cli_invokes_model_report(dumped_weekly_data_paths, tmp_path):
+def test_report_cli_trains_then_reports(dumped_weekly_data_paths, tmp_path):
     _, historic_path, _ = dumped_weekly_data_paths
     out_file = tmp_path / "report.pdf"
-    model_artifact = tmp_path / "trained_model"
-    model_artifact.write_bytes(b"fake-model-bytes")
 
     mock_estimator = MagicMock()
     mock_template = MagicMock()
@@ -23,15 +21,21 @@ def test_report_cli_invokes_model_report(dumped_weekly_data_paths, tmp_path):
     ) as mock_from:
         report(
             model_path=tmp_path / "fake_mlproject",
-            model_artifact=model_artifact,
             dataset_csv=historic_path,
             out_file=out_file,
         )
 
     mock_from.assert_called_once()
+    mock_estimator.train.assert_called_once()
     mock_estimator.report.assert_called_once()
-    _, kwargs = mock_estimator.report.call_args
-    assert kwargs["model_artifact"] == model_artifact
-    # positional args: (dataset, out_file)
-    args, _ = mock_estimator.report.call_args
+    # train is called before report
+    train_call_index = mock_estimator.method_calls.index(
+        next(c for c in mock_estimator.method_calls if c[0] == "train")
+    )
+    report_call_index = mock_estimator.method_calls.index(
+        next(c for c in mock_estimator.method_calls if c[0] == "report")
+    )
+    assert train_call_index < report_call_index
+    args, kwargs = mock_estimator.report.call_args
     assert args[1] == out_file
+    assert "model_artifact" not in kwargs


### PR DESCRIPTION
## Summary

Add a `report` hook that lets MLProject-integrated models produce a PDF report about the trained model, invoked via a new `chap report` CLI command.

Initial scope:
- MLProject models only. Chapkit HTTP `/api/v1/ml/$report` is deferred to a follow-up.
- CLI-only entry point; no REST routes, no DB storage, and no automatic generation during `predict`/`backtest`.
- Security/validation (MIME checks, size limits, path traversal, etc.) deferred per the simplified design on the Jira ticket.

## Changes

- `EntryPointConfig` gains an optional `report: CommandConfig | None` field.
- `TrainPredictRunner` gets a default `report()` that raises `NotImplementedError`; `MlFlowTrainPredictRunner` implements it by invoking the MLflow `report` entry point with `{model, historic_data, out_file}`.
- `ExternalModel.report(historic_data, out_file, model_artifact=...)` writes the historic CSV and delegates to the runner. Raises `InvalidModelException` when the model has no `report` entry point.
- New `chap report` CLI command (`chap_core/cli_endpoints/report.py`) taking a pre-trained model artifact path, a historic CSV, and an output PDF path.

## Test plan

- [x] `make lint` and `make test` pass locally (692 passed).
- [x] Unit tests for `MlFlowTrainPredictRunner.report` and its error wrapping.
- [x] Unit tests for `ExternalModel.report` (happy path + missing-entry-point error), reusing the `weekly_full_data` fixture.
- [x] CLI test mocks the model template and asserts the estimator's `report` is invoked with the right arguments.
- [ ] End-to-end smoke test against a real MLProject model that defines a `report` entry point (future follow-up).

Jira: CLIM-179