### PR TITLE
fix: polygon/dataset sync fails using CLI when geojson id is in properties (CLIM-609)

### DIFF
--- a/chap_core/spatio_temporal_data/temporal_dataclass.py
+++ b/chap_core/spatio_temporal_data/temporal_dataclass.py
@@ -500,14 +500,12 @@ class DataSet[FeaturesT]:
         if isinstance(file_name, (str, Path)):
             path = Path(file_name).with_suffix(".geojson")
             if path.exists():
-                with open(path) as f:
-                    obj.set_polygons(FeatureCollectionModel.model_validate_json(f.read()))
+                obj.set_polygons(Polygons.from_file(path).feature_collection())
             else:
                 path = Path(file_name).with_suffix(".json")
                 if path.exists():
                     polygons = Polygons.from_file(path, id_property="NAME_1")
-                    with open(path) as f:
-                        obj.set_polygons(polygons.feature_collection())
+                    obj.set_polygons(polygons.feature_collection())
         if isinstance(file_name, (str, PurePath)):
             meta_data = DataSetMetaData(name=str(Path(file_name).stem), filename=str(file_name))
             obj.metadata = meta_data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,6 +242,40 @@ def dumped_weekly_data_paths(weekly_full_data, tmp_path):
 
 
 @pytest.fixture
+def csv_with_sibling_geojson_id_in_properties(tmp_path):
+    """CSV path whose sibling .geojson stores feature id under properties.id
+    (no top-level id). Exercises the DataSet.from_csv autodiscovery path."""
+    csv_path = tmp_path / "data.csv"
+    pd.DataFrame(
+        {
+            "time_period": ["2020-01", "2020-02", "2020-01", "2020-02"],
+            "location": ["A", "A", "B", "B"],
+            "disease_cases": [1, 2, 3, 4],
+        }
+    ).to_csv(csv_path, index=False)
+    (tmp_path / "data.geojson").write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {"id": "A"},
+                        "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
+                    },
+                    {
+                        "type": "Feature",
+                        "properties": {"id": "B"},
+                        "geometry": {"type": "Polygon", "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]},
+                    },
+                ],
+            }
+        )
+    )
+    return csv_path
+
+
+@pytest.fixture
 def request_json(data_path):
     return open(data_path / "v1_api/request.json", "r").read()
 

--- a/tests/test_temporal_dataclass.py
+++ b/tests/test_temporal_dataclass.py
@@ -48,3 +48,11 @@ def test_aggregate_to_parent(vietnam_dataset):
     )
     a = samples_with_truth.aggregate_to_parent(field_name="samples")
     print(a)
+
+
+def test_from_csv_autodiscovers_geojson_with_id_in_properties(csv_with_sibling_geojson_id_in_properties):
+    """Regression for CLIM-609: when the sibling .geojson has feature id under
+    properties.id rather than the top-level id field, DataSet.from_csv must
+    still populate feature ids so dataset locations are not filtered out."""
+    dataset = DataSet.from_csv(csv_with_sibling_geojson_id_in_properties)
+    assert set(dataset.locations()) == {"A", "B"}


### PR DESCRIPTION
## Summary

When running polygon/dataset sync via the CLI, if the feature id is stored under `properties.id` in the GeoJSON (rather than on the feature's top-level `id` field), it is not copied into the feature `id` field before aligning with the dataset. Alignment then fails to match any feature to dataset locations and all locations are filtered out.

Jira: CLIM-609