### PR TITLE
refactor: remove legacy chap evaluate-hpo CLI command

### DIFF
--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -2,16 +2,12 @@
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated
 
-import pandas as pd
-import yaml
 from cyclopts import Parameter
 
-from chap_core import get_temp_dir
 from chap_core.api_types import BackTestParams, EstimatorMode, EstimatorOptions, RunConfig
 from chap_core.assessment.evaluation import Evaluation
-from chap_core.assessment.prediction_evaluator import evaluate_model
 from chap_core.cli_endpoints._common import (
     discover_geojson,
     get_estimator,
@@ -19,171 +15,17 @@ from chap_core.cli_endpoints._common import (
     load_dataset_from_csv,
     resolve_csv_path,
 )
-from chap_core.database.model_templates_and_config_tables import ModelConfiguration
-from chap_core.datatypes import FullData
-from chap_core.exceptions import NoPredictionsError
 from chap_core.external.ExtendedPredictor import ExtendedPredictor
-from chap_core.file_io.example_data_set import DataSetType, datasets
-from chap_core.geometry import Polygons
-from chap_core.hpo.base import load_search_space_from_config
-from chap_core.hpo.hpoModel import Direction, HpoModel
-from chap_core.hpo.objective import Objective
 from chap_core.hpo.searcher import RandomSearcher
 from chap_core.log_config import initialize_logging
 from chap_core.models.model_template import ModelTemplate
 from chap_core.models.utils import CHAP_RUNS_DIR
-from chap_core.predictor import ModelType
-from chap_core.spatio_temporal_data.multi_country_dataset import MultiCountryDataSet
-from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 
 if TYPE_CHECKING:
+    from chap_core.hpo.hpoModel import HpoModel
     from chap_core.models.external_model import ExternalModel
 
 logger = logging.getLogger(__name__)
-
-
-def evaluate_hpo(
-    model_name: ModelType | str,
-    dataset_name: DataSetType | None = None,
-    dataset_country: str | None = None,
-    dataset_csv: Path | None = None,
-    polygons_json: Path | None = None,
-    polygons_id_field: str | None = "id",
-    prediction_length: int = 3,
-    n_splits: int = 7,
-    report_filename: str | None = str(get_temp_dir() / "report.pdf"),
-    ignore_environment: bool = False,
-    debug: bool = False,
-    log_file: str | None = None,
-    run_directory_type: Literal["latest", "timestamp", "use_existing"] | None = "timestamp",
-    model_configuration_yaml: str | None = None,
-    metric: str | None = "MSE",
-    direction: Direction = "minimize",
-    do_hpo: bool | None = True,
-):
-    """
-    Same as evaluate, but has three added arguments and a if check on argument do_hpo.
-    """
-    initialize_logging(debug, log_file)
-    if dataset_name is None:
-        assert dataset_csv is not None, "Must specify a dataset name or a dataset csv file"
-        logging.info(f"Loading dataset from {dataset_csv}")
-        dataset = DataSet.from_csv(dataset_csv, FullData)
-        if polygons_json is not None:
-            logging.info(f"Loading polygons from {polygons_json}")
-            polygons = Polygons.from_file(polygons_json, id_property=polygons_id_field)
-            polygons.filter_locations(dataset.locations())
-            dataset.set_polygons(polygons.data)
-    else:
-        logger.info(f"Evaluating model {model_name} on dataset {dataset_name}")
-
-        example_ds = datasets[dataset_name]
-        dataset = example_ds.load()
-
-        if isinstance(dataset, MultiCountryDataSet):
-            assert dataset_country is not None, "Must specify a country for multi country datasets"
-            assert dataset_country in dataset.countries, (
-                f"Country {dataset_country} not found in dataset. Countries: {dataset.countries}"
-            )
-            dataset = dataset[dataset_country]  # type: ignore[assignment]
-
-    model_configuration_yaml_list: list[str | None]
-    if "," in model_name:
-        model_list = model_name.split(",")
-        model_configuration_yaml_list = [None for _ in model_list]
-        if model_configuration_yaml is not None:
-            model_configuration_yaml_list = list(model_configuration_yaml.split(","))
-            assert len(model_list) == len(model_configuration_yaml_list), (
-                "Number of model configurations does not match number of models"
-            )
-    else:
-        model_list = [model_name]
-        model_configuration_yaml_list = [model_configuration_yaml]
-
-    logging.info(f"Model configuration: {model_configuration_yaml_list}")
-
-    results_dict = {}
-    for name, configuration in zip(model_list, model_configuration_yaml_list, strict=False):
-        template = ModelTemplate.from_directory_or_github_url(
-            name,
-            base_working_dir=CHAP_RUNS_DIR,
-            ignore_env=ignore_environment,
-            run_dir_type=run_directory_type,
-        )
-        logging.info(f"Model template loaded: {template}")
-        if not do_hpo:
-            model_config: ModelConfiguration | None = None
-            if configuration is not None:
-                logger.info(f"Loading model configuration from yaml file {configuration}")
-                model_config = ModelConfiguration.model_validate(yaml.safe_load(open(configuration)))
-                logger.info(f"Loaded model configuration from yaml file: {model_config}")
-
-            model = template.get_model(model_config)  # type: ignore[arg-type]
-            model = model()
-        else:
-            if configuration is not None:
-                logger.info(f"Loading model configuration from yaml file {configuration}")
-                with open(configuration, encoding="utf-8") as f:
-                    configs = yaml.safe_load(f)
-                if not isinstance(configs, dict) or not configs:
-                    raise ValueError("YAML must define a non-empty mapping of parameters")
-                logger.info(f"Loaded model base configurations from yaml file: {configs}")
-            else:
-                configs = template.model_template_config.hpo_search_space
-
-            configs = load_search_space_from_config(configs)
-            assert metric is not None, "metric must be specified for HPO"
-            # objective = Objective(template, metric, prediction_length, n_splits)
-            # now with the new Objective signature, with BackTestParams
-            backtest_params = BackTestParams(n_periods=prediction_length, n_splits=n_splits)
-            objective = Objective(template, backtest_params, metric)
-            model = HpoModel(RandomSearcher(2), objective, direction, configs)
-
-        model_info = model.model_information
-        if model_info.min_prediction_length is None or model_info.max_prediction_length is None:
-            logger.warning("Model has not specified minimum and maximum predicted length")
-        else:
-            if model_info.min_prediction_length > prediction_length:
-                raise ValueError(
-                    f"The desired prediction length of {prediction_length} is less than the model's minimum prediction length of {model_info.min_prediction_length}"
-                )
-            elif model_info.max_prediction_length < prediction_length:
-                logger.warning(
-                    f"Wrapping model to extend prediction length from {model_info.max_prediction_length} to {prediction_length}. This is done iteratively, and may worsen model performance"
-                )
-                model = ExtendedPredictor(model, prediction_length)
-
-        try:
-            results = evaluate_model(
-                estimator=model,
-                data=dataset,
-                prediction_length=prediction_length,
-                n_test_sets=n_splits,
-                report_filename=report_filename,
-            )
-        except NoPredictionsError as e:
-            logger.error(f"No predictions were made: {e}")
-            return
-        print(f"Results: {results}")
-        results_dict[name] = results
-
-    data = []
-    first_model = True
-    for key, value in results_dict.items():
-        aggregate_metric_dist = value[0]
-        row = [key, *aggregate_metric_dist.values()]
-        if first_model:
-            data.append(["Model", *list(aggregate_metric_dist.keys())])
-            first_model = False
-        data.append(row)
-    dataframe = pd.DataFrame(data)
-    assert report_filename is not None
-    csvname = Path(report_filename).with_suffix(".csv")
-
-    dataframe.to_csv(csvname, index=False, header=False)
-    logger.info(f"Evaluation complete. Results saved to {csvname}")
-
-    return results_dict
 
 
 def eval_cmd(
@@ -422,5 +264,4 @@ def eval_cmd(
 
 def register_commands(app):
     """Register evaluate commands with the CLI app."""
-    app.command()(evaluate_hpo)
     app.command(name="eval")(eval_cmd)

--- a/chap_core/hpo/README.md
+++ b/chap_core/hpo/README.md
@@ -4,4 +4,4 @@ Inside the hpo loop a Searcher object is given the whole search space through re
 
 Also inside the hpo loop an Objective object is reponsible of returning a score for each configuration. Objective is initialized with the base model specified by the user and when it's called with a configuration it calls evaluate_model (the same method evaluate calls) with the base model tuned with the given configuration.
 
-Hyperparameter optimization configurations can be passed by user through model_configuration_yaml. If no such file is given by user, data under the field hpo_configs in model's MLproject will be used. At least one of these must exist to run evaluate_hpo. 
+Hyperparameter optimization configurations can be passed by user through model_configuration_yaml. If no such file is given by user, data under the field hpo_configs in model's MLproject will be used. At least one of these must exist to run `chap eval --estimator-options.mode=hpo`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chap_core"
-version = "2.0.0.dev0"
+version = "2.0.0.dev1"
 description = "Climate Health Analysis Platform (CHAP)"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from chap_core.api import forecast
 import pytest
 from chap_core.util import docker_available
-from chap_core.cli_endpoints.evaluate import eval_cmd, evaluate_hpo
+from chap_core.cli_endpoints.evaluate import eval_cmd
 from chap_core.cli_endpoints.utils import sanity_check_model
 
 
@@ -10,16 +10,6 @@ from chap_core.cli_endpoints.utils import sanity_check_model
 def test_forecast_github_model():
     repo_url = "https://github.com/knutdrand/external_rmodel_example.git"
     results = forecast("external", "hydromet_5_filtered", 12, repo_url)
-
-
-@pytest.mark.xfail(reason="Error in use_option_values: TODO: lilu")
-def test_hpo_evaluate(data_path):
-    hpo_config_yaml = data_path / "hpo_config.yaml"
-    evaluate_hpo(
-        model_name="https://github.com/dhis2-chap/chtorch",
-        dataset_name="hydromet_5_filtered",
-        model_configuration_yaml=hpo_config_yaml,
-    )
 
 
 def test_eval_cmd(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -342,7 +342,7 @@ wheels = [
 
 [[package]]
 name = "chap-core"
-version = "2.0.0.dev0"
+version = "2.0.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -450,6 +450,7 @@ requires-dist = [
     { name = "diskcache", specifier = ">=5.6.3" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "fastdtw", marker = "extra == 'explainability'", specifier = ">=0.3.4" },
     { name = "geojson-pydantic", specifier = ">=2.1.1" },
     { name = "geopandas", specifier = ">=1.1.1" },
     { name = "geopy", specifier = ">=2.4.1" },


### PR DESCRIPTION
## Summary

- `chap evaluate-hpo` is fully superseded by `chap eval --estimator-options.mode=hpo`: both go through `get_hpo_estimator` with `RandomSearcher(2)` and load search spaces via `load_search_space_from_config`.
- Deletes the `evaluate_hpo` function and its CLI registration from `chap_core/cli_endpoints/evaluate.py`, prunes the now-unused imports, removes the accompanying xfail test, and points the HPO README at the surviving entry point.

## Test plan

- [x] `uv run ruff check chap_core/cli_endpoints/evaluate.py tests/test_cli.py` — clean
- [x] `uv run mypy chap_core/cli_endpoints/evaluate.py` — clean
- [x] `uv run chap --help` — `evaluate-hpo` no longer appears, `eval` still present
- [x] `uv run chap eval --help` — HPO guidance still documented on `--estimator-options.mode`
- [x] `uv run pytest` — full suite passes (697 passed, 108 skipped, 4 xfailed, 1 xpassed)

## Notes / follow-ups (not in this PR)

- `get_hpo_estimator` hardcodes the HPO direction to `"minimize"`. `evaluate_hpo` previously exposed a `direction` parameter; no in-repo caller used maximization, so removal is safe. If maximization is later needed for metrics like `sensitivity`, extend `EstimatorOptions` / `get_hpo_estimator` as a separate change.