### PR TITLE
fix: stop forcing DEBUG log level in REST API

### DIFF
--- a/chap_core/rest_api/v1/jobs.py
+++ b/chap_core/rest_api/v1/jobs.py
@@ -10,7 +10,7 @@ from chap_core.rest_api.celery_tasks import CeleryPool, JobDescription
 from chap_core.rest_api.celery_tasks import r as redis
 from chap_core.rest_api.data_models import FullPredictionResponse
 
-initialize_logging(True, "logs/rest_api.log")
+initialize_logging()
 logger = logging.getLogger(__name__)
 logger.info("Logging initialized")
 

--- a/chap_core/rest_api/v1/rest_api.py
+++ b/chap_core/rest_api/v1/rest_api.py
@@ -7,7 +7,7 @@ from chap_core.rest_api.v1.routers import analytics, crud, visualization
 
 from . import jobs
 
-initialize_logging(True, "logs/rest_api.log")
+initialize_logging()
 logger = logging.getLogger(__name__)
 logger.info("Logging initialized")
 

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -1,0 +1,21 @@
+import logging
+
+from chap_core.log_config import initialize_logging
+
+
+def test_initialize_logging_defaults_to_info_when_env_unset(monkeypatch):
+    monkeypatch.delenv("CHAP_DEBUG", raising=False)
+    logging.getLogger().setLevel(logging.WARNING)
+
+    initialize_logging()
+
+    assert logging.getLogger().level == logging.INFO
+
+
+def test_initialize_logging_respects_chap_debug_env(monkeypatch):
+    monkeypatch.setenv("CHAP_DEBUG", "true")
+    logging.getLogger().setLevel(logging.WARNING)
+
+    initialize_logging()
+
+    assert logging.getLogger().level == logging.DEBUG


### PR DESCRIPTION
## Summary
- `chap_core/rest_api/v1/rest_api.py` and `chap_core/rest_api/v1/jobs.py` called `initialize_logging(True, "logs/rest_api.log")` at import time, hardcoding the root logger to DEBUG. Once servicekit/httpx traffic started flowing through the `chap` container, this surfaced as a flood of `DEBUG [httpcore.http11]` lines in the logs.
- Switched both call sites to `initialize_logging()`, which picks the level from `CHAP_DEBUG` (INFO by default, DEBUG when `CHAP_DEBUG=true`).
- The second argument (`log_file`) was already dead code inside `initialize_logging` — the file-handler block is commented out — so dropping it does not change file-output behavior.
- Added `tests/test_log_config.py` covering the default-INFO and `CHAP_DEBUG=true` paths.

## Test plan
- [x] `uv run pytest tests/test_log_config.py` — new tests pass
- [x] `uv run pytest tests/ --ignore=tests/integration --ignore=tests/docker_db_flow*.py --ignore=tests/celery_flow.py` — 585 passed, no regressions
- [x] `uv run ruff check` / `ruff format --check` clean on touched files
- [x] Rebuild the stack and confirm the `chap` container no longer emits `DEBUG [httpcore.http11]` lines under normal operation
- [x] Confirm `CHAP_DEBUG=true` in the environment re-enables DEBUG output when needed