### PR TITLE
docs: write minimalist-example eval output to /tmp/chap/temp

### DIFF
--- a/docs/chap-cli/minimalist-example.md
+++ b/docs/chap-cli/minimalist-example.md
@@ -10,7 +10,7 @@ Run an evaluation against the minimalist example model, using an example dataset
 chap eval \
     --model-name https://github.com/dhis2-chap/minimalist_example_uv \
     --dataset-csv https://raw.githubusercontent.com/dhis2-chap/chap-core/master/example_data/laos_subset.csv \
-    --output-file eval.nc \
+    --output-file /tmp/chap/temp/eval.nc \
     --backtest-params.n-splits 2 \
     --backtest-params.n-periods 1 \
     --plot
@@ -18,6 +18,6 @@ chap eval \
 
 ## Verification
 
-If the command completes and writes `eval.nc` and `eval.html`, your Chap installation is working: it can resolve a GitHub-hosted model, set up its environment, run a rolling-origin backtest on a remote dataset, and plot the results.
+If the command completes and writes `/tmp/chap/temp/eval.nc` and `/tmp/chap/temp/eval.html`, your Chap installation is working: it can resolve a GitHub-hosted model, set up its environment, run a rolling-origin backtest on a remote dataset, and plot the results.
 
 The next step is to integrate your own model into Chap.


### PR DESCRIPTION
## Summary

- The bash block in `docs/chap-cli/minimalist-example.md` is executed by `test_docs_bash` in `tests/test_documentation.py:59-62`. Because it used a relative `--output-file eval.nc` (and `--plot` writes a sibling `eval.html`), every test run dropped those files into the repo root.
- Point the example at `/tmp/chap/temp/`, which matches the `get_temp_dir()` convention defined in `chap_core/__init__.py:21-35`. Repo root stays clean; verification text updated to match.

## Test plan

- [x] `uv run pytest "tests/test_documentation.py::test_docs_bash[docs/chap-cli/minimalist-example.md]" -v` — passes
- [x] After the run: no `eval.nc` / `eval.html` in repo root; files present under `/tmp/chap/temp/`