### PR TITLE
fix: expose uses_chapkit on configured-models API response

### DIFF
--- a/chap_core/database/model_spec_tables.py
+++ b/chap_core/database/model_spec_tables.py
@@ -36,6 +36,7 @@ class ModelSpecRead(ModelSpecBase):
     covariates: list[FeatureType]
     target: FeatureType
     archived: bool = False
+    uses_chapkit: bool = False
 
 
 target_type = FeatureType(name="disease_cases", display_name="Disease Cases", description="Disease Cases")

--- a/tests/integration/rest_api/test_chapkit_self_registration.py
+++ b/tests/integration/rest_api/test_chapkit_self_registration.py
@@ -108,6 +108,7 @@ def test_registered_service_has_configured_model(client, register_service):
     # Default configuration uses template name as configured model name
     chapkit_models = [m for m in models if m["name"] == "test-model"]
     assert len(chapkit_models) == 1
+    assert chapkit_models[0]["usesChapkit"] is True
 
 
 def test_creates_default_config_when_no_configs(client, register_service, mock_wrapper_cls):


### PR DESCRIPTION
## Summary

- The `uses_chapkit` flag was stored on `ConfiguredModelDB` and populated during chapkit self-registration, but `ModelSpecRead` did not declare the field, so Pydantic silently stripped it before FastAPI serialized the response to `GET /v1/crud/configured-models` and `GET /v1/crud/models`.
- Add `uses_chapkit: bool = False` to `ModelSpecRead`. The existing camelCase alias generator on `DBModel` means the field is exposed as `usesChapkit` in the JSON payload, so frontend apps can branch on it.
- Extend the existing chapkit self-registration integration test to assert `usesChapkit is True` on a chapkit-registered configured model.

## Test plan

- [x] `uv run pytest tests/integration/rest_api/test_chapkit_self_registration.py` passes (14/14)
- [x] `make test` passes (694 passed, 108 skipped)
- [ ] Manual: hit `GET /v1/crud/configured-models` and confirm `usesChapkit` appears on each entry