### PR TITLE
feat: add compose.chapkit.yml umbrella overlay (CLIM-626)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,10 @@ install: clean ## sync dependencies and install package in development mode
 	uv sync
 
 force-restart: ## tear down, rebuild, and start docker compose from scratch (WIPES VOLUMES including chap-db)
-	docker compose -f compose.yml -f compose.ewars.yml down -v && docker compose -f compose.yml -f compose.ewars.yml build --no-cache && docker compose -f compose.yml -f compose.ewars.yml up --remove-orphans
+	docker compose -f compose.yml -f compose.chapkit.yml down -v && docker compose -f compose.yml -f compose.chapkit.yml build --no-cache && docker compose -f compose.yml -f compose.chapkit.yml up --remove-orphans
 
 restart: ## soft restart docker compose (preserves volumes; rebuilds only on source changes)
-	docker compose -f compose.yml -f compose.ewars.yml down && docker compose -f compose.yml -f compose.ewars.yml up -d --build --remove-orphans && $(MAKE) chap-version
+	docker compose -f compose.yml -f compose.chapkit.yml down && docker compose -f compose.yml -f compose.chapkit.yml up -d --build --remove-orphans && $(MAKE) chap-version
 
 chap-version: ## print the chap_core version running inside the chap container
-	@docker compose -f compose.yml -f compose.ewars.yml exec -T chap python -c 'import chap_core; print(f"chap_core running in container: {chap_core.__version__}")' 2>/dev/null || echo "chap container not running"
+	@docker compose -f compose.yml -f compose.chapkit.yml exec -T chap python -c 'import chap_core; print(f"chap_core running in container: {chap_core.__version__}")' 2>/dev/null || echo "chap container not running"

--- a/README.md
+++ b/README.md
@@ -47,12 +47,23 @@ also wipes the Postgres volume, so reach for it only when you need a clean
 slate. `make chap-version` is also printed automatically at the end of
 `make restart` so version drift is visible at a glance.
 
-### Running with the chapkit EWARS overlay
+### Running with chapkit model overlays
 
-The chapkit-based EWARS model ships as an opt-in compose overlay at
-`compose.ewars.yml`. Layer it onto `compose.yml` (not `compose.ghcr.yml`
-— those two are alternatives, not stackable) to run chap-core with the
-ewars service already self-registered:
+Chapkit-based models ship as opt-in compose overlays. Layer one onto
+`compose.yml` (not `compose.ghcr.yml` — those two are alternatives, not
+stackable) to run chap-core with the chapkit services already
+self-registered.
+
+The recommended overlay is `compose.chapkit.yml`, an umbrella file that
+includes every chapkit-converted model. As more models are converted to
+chapkit, they get added here so a single `-f` flag pulls them all in:
+
+```shell
+docker compose -f compose.yml -f compose.chapkit.yml up -d
+```
+
+If you only want the EWARS service, use the single-model overlay
+`compose.ewars.yml` instead:
 
 ```shell
 docker compose -f compose.yml -f compose.ewars.yml up -d

--- a/compose.chapkit.yml
+++ b/compose.chapkit.yml
@@ -1,0 +1,10 @@
+# Umbrella overlay for all chapkit-converted model services.
+# Includes every per-model overlay so a single -f flag pulls them all in.
+# Add new chapkit-based models here as they are converted.
+# Requires Docker Compose v2.20+ for the `include` directive.
+
+include:
+  - compose.ewars.yml
+  # add more chapkit overlays here as models are converted
+  # - compose.multistep.yml
+  # - compose.chtorch.yml

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -43,6 +43,7 @@
     v1: "d666546c3975994183a6386468af217aba06b6c5"
     v2: 'main'
     v3: 'e4520a2123a3228c10947f2b25029c3f7190e320'
+    v4: 'cb4edc53ce3ed1353ae5b60a501b23095d8430fc'
   configurations:
     default:
       user_option_values:


### PR DESCRIPTION
## Summary

Adds `compose.chapkit.yml` as an umbrella Docker Compose overlay that pulls in every chapkit-converted model service via the Compose `include` directive. Addresses [CLIM-626](https://dhis2.atlassian.net/browse/CLIM-626).

- Today only `compose.ewars.yml` is included — future chapkit conversions (multistep, chtorch, etc.) append here so a single `-f` flag pulls them all in.
- `compose.ewars.yml` is kept as-is for the single-model use case.
- `Makefile` `restart`, `force-restart`, and `chap-version` targets now use the umbrella overlay.
- README documents both overlays and when to use each.

Requires Docker Compose v2.20+ for the `include` directive.

## Test plan

- [x] `docker compose -f compose.yml -f compose.chapkit.yml config` parses without errors and resolves the ewars service
- [x] `make restart` brings up chap + ewars and ewars self-registers (visible at `curl http://localhost:8000/v1/crud/models`)
- [x] `make chap-version` prints the running chap_core version
- [x] `compose.ewars.yml` still works standalone for users who want only ewars

[CLIM-626]: https://dhis2.atlassian.net/browse/CLIM-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ