### PR TITLE
docs: fix broken chap.dhis2.org links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This is the main repository for the Chap modelling platform.
 
 ## Code documentation
 
-The main documentation for the modelling platform is located at [https://chap.dhis2.org/chap-documentation/](https://chap.dhis2.org/chap-documentation/).
+The main documentation for the modelling platform is located at [https://chap.dhis2.org/chap-modeling-platform/](https://chap.dhis2.org/chap-modeling-platform/).
 
 ## Development / contribution
 
-Information about how to contributre to the the Chap Modelling Platform: [https://github.com/orgs/dhis2-chap/projects/4](https://chap.dhis2.org/chap-documentation/contributor/).
+Information about how to contribute to the Chap Modelling Platform: [https://chap.dhis2.org/chap-modeling-platform/contributor/](https://chap.dhis2.org/chap-modeling-platform/contributor/).
 
 ## Issues/Bugs
 


### PR DESCRIPTION
## Summary

- Two README links pointing to `https://chap.dhis2.org/chap-documentation/...` now return 404. The docs site has been reorganized under `/chap-modeling-platform/`.
- Updated the main documentation link (line 15) and the contributor link (line 19) to the working paths.
- Fixed the contributor line, which was also malformed: the visible link text was `github.com/orgs/dhis2-chap/projects/4` while the href pointed at the docs. Rewrote it as a single clean link, and corrected the typos `contributre` and `the the` along the way.

## Verification

- `https://chap.dhis2.org/chap-modeling-platform/` — verified live (Getting Started page).
- `https://chap.dhis2.org/chap-modeling-platform/contributor/` — verified live (Contributor Guide).
- All other URLs and references in the README (CI badge, PyPI, Python version, `.env.example`, compose files, make targets) were checked and remain accurate.

## Test plan

- [ ] Click both updated links in the rendered README on the PR diff and confirm 200.