### PR TITLE
fix: patch ewars_plus_api get_preds rbind for per-year lag drift (CLIM-617)

### DIFF
--- a/compose.override.yml.example
+++ b/compose.override.yml.example
@@ -15,8 +15,11 @@ services:
     restart: unless-stopped
 
   # ewars plus
+  # Built locally from external_models/ewars_plus_api_patch/ which overlays
+  # the CLIM-617 get_preds bind_rows fix on top of maquins/ewars_plus_api:Upload.
   ewars_plus:
-    image: maquins/ewars_plus_api:Upload
+    build: ./external_models/ewars_plus_api_patch
+    image: chap-core/ewars_plus_api:clim-617
     container_name: ewars_plus
     ports:
       - "3288:3288"

--- a/docs/contributor/ewars_plus_backtest_flow.md
+++ b/docs/contributor/ewars_plus_backtest_flow.md
@@ -1,0 +1,110 @@
+# `ewars_plus` backtest call flow
+
+End-to-end map of what happens when a client submits
+`POST /v1/analytics/create-backtest-with-data/` with `modelId: ewars_plus`.
+
+The diagram traces the request through five components that live in
+different processes (and three different repos):
+
+| Component | Repo | Process |
+|---|---|---|
+| chap-core API | `dhis2-chap/chap-core` | FastAPI in `chap` container |
+| Celery worker | `dhis2-chap/chap-core` | `chap-core-worker-1` container |
+| Wrapper subprocess | `dhis2-chap/ewars_plus_python_wrapper` | `python main.py predict ...` spawned per backtest window inside the worker container |
+| ewars_plus API | published only as `maquins/ewars_plus_api:Upload`; the chap patch lives in `external_models/ewars_plus_api_patch/` here | R + plumber in `ewars_plus` container |
+| Postgres | infra | `chap-core-postgres-1` container |
+
+```mermaid
+sequenceDiagram
+  actor U as Client
+  participant API as chap-core API<br/>(:8000, FastAPI)
+  participant W as Celery worker<br/>(chap-core-worker-1)
+  participant WR as wrapper subprocess<br/>(python main.py predict)
+  participant E as ewars_plus<br/>(R + plumber, :3288)
+  participant DB as Postgres
+
+  U->>API: POST /v1/analytics/create-backtest-with-data/<br/>{name, geojson, providedData, modelId, nPeriods, nSplits, stride}
+  API->>API: validate + filter rejections
+  API->>DB: persist DataSet
+  API->>W: enqueue celery task (run_backtest_from_dataset)
+  API-->>U: 200 {job_id}
+
+  W->>W: git clone wrapper @modeling_app_test<br/>(/data/runs/.../timestamped/)
+
+  loop one iteration per backtest window<br/>(nSplits, stride)
+    W->>W: build historic_data_<date>.csv<br/>+ future_data_<date>.csv
+    W->>WR: spawn subprocess "python main.py predict ..."
+
+    Note over WR,E: TRAIN — runs full lag selection + CV every window
+    WR->>E: curl --max-time 1800 POST /Ewars_run<br/>(csv + geojson + config)         [B4]
+    E->>E: for each district:<br/>Running lags → Running Lag combs → Running Cross validations<br/>(per-fold INLA fit, posterior sample, save RDS)
+    E->>E: assemble all_cv via bind_rows                                              [B2]
+    E-->>WR: 200 {} (or 500 with simpleError)
+    WR->>WR: _check_api_response → RuntimeError on JSON {error: ...}                  [B1]
+
+    Note over WR,E: PREDICT — runs twice<br/>(1st run learns lag offsets, 2nd uses adjusted historic)
+    WR->>E: curl --max-time 900 POST /Ewars_predict (future csv)                      [B4]
+    E->>E: idx.end_all = match(prospective.week, endemic_channel.week)                [B3]
+    E->>E: build prob_Exceed_mat (no longer non-conformable)
+    E-->>WR: 200
+    WR->>E: curl --max-time 120 GET /retrieve_predicted_cases                         [B4]
+    E-->>WR: JSON [{Prospective_prediction: [...]}]
+    WR->>WR: change_prediction_format_to_chap<br/>(validate shape [B1], filter to requested_periods)   [B5]
+    WR->>WR: compute per-district offsets → adjusted historic
+    WR->>E: 2nd POST /Ewars_predict + GET /retrieve_predicted_cases
+    E-->>WR: predictions JSON
+    WR->>WR: write predictions_<date>.csv (consecutive ↗ requested weeks)
+    WR-->>W: exit 0 (or RuntimeError → CommandLineException)
+
+    W->>W: read predictions CSV<br/>DataSet.from_pandas(df, Samples)<br/>← _check_consequtive enforces consecutive periods
+  end
+
+  W->>W: Evaluation.from_samples_with_truth across windows
+  W->>DB: persist BackTest + samples + metrics
+  W-->>API: SUCCESS / FAILURE
+
+  U->>API: GET /v1/jobs/{job_id}
+  API-->>U: status + backtest_id
+```
+
+## Bug-site legend
+
+These are the five places we've patched (or are patching) in the pipeline.
+Numbers refer to the `[Bn]` annotations in the diagram above.
+
+| Tag | Layer | Symptom | Fix | Status |
+|---|---|---|---|---|
+| **B1** | wrapper response handling | `AttributeError: 'str' object has no attribute 'get'` on opaque error bodies | `_check_api_response` + JSON-shape validation in `change_prediction_format_to_chap` | merged ([CLIM-614](https://dhis2.atlassian.net/browse/CLIM-614)) |
+| **B2** | R, `Lag_Model_selection_ewars_By_District_api.R` | `<simpleError in get_preds(aa): names do not match previous names>` when per-year lag selection picks differently-named columns | `dplyr::bind_rows(lapply(...))` instead of `foreach(.combine = rbind)` | chap-core PR [#315](https://github.com/dhis2-chap/chap-core/pull/315) ([CLIM-617](https://dhis2.atlassian.net/browse/CLIM-617)) |
+| **B3** | R, `DBII_predictions_Vectorized_API.R` | `<simpleError ... non-conformable arrays>` when prospective weeks fall outside the endemic-channel table | `match(prospective.week, endemic.week)` instead of `foreach(.combine = c) %do% which(...)` | chap-core PR [#315](https://github.com/dhis2-chap/chap-core/pull/315) ([CLIM-617](https://dhis2.atlassian.net/browse/CLIM-617)) |
+| **B4** | wrapper, every curl call | task hangs forever when the R server stalls (R at 0% CPU, no log progress) | `curl --max-time {1800,900,120}` per endpoint | merged ([CLIM-618](https://dhis2.atlassian.net/browse/CLIM-618)) |
+| **B5** | wrapper, `change_prediction_format_to_chap` | gappy predictions (e.g. `2024W20, W24, W26`) trigger chap-core `Periods must be consecutive` | optional `requested_periods` arg restricting output to the (year, week) tuples actually requested by `future_data` | wrapper PR [#5](https://github.com/dhis2-chap/ewars_plus_python_wrapper/pull/5) ([CLIM-617](https://dhis2.atlassian.net/browse/CLIM-617)) |
+
+## Load-bearing facts the diagram makes obvious
+
+- **One full CV runs per backtest window.** The wrapper calls `train()` at
+  the top of every `predict` invocation, and `train()` re-runs lag selection
+  + cross-validation from scratch. There is no caching layer between
+  windows; ten splits = ten × ~6 min CV.
+- **Each `predict` does two `/Ewars_predict` calls.** The first call solves
+  for the per-district lag offset, the second produces the actual forecast
+  on adjusted historic data.
+- **Three layers can fail a request**: the curl/HTTP layer, the R server,
+  and chap-core's parser. After the patches above, the failure modes are
+  all surfaced as `RuntimeError` / `ModelFailedException` with diagnosable
+  messages — no silent hangs and no opaque `AttributeError`s.
+- **Lag selection is at train time, not predict time.** `/Ewars_predict`
+  consumes the RDS files written during `/Ewars_run` and does no further
+  lag selection. Different windows can therefore pick different optimal
+  lags from each other (that is what made the per-year `LAG12 / LAG10 /
+  LAG7` collision in the original CLIM-617 failure possible).
+
+## Origin of the test data
+
+`/Users/knutdr/Downloads/EWARS.json` (the Malawi 1-district payload used
+throughout this investigation): single org-unit `A2Kgu7zMgJr`
+("Phalombe-DHO"), 114 weekly periods 2022W44 → 2025W1, four feature
+streams (`disease_cases`, `rainfall`, `mean_temperature`, `population`).
+Multi-district payloads exercise spatial pooling that is degenerate on
+n=1; the 1-district case is fine for end-to-end smoke testing of the
+pipeline but not for evaluation quality.

--- a/docs/contributor/ewars_plus_status_report.md
+++ b/docs/contributor/ewars_plus_status_report.md
@@ -1,0 +1,111 @@
+---
+title: ewars_Plus integration status report
+date: 2026-05-04
+---
+
+*Investigation period: 2026-04-23 → 2026-04-30. Stack: `chap-core` master + R model `maquins/ewars_plus_api:Upload` overlaid with the CHAP patch. Test payloads: 1-district Malawi (`~/Downloads/EWARS.json`, 114 weekly periods, single org-unit `A2Kgu7zMgJr` "Phalombe-DHO") and a synthetic 5-district variant (`EWARS_5copies_v3.json`).*
+
+---
+
+## 1. Executive summary
+
+The `ewars_plus` model now reaches a chap-core `BackTest` artefact for **about 80% of the backtest windows it is asked to compute** on the 1-district Malawi payload. Before this work, *zero* windows completed end-to-end — the very first call failed with an opaque `AttributeError`. Five distinct defects were diagnosed, reproduced with unit tests, and fixed across two repositories. One defect remains as a workaround rather than a true fix (predictions are carry-forward-imputed because the model produces sparse output), and one defect is unfixable from outside the R model itself: the R server stalls non-deterministically inside INLA on roughly one window in every 10 of a sequential backtest. With the merged `curl --max-time` change, that stall now fails fast (~30 min) with a diagnosable error rather than blocking the worker forever.
+
+**Net assessment.** The code path is now operationally usable for end-to-end smoke tests on any payload, but it is **not** ready to produce a meaningful evaluation on 1-district inputs (carry-forward bias) and is **not** ready for unattended long backtests until the INLA stall is addressed upstream. Multi-district inputs were not end-to-end-validated in this session (every attempt was time-bounded or interrupted).
+
+---
+
+## 2. Issues found and resolved
+
+### 2.1 Wrapper layer (`dhis2-chap/ewars_plus_python_wrapper`)
+
+| ID | Symptom | Root cause | Fix | PR |
+|---|---|---|---|---|
+| **B1** | `AttributeError: 'str' object has no attribute 'get'` from `change_prediction_format_to_chap` whenever the R server returned a non-list error body. | The function iterated `json_data` blindly — a dict yields its string keys, a bare-string body yields characters. | Added `_check_api_response()` that raises `RuntimeError: EWARS API error from {endpoint}: {body}` when the body is `{error: ...}`; added an `isinstance(json_data, list)` guard before iterating. | [#2](https://github.com/dhis2-chap/ewars_plus_python_wrapper/pull/2) merged (CLIM-614) |
+| **B4** | Worker hung indefinitely (1h+ at 0% CPU) when the R server stalled mid-CV. | All three curl invocations omitted `--max-time`; the wrapper's `subprocess.run(...)` blocked on the unresponsive curl. | `curl --max-time {1800,900,120}` for `/Ewars_run`, `/Ewars_predict`, `/retrieve_predicted_cases` respectively. On timeout `curl` exits 28 and the wrapper raises a clean `RuntimeError`. | [#3](https://github.com/dhis2-chap/ewars_plus_python_wrapper/pull/3) merged (CLIM-618) |
+| **B5a** | chap-core rejected predictions with `Periods must be consecutive`. | The R model only fills `predicted_cases` for a sparse subset of the requested forecast weeks (e.g. it returned `(W20, W24, W26)` when `future_data` asked for `(W19, W20, W21)`). The wrapper used `df.groupby('location').head(n_to_predict)` which took whichever populated rows happened to come first, regardless of which weeks they covered. | Added `requested_periods=[(year, week), ...]` argument to `change_prediction_format_to_chap`, populated from the `future_data` CSV. Output is restricted to that intersection, sorted ascending. | [#5](https://github.com/dhis2-chap/ewars_plus_python_wrapper/pull/5) merged |
+| **B5b** | After PR #5, wrapper crashed with `pd.concat(...): No objects to concatenate`. | `predict_wrapper` makes two `/Ewars_predict` calls per backtest window. The first is an offset-discovery probe that needs to see whichever weeks the model populated; PR #5 made it filter to `requested_periods`, which collapsed to empty when the model and the request didn't overlap. | Added `apply_period_filter=True` argument to `predict()`, pass `False` for the offset-discovery call. | [#6](https://github.com/dhis2-chap/ewars_plus_python_wrapper/pull/6) merged |
+| **B5c** | After PR #6, chap-core rejected predictions with `PeriodRange(2024W19..2024W21) != PeriodRange(2024W20..2024W20)`. | chap-core's `Evaluation.from_samples_with_truth` merges prediction and truth by exact `PeriodRange` equality. A 1-week prediction for a 3-week truth window does not satisfy the merge. | Added `align_to_future_periods()` that pads the prediction frame to one row per `(location, year, week)` tuple in `future_data`. | [#7](https://github.com/dhis2-chap/ewars_plus_python_wrapper/pull/7) merged |
+| **B5d** | After PR #7's NaN padding, chap-core rejected predictions with `Samples are not finite`. | `Samples.from_pandas` enforces `np.isfinite(samples).all()`. | Switched padding from NaN to `groupby('location').ffill().bfill()` so missing weeks inherit the nearest populated week's samples. Raises a clear `RuntimeError` if any location has zero populated rows. | [#8](https://github.com/dhis2-chap/ewars_plus_python_wrapper/pull/8) merged |
+| **Tests** | None of the helpers had unit coverage. | — | 12-test pytest module covering `change_prediction_format_to_chap` shape validation, `run_command` exit codes (including `28` for timeout), and `_check_api_response` JSON-error handling. | [#4](https://github.com/dhis2-chap/ewars_plus_python_wrapper/pull/4) **open** |
+
+### 2.2 R model layer (chap-core PR [#315](https://github.com/dhis2-chap/chap-core/pull/315), open)
+
+The R model code is shipped as an unpublished Docker image (`maquins/ewars_plus_api:Upload`). Patches are applied as a one-layer overlay defined in `external_models/ewars_plus_api_patch/`.
+
+| ID | Symptom | Root cause | Fix |
+|---|---|---|---|
+| **B2** | `<simpleError in get_preds(aa): names do not match previous names>` from `Lag_Model_selection_ewars_By_District_api.R` after CV completed. | Lag selection picks a different optimal lag per year (e.g. 2022 → `_LAG12`, 2023 → `_LAG10`, 2024 → `_LAG7`). The 39 per-fold RDS files therefore had differently-named columns; base R `rbind` via `foreach(.combine = rbind)` refused to stack them. | Replace with `dplyr::bind_rows(lapply(seq_len(nrow(all_files_Cv)), get_preds))`. Missing columns become NA; downstream code does not read the lag-suffixed columns so the extra NAs are harmless. |
+| **B3** | `<simpleError ... non-conformable arrays>` from `DBII_predictions_Vectorized_API.R` during `/Ewars_predict`. | The idiom `idx.end_all <- foreach(aa = Prospective_Data_with_inla_grp$week, .combine = c) %do% which(endemic_channel_Use$week == aa)` silently drops weeks not present in the endemic table. The threshold matrix shrank, then the elementwise comparison with the predicted-rate matrix failed. | Replace with `idx.end_all <- match(Prospective_Data_with_inla_grp$week, endemic_channel_Use$week)`. Length is preserved; unmatched weeks become NA; comparison harmlessly produces NA in those rows. |
+| **Tests** | None for the R patches. | — | Two synthetic-fixture R unit tests (`test_bind_rows_assembly.R`, `test_idx_end_match.R`) plus a docker-build smoke (`tests/test_ewars_plus_api_patch.sh`). |
+| **Docs** | The full call flow had never been written down. | — | `docs/contributor/ewars_plus_backtest_flow.md` — sequence diagram + bug-site legend. |
+
+---
+
+## 3. Issues that remain
+
+### 3.1 Non-deterministic INLA stalls (highest priority)
+
+**Symptom.** During CV inside `/Ewars_run`, the R process drops to 0% CPU and prints nothing further. After 30 min the wrapper's `curl --max-time 1800` cancels the request and the Celery task fails with `curl: (28) Operation timed out`.
+
+**Observed behaviour over three sequential 10-window backtests of the same Malawi payload:**
+
+| Run | Windows completed | Stall window |
+|---|---|---|
+| First debug-loop run | 5 | window 6 (`historic_data_2024-08-26.csv`) |
+| Second debug-loop run | 8 | window 9 (`historic_data_2024-11-18.csv`) |
+| Initial v3 5-district run (interrupted by user) | 0 (window 1, district 2 reached when stopped) | n/a |
+
+The stall position changes between runs — strong evidence this is not data-specific but an INLA-internal convergence/concurrency phenomenon. With CLIM-618 in place the worker is no longer wedged, but each stalled window still costs ~30 min of compute and produces no predictions for that fold.
+
+**What is *not* known.** Whether this reproduces on a native amd64 host (current observations are all on Mac qemu emulation), whether `inla.set.control.compute(safe = TRUE)` or other INLA tuning would help, and whether the stalls correlate with any data feature of the affected slice.
+
+**Recommended next step.** Reproduce on a native amd64 chap-core host and, if present, instrument R-side: trace which call inside the CV loop fails to return (likely `inla.posterior.sample`, `inla.posterior.sample.eval`, or one of the `apply()` calls building `preds`). Possibly tighten `num.threads` from `"1:1"` to `"1:1"` explicitly or add `control.inla = list(strategy = "laplace")`. None of this is fixable from chap-core or the wrapper.
+
+### 3.2 Sparse `predicted_cases` output (model-design, not bug)
+
+**Symptom.** The R model populates `predicted_cases` for an irregular subset of the requested forecast weeks (lag warm-up + horizon decisions). For one observed window, the model returned `predicted_cases` for `(W20, W24, W26, W27, W28)` while `future_data` requested `(W19, W20, W21)`. Without a wrapper-side filter chap-core sees the wrong weeks; with it, several requested weeks have no model prediction at all.
+
+**Current workaround (PR #8).** `align_to_future_periods` carries forward (`ffill().bfill()`) the nearest populated week's samples into the missing rows. This satisfies chap-core's three-way constraint (consecutive periods, exact-equality merge, finite samples) **but biases the evaluation**: multiple weeks share a single point estimate. Window-level metrics on such windows are not statistically meaningful.
+
+**Why this matters more on 1-district inputs.** With one district the model often produces only 1–3 populated weeks per request, so most cells are imputed. With multi-district inputs the spatial-pooling step usually produces fuller forecast horizons; that's not been validated end-to-end this session.
+
+**Recommended next step.** Investigate the R-side `Prediction distance` config and `predict_wrapper`'s offset arithmetic. If the offset is computed correctly we should be asking the R server for the precise weeks we need; the fact that we get `predicted_cases` for `(W20, W24, W26, W27, W28)` instead of contiguous `(W19, W20, W21)` suggests either a config mismatch or a bug in the R model's prediction-window selection.
+
+### 3.3 Stateful R container forces re-training per window
+
+**Symptom.** chap-core's external-model contract calls `predict` once per backtest window. The wrapper's `predict` entry point unconditionally calls `train()` first because the R server stores trained state on its own filesystem and cannot pickle it back to the wrapper.
+
+**Cost.** ~6–15 min CV per window per district. A 10-window 1-district backtest is ~60–150 min wall-time on emulation; multi-district scales linearly.
+
+**Recommended next step.** Either (a) make the R server stateless (carry the trained state in HTTP responses), (b) introduce named training sessions (`/Ewars_run?session=window-7`), or (c) have the R server return a tarball of the RDS files and the wrapper push it back on each predict. None of these are wrapper-only fixes.
+
+### 3.4 1-district payloads are not a fair evaluation surface
+
+The model was designed for multi-district spatial pooling. With n=1 the spatial component is degenerate and `predicted_cases` is sparse. The 1-district Malawi payload has been useful as a smoke test for the pipeline but should not be used to assess model quality. The synthetic 5-district variant (`EWARS_5copies_v3.json`) reached `done district:2 of 5` in window 1 before being stopped; a full 5-district run is the next obvious validation experiment but takes ≥5 hours of wall-time on emulation.
+
+### 3.5 Upstream code is unpublished
+
+The `Lag_Model_selection_ewars_By_District_api.R` and `DBII_predictions_Vectorized_API.R` files baked into `maquins/ewars_plus_api:Upload` are not in any public GitHub repository found this session. The closest relatives are `maquins/ewars_Plus` (Shiny app) and `maquins/EWARS_Plus_Server` (different code). The chap-core patch directory (`external_models/ewars_plus_api_patch/`) is therefore a permanent fork rather than a temporary patch awaiting upstream merge. Any future image bump from the upstream maintainer needs re-application of the two R patches and re-validation against the failure payloads documented in CLIM-615 / CLIM-617.
+
+---
+
+## 4. Where the deliverables live
+
+| Item | Location | State |
+|---|---|---|
+| chap-core R-patch + tests + docs | `dhis2-chap/chap-core` PR [#315](https://github.com/dhis2-chap/chap-core/pull/315) | open, mergeable |
+| Wrapper response-handling fixes | `ewars_plus_python_wrapper` PRs #2, #3, #5, #6, #7, #8 | merged into `modeling_app_test` |
+| Wrapper unit tests | `ewars_plus_python_wrapper` PR [#4](https://github.com/dhis2-chap/ewars_plus_python_wrapper/pull/4) | open |
+| Backtest call-flow doc | `chap-core/docs/contributor/ewars_plus_backtest_flow.md` (in PR #315) | committed |
+| Jira | CLIM-614 Done, CLIM-615 Done, CLIM-617 Selected for Development, CLIM-618 Selected for Development | tracked |
+
+---
+
+## 5. Recommendations, in priority order
+
+1. **Investigate the INLA stall on native amd64 hardware** before assuming it's a Mac qemu artefact. If it reproduces, instrument R-side and consider INLA tuning. This is the single biggest blocker to any unattended deployment.
+2. **Run the 5-district payload end-to-end** on a native host. Multi-district is what the model is built for; a clean 5-district success would let us retire the carry-forward workaround for that input shape.
+3. **Decide a posture on 1-district inputs**: either document them as smoke-test-only (recommended) or implement an explicit downstream warning when chap-core sees imputed predictions (the wrapper could emit a marker column the evaluator surfaces).
+4. **Land PR #315 and PR #4.** The R patches are validated; the wrapper tests guard the helpers. Both are low-risk merges and unblock the deployment story.
+5. **Address the train-per-window cost** (Issue 3.3) only after 1 and 2 are answered. Without those, a fast pipeline still produces unreliable results.

--- a/external_models/ewars_plus_api_patch/DBII_predictions_Vectorized_API.R
+++ b/external_models/ewars_plus_api_patch/DBII_predictions_Vectorized_API.R
@@ -1,0 +1,895 @@
+#DBII predictions API
+
+library(rjson)
+library(dplyr)
+library(stringr)
+library(flextable)
+library(foreach)
+library(ggplot2)
+library(leaflet)
+library(dlnm)
+library(RColorBrewer)
+library(lubridate)
+library(xts)
+library(dygraphs)
+library(quarto)
+library(khroma)
+
+
+
+
+for (DD in 1:length(all_districts_pros)){
+  
+  District_Now<-all_districts_pros[DD]
+  
+  if(District_Now%in%Districts_DBI_surve_Dat){
+    
+  
+  one_of_dist_str_pros<-paste0('(',DD,' of ',length(all_districts_pros),' districts)')
+  
+  
+  
+  Prospective_Data_Sub<-Prospective_Data |> 
+    dplyr::filter(district==District_Now)
+  
+  dist_padded<-str_pad(District_Now,side="left",width=3,pad=0)
+  shiny_obj_pth<-file.path(shiny_obj_Main_pth,paste0("District_",dist_padded))
+  shinyDBII_obj_pth<-file.path(shinyDBII_obj_Main_pth,paste0("District_",dist_padded))
+  pred_weights_pth<-file.path(pred_weights_Main_pth,paste0("District_",dist_padded))
+  
+  
+    
+  
+  get_Ojs1<-function(){
+    gc()
+    readRDS(file.path(shiny_obj_pth,"Shiny_Objs.rds"))
+    
+    
+  }
+  
+  shiny_obj1<-get_Ojs1()
+  # reporT_pAth0<-shiny_obj1[["report_pth"]]
+  # reporT_pAth<-stringr::str_replace(reporT_pAth0,'.',getwd())
+  # 
+  reporT_pAth0<-shiny_obj1[["report_pth"]]
+  reporT_pAth<-stringr::str_replace(reporT_pAth0,'.',getwd())
+  
+  ## read in var splines
+  
+  Inlagrp_Vars_pros<-readRDS(file.path(shiny_obj_pth,"Shiny_Objs.rds"))$Inlagrp_Vars
+  selected_zvalue_pros0<-readRDS(file.path(shiny_obj_pth,"Shiny_Objs.rds"))$selected_zvalue
+  Selected_out_threshold0<-as.numeric(readRDS(file.path(shiny_obj_pth,"Shiny_Objs.rds"))$zvalue_sel_Ordered[1,"Cutoff"])
+  
+  selected_zvalue_pros<-ifelse(is.na(selected_zvalue_pros0),1.2,selected_zvalue_pros0)
+  Selected_out_threshold<-ifelse(is.na(Selected_out_threshold0),0.1,Selected_out_threshold0)
+  
+  alarm_vars_pros<-readRDS(file.path(shiny_obj_pth,"Shiny_Objs.rds"))$alarm_vars
+  
+  Selected_lag_Vars_pros<-readRDS(file.path(shiny_obj_pth,"Shiny_Objs.rds"))$Selected_lag_Vars
+  
+  Computed_pred_Distance<-floor(mean(as.numeric(unlist(str_extract_all(Selected_lag_Vars_pros,"[:number:]+")))))
+  
+  
+  Inla_grp_Nsize_pros<-readRDS(file.path(shiny_obj_pth,"Shiny_Objs.rds"))$Inla_grp_Nsize
+  
+  
+  for_endemic_pros<-readRDS(file.path(all_files_Path,"Shiny_Objs_all.rds"))$all_endemic |> 
+    dplyr::filter(district==District_Now) |> 
+    dplyr::mutate(threshold_cases=mean_cases+selected_zvalue_pros*(sd_cases),
+                  threshold_rate=mean_rate+selected_zvalue_pros*(sd_rate))
+  
+  work_CV_Weight_pros<-readRDS(file.path(pred_weights_pth,"Pred_weights_meta.rds"))$work_CV_Weight
+  inla_grp_Names_pros<-readRDS(file.path(pred_weights_pth,"Pred_weights_meta.rds"))$inla_grp_Names
+  
+  last_Dat_Year<-unique(work_CV_Weight_pros$year)
+  
+  endemic_channel_Use<-for_endemic_pros |> 
+    dplyr::filter(year==last_Dat_Year)
+  
+  cat(paste0('rows for_endemic_pros ..',nrow(for_endemic_pros)),sep='\n')
+  ## get right prediction weight to load
+  
+  pred_week_Objs<-foreach(aa=1:nrow(work_CV_Weight_pros),.combine=rbind)%do%
+    data.frame(seq=aa,week=work_CV_Weight_pros$beg_week[aa]:work_CV_Weight_pros$end_week[aa]) |> 
+    dplyr::mutate(mn_pref=str_pad(seq,pad=0,side='left',width=2),
+                  pred_obj=file.path(pred_weights_pth,paste0('Pred_weights_',last_Dat_Year,'_',mn_pref,'.rds')))
+
+  
+  #vars_For_inla_grp<-str_split_fixed(Selected_lag_Vars_pros,"_",2)[,1]
+  vars_For_inla_grp<-str_remove(Selected_lag_Vars_pros,'_LAG[:number:]+')
+  
+  
+  for (vv in 1:length(vars_For_inla_grp)){
+    
+    # Inlagrp_Int_dat<-Inlagrp_Vars_pros[[vv]] |> 
+    #   dplyr::mutate(intval=str_remove_all(Interval,'[)()]|\\[|\\]'),
+    #                 int_beg=as.numeric(str_split(intval,pattern=',',n=2,simplify=T)[,1]),
+    #                 int_end=as.numeric(str_split(intval,pattern=',',n=2,simplify=T)[,2]))
+    
+    Inlagrp_Int_dat<-Inlagrp_Vars_pros[[vv]]
+    
+    grp_obj_Name_pros<-paste0('Var',vv,'_inla_grp')
+    
+    Var_grp_pref_pros<-paste0('Var',vv)
+    
+    ##find interval where the variables lie
+    
+    Vars_Find<-Prospective_Data_Sub[,vars_For_inla_grp[vv]]
+    
+    #findInterval(Vars_Find,Inlagrp_Int_dat$int_beg)
+    Size.grp<-nrow(Inlagrp_Int_dat)
+    
+    #Matrix_wgts<-matrix(NA,length(Vars_Find),Inla_grp_Nsize_pros)
+    Matrix_wgts<-matrix(NA,length(Vars_Find),Size.grp)
+    
+    
+    for(ww in 1:length(Vars_Find)){
+      int_found0<-findInterval(Vars_Find[ww],c(Inlagrp_Int_dat$int_beg))
+      int_found<-ifelse(int_found0==0,1,int_found0)
+      
+      Matrix_wgts[ww,]<-as.numeric(1:Size.grp==int_found)
+    }
+    
+    #padded_grp_N<-str_pad(1:Inla_grp_Nsize_pros,pad=0,side ='left',width =2)
+    padded_grp_N<-str_pad(1:Size.grp,pad=0,side ='left',width =2)
+
+    
+    colnames(Matrix_wgts)<-paste0(Var_grp_pref_pros,'_Inla_group_',padded_grp_N)
+    
+    assign(grp_obj_Name_pros,
+           Matrix_wgts)
+    
+  }
+  
+  
+  ## Compute the predictions here
+  
+  rw_Names_string<-paste0(inla_grp_Names_pros,collapse=',')
+  
+  names_Select_pred<-c("a","coefspat","week",inla_grp_Names_pros,"pop_offset")
+  
+  #Var1_Spline
+  
+  Objects_Cbind<-c("Prospective_Data_Sub",paste0("Var",1:length(vars_For_inla_grp),"_inla_grp"))
+  
+  Prospective_Data_with_inla_grp<-foreach(aa=1:length(Objects_Cbind),.combine =cbind)%do% get(Objects_Cbind[aa])
+  
+  Pred_NSize<-nrow(Prospective_Data_with_inla_grp)
+  
+  all_Pros_Predictions_ls<-vector("list",Pred_NSize)
+  
+  cat("",sep='\n')
+  cat("generating Predictions ..,",sep='\n')
+  
+  cov_matrix_Pred_all<-Prospective_Data_with_inla_grp|> 
+    dplyr::mutate(a=1,coefspat=1,week=1) |>
+    dplyr::select(all_of(names_Select_pred)) |> 
+    as.matrix()
+  
+  
+  ## create prediction matrix
+  
+  num_Features<-ncol(cov_matrix_Pred_all)
+  num_Pred<-nrow(cov_matrix_Pred_all)
+  
+  
+  matrix_Pred<-matrix(0,num_Pred,num_Pred*num_Features)
+  
+  
+  beg_idx<-seq(1,num_Pred*num_Features,num_Features)
+  end_idx<-seq(num_Features,num_Pred*num_Features,num_Features)
+  
+  #ii<-20
+  
+  for(ii in 1:num_Pred){
+    matrix_Pred[ii,beg_idx[ii]:end_idx[ii]]<-1
+  }
+  
+  
+  
+  
+  cov_matrix_Mult<-do.call('cbind',replicate(num_Pred,cov_matrix_Pred_all,simplify =F))*matrix_Pred
+  
+  dim(cov_matrix_Mult)
+  
+  pred_week_Objs<-foreach(aa=1:nrow(work_CV_Weight_pros),.combine=rbind)%do%
+    data.frame(seq=aa,week=work_CV_Weight_pros$beg_week[aa]:work_CV_Weight_pros$end_week[aa]) |> 
+    dplyr::mutate(mn_pref=str_pad(seq,pad=0,side='left',width=2),
+                  pred_obj=file.path(pred_weights_pth,paste0('Pred_weights_',last_Dat_Year,'_',mn_pref,'.rds')))
+  
+  get_Week_Weight_mat<-function(Pred_Week){
+    
+    pred_week_Objs_sub<-pred_week_Objs |> 
+      dplyr::filter(week==Pred_Week)
+    
+    readRDS(pred_week_Objs_sub$pred_obj)$pred_weights[Pred_Week,,]
+  }
+  
+  #Pred_Week<-26
+  
+  Size_cv_mat<-function(Pred_Week){
+    
+    pred_week_Objs_sub<-pred_week_Objs |> 
+      dplyr::filter(week==Pred_Week)
+    
+    readRDS(pred_week_Objs_sub$pred_obj)$ns_size
+  }
+  
+  #weight_Matrix_Mult_ls<-foreach(aa=Prospective_Data_with_inla_grp$week)%do% get_Week_Weight_mat(aa)
+  
+  weight_Matrix_Mult<-do.call('rbind',foreach(aa=Prospective_Data_with_inla_grp$week)%do% get_Week_Weight_mat(aa))
+  
+  All_pred_all<-exp(cov_matrix_Mult%*%weight_Matrix_Mult)
+  
+  dim(All_pred_all)
+  
+  #Size_cv_Mod<-readRDS(pred_week_Objs_sub$pred_obj)$ns_size
+  
+  #Size_cv_Mod<-do.call('cbind',foreach(aa=Prospective_Data_with_inla_grp$week)%do% Size_cv_mat(aa))
+  Size_cv_Mod<-Size_cv_mat(Prospective_Data_with_inla_grp$week[2])
+  
+  #dim(Size_cv_Mod)
+  
+
+  ypred_NB_1000_all<-foreach(aa=1:1000,.combine =cbind)%do% rnbinom(num_Pred,mu=All_pred_all[,aa],size=Size_cv_Mod[aa])
+  
+  pop_1000<-replicate(1000,Prospective_Data_with_inla_grp$population,simplify ="matrix")
+  
+  
+  ypred_NB_1000_rate_all<-(ypred_NB_1000_all/pop_1000)*1e5
+  
+  # CHAP patch (CLIM-617): the original idiom
+  #   foreach(aa = Prospective_Data_with_inla_grp$week, .combine = c) %do%
+  #     which(endemic_channel_Use$week == aa)
+  # silently drops weeks that are not in the precomputed endemic-channel table
+  # (which() returns integer(0); .combine=c skips it). idx.end_all then ends
+  # up shorter than the prospective row count, week_rate_threshold_all0
+  # inherits the shortened length, and the elementwise comparison
+  #   ypred_NB_1000_rate_all > week_rate_threshold_all
+  # crashes with "non-conformable arrays".
+  # match() preserves length: unmatched weeks become NA, the threshold cell
+  # becomes NA, and the comparison harmlessly produces NA in those rows.
+  idx.end_all <- match(Prospective_Data_with_inla_grp$week, endemic_channel_Use$week)
+
+  week_rate_threshold_all0<-endemic_channel_Use$threshold_rate[idx.end_all]
+  
+  week_rate_threshold_all<-replicate(1000,week_rate_threshold_all0,simplify ="matrix")
+  
+  prob_Exceed_mat<-ypred_NB_1000_rate_all>week_rate_threshold_all
+  dim(prob_Exceed_mat)
+  
+  prob_exceed_threshold_all<-apply(prob_Exceed_mat,1,FUN=function(x) mean(x))
+  
+  vars_pro_Base_select<-c("district","year","week",alarm_vars_pros,"Cases","population","observed_rate")
+  
+  
+  
+  all_Pros_Predictions<-Prospective_Data_with_inla_grp |> 
+    dplyr::select(all_of(vars_pro_Base_select)) |> 
+    dplyr::mutate(
+      # Cases
+      predicted_cases = apply(ypred_NB_1000_all,1,FUN=function(x) mean(x,na.rm=T)), 
+      predicted_cases_lci = apply(ypred_NB_1000_all,1,FUN=function(x) quantile(x,c(0.025),na.rm=T)), 
+      predicted_cases_uci = apply(ypred_NB_1000_all,1,FUN=function(x) quantile(x,c(0.975),na.rm=T)), 
+      # rates
+      predicted_rate = apply(ypred_NB_1000_rate_all,1,FUN=function(x) mean(x,na.rm=T)), 
+      predicted_rate_lci = apply(ypred_NB_1000_rate_all,1,FUN=function(x) quantile(x,c(0.025),na.rm=T)), 
+      predicted_rate_uci = apply(ypred_NB_1000_rate_all,1,FUN=function(x) quantile(x,c(0.975),na.rm=T)), 
+      
+      endemic_threshold=week_rate_threshold_all0,
+      outbreak=predicted_cases,
+      outbreak_rate=predicted_rate,
+      prob_exceed_threshold=prob_exceed_threshold_all,
+      alarm_threshold=Selected_out_threshold,
+      outbreak_probability=prob_exceed_threshold
+    )
+  
+  #gc()
+  
+  
+  year_pred<-unique(Prospective_Data_with_inla_grp$year)
+  first_week_Pred<-min(Prospective_Data_with_inla_grp$week)
+  last_week_Pred<-max(Prospective_Data_with_inla_grp$week)
+  last_week_Pred_Plus_PredD<-last_week_Pred+Computed_pred_Distance+2
+  Week_seQF<-max(c(last_week_Pred_Plus_PredD,54))
+  
+  alarm_thresh<-unique(all_Pros_Predictions$alarm_threshold)
+  
+  
+  # year_week_Pred<-expand.grid(week=2:52,year=year_pred:(year_pred+1)) |> 
+  #   dplyr::mutate(start_Plot=as.numeric(!(year==year_pred & week<(first_week_Pred-1)))) |> 
+  #   dplyr::filter(start_Plot==1) |> 
+  #   dplyr::mutate(week_seq=1:n(),
+  #                 week_pad=str_pad(week,side="left",pad=0,width=2),
+  #                 plot_lab=as.factor(paste0(year,'_',week_pad))) |> 
+  #   dplyr::filter(week_seq<53)
+  
+  year_week_Pred<-expand.grid(week=1:52,year=year_pred:(year_pred+1)) |> 
+    #dplyr::mutate(start_Plot=as.numeric(!(year==year_pred & week<(first_week_Pred-1)))) |> 
+    dplyr::mutate(start_Plot=1) |> 
+    dplyr::filter(start_Plot==1) |> 
+    dplyr::mutate(week_seq=1:n(),
+                  week_pad=str_pad(week,side="left",pad=0,width=2),
+                  plot_lab=as.factor(paste0(year,'_',week_pad))) |> 
+    dplyr::filter(week_seq<Week_seQF)
+  
+  
+  endemic_channel_Use_a<-endemic_channel_Use |> 
+    dplyr::select(-year)
+  
+  year_week_Pred_endmic<-year_week_Pred |> 
+    dplyr::left_join(endemic_channel_Use_a,by="week") |> 
+    dplyr::mutate(outbreak_moving=round(mean_rate,6),
+                  outbreak_moving_sd=sd_rate,
+                  outbreak_moving_limit=round(threshold_rate,6),
+                  endemic_chanel=round(threshold_rate,6)) %>% 
+    dplyr::select(district,year,week,plot_lab,week_seq,outbreak_moving,outbreak_moving_sd,outbreak_moving_limit,
+                  endemic_chanel)
+  
+  all_Pros_Predictions_Week_a<-all_Pros_Predictions |> 
+    dplyr::left_join(year_week_Pred,by=c("year","week"))
+  
+  #names(all_Pros_Predictions_Week_a)
+  
+  all_Pros_Predictions_Week<-all_Pros_Predictions_Week_a |> 
+    dplyr::select(-week_pad,-start_Plot,-week_pad,-plot_lab) |> 
+    dplyr::mutate(week_seq=week_seq+Computed_pred_Distance)
+  
+  names(all_Pros_Predictions_Week_a)
+  
+  Plot_obs_rate<-all_Pros_Predictions_Week_a |> 
+    dplyr::select(district,year,week_seq,observed_rate)
+  
+  
+  dat_eval_merge<-year_week_Pred_endmic |> 
+    dplyr::left_join(all_Pros_Predictions_Week,by=c("district","week_seq")) |> 
+    dplyr::mutate(outbreak_period=case_when(outbreak>endemic_chanel~1,
+                                            TRUE~0),
+                  alarm_signal=case_when(outbreak_probability>alarm_threshold~1,
+                                         is.na(outbreak_probability)~as.double(NA),
+                                         TRUE~0))
+  
+  
+  tem.d<-dat_eval_merge %>% mutate(lag0=dplyr::lag(alarm_signal,0),
+                                   lag1=dplyr::lag(alarm_signal,1),
+                                   lag2=dplyr::lag(alarm_signal,2),
+                                   lag3=dplyr::lag(alarm_signal,3),
+                                   lag4=dplyr::lag(alarm_signal,4)) %>% 
+    mutate(response_cat=case_when(lag0==1 & lag1==1 & lag2 %in% c(0,NA) ~1,
+                                  lag0==1 & lag1==1 & lag2==1 & lag3 %in% c(0,NA) ~1.5,
+                                  lag0==1 & lag1==1 & lag2==1  & lag3==1 ~2,
+                                  is.na(alarm_signal)~ as.double(NA),
+                                  TRUE~0.5),
+           pred_Distance=paste0("Prediction distance=",Computed_pred_Distance," Weeks"),
+           alarm_threshold=alarm_thresh)
+  
+  
+  
+  dat_lab<-data.frame(response_cat=c("No response",
+                                     "Initial response",
+                                     "Early response",
+                                     "Late/emergency response"),
+                      x=-20,y=seq(0.65,2.5,0.5))
+  
+  iridescent<-khroma::color(palette="iridescent")
+  bright<-khroma::color(palette="bright")
+  
+  
+  iridescent(10)
+  scales::show_col(iridescent(10))
+  
+  bright(7)
+  scales::show_col(bright(7))
+  
+  plot1<-ggplot(aes(x=week_seq,y=outbreak_moving_limit),data=tem.d)+
+    geom_area(aes(fill="Endemic channel"),alpha=0.4)+
+    geom_ribbon(aes(ymin=predicted_rate_lci,
+                    ymax=predicted_rate_uci,
+                    fill="Prediction\n Interval"),alpha=0.6)+
+    facet_wrap(~pred_Distance)+
+    geom_line(aes(y=outbreak,col="Confirmed cases"),linewidth=0.6)+
+    geom_point(aes(y=outbreak,col="Confirmed cases"),size=2.5,pch=15)+
+    ylab("Incidence Rate\n per 100000")+
+    theme_bw()+
+    scale_fill_manual(values =c("Endemic channel"="#90CCE3",
+                                "Prediction\n Interval"="#9C7BAF"))+
+    scale_color_manual(values =c("Confirmed cases"='red1'))+
+    scale_x_continuous(breaks=tem.d$week_seq,label=tem.d$plot_lab)+
+    theme(panel.grid.major.x =element_blank(),
+          panel.grid.minor.x =element_blank(),
+          panel.grid.major.y =element_line(linetype=2),
+          panel.grid.minor.y =element_blank(),
+          axis.line.x.top =element_blank(),
+          strip.text =element_text(size=16),
+          axis.text.x.bottom =element_text(angle =90),
+          panel.border =element_blank(),
+          axis.line.y =element_line(linetype=1,colour="grey",linewidth=0.4,lineend="butt"),
+          axis.line.x =element_line(linetype=1,colour="grey",linewidth=0.4,lineend="butt"),
+          legend.position ="top",
+          #axis.title.y =element_blank(),
+          legend.text =element_text(size=14))+
+    guides(fill=guide_legend(title =NULL),
+           color=guide_legend(title =NULL))+
+    xlab("Prediction \nYear_Week")
+  
+  tem.d$alarm_threshold<-as.numeric(tem.d$alarm_threshold)
+  
+  plot2<-ggplot()+
+    
+    geom_line(aes(x=week_seq,y=outbreak_probability,col="Outbreak probability"),linewidth=0.3,data=tem.d)+
+    geom_point(aes(x=week_seq,y=outbreak_probability,col="Outbreak probability"),size=2.5,pch=15,data=tem.d)+
+    geom_line(aes(x=week_seq,y=alarm_threshold,col="Alarm threshold"),linewidth=0.7,data=tem.d,lty=2)+
+    facet_wrap(~pred_Distance)+
+    
+    theme_bw()+
+    scale_color_manual(values =c("Outbreak probability"='dark blue',
+                                 "Alarm threshold"="forest green"))+
+    scale_x_continuous(breaks=tem.d$week_seq,label=tem.d$plot_lab)+
+    theme(panel.grid.major.x =element_blank(),
+          panel.grid.minor.x =element_blank(),
+          panel.grid.major.y =element_line(linetype=2),
+          panel.grid.minor.y =element_blank(),
+          axis.line.x.top =element_blank(),
+          strip.text =element_text(size=16),
+          axis.text.x.bottom =element_text(angle =90),
+          panel.border =element_blank(),
+          axis.line.y =element_line(linetype=1,colour="grey",linewidth =0.4,lineend="butt"),
+          axis.line.x =element_line(linetype=1,colour="grey",linewidth=0.4,lineend="butt"),
+          legend.position ="top",
+          axis.title.y =element_blank(),
+          legend.text =element_text(size=14)
+    )+
+    guides(fill=guide_legend(title =NULL),
+           color=guide_legend(title =NULL))+
+    xlab("Prediction \nYear_Week")
+  
+  # ratio_DB2<-max(c(tem.d$outbreak_moving_limit,tem.d$outbreak,
+  #                  tem.d$predicted_rate_uci),na.rm =T)/
+  #   max(c(tem.d$outbreak_probability,tem.d$alarm_threshold),na.rm =T)
+  
+  ratio_DB2<-max(c(tem.d$outbreak_moving_limit,tem.d$outbreak_rate,
+                   tem.d$predicted_rate_uci,
+                   tem.d$observed_rate),na.rm =T)/
+    max(c(tem.d$outbreak_probability,tem.d$alarm_threshold),na.rm =T)
+  
+  Plot_pros<-tem.d |> 
+    dplyr::mutate(outbreak_probability_Signal=case_when(alarm_signal==1~outbreak_probability,
+                                                        TRUE~as.numeric(NA)))
+  #names(Plot_obs_rate)
+  
+  plot3<-ggplot(aes(x=week_seq,y=outbreak_moving_limit),data=Plot_pros)+
+    geom_area(aes(fill="Endemic channel"),alpha=0.6)+
+    geom_ribbon(aes(ymin=predicted_rate_lci,ymax=predicted_rate_uci,
+                    fill="Prediction Interval"),alpha=0.5)+
+    facet_wrap(~pred_Distance)+
+    geom_line(aes(y=outbreak_rate,col="Predicted"),linewidth=0.3)+
+    geom_point(aes(y=outbreak_rate,col="Predicted"),size=2.5,pch=15)+
+    
+    geom_line(aes(y=observed_rate,col="Observed rate"),linewidth=0.7,data=Plot_obs_rate)+
+    
+    geom_line(aes(x=week_seq,y=outbreak_probability*ratio_DB2,col="Outbreak probability"),linewidth=0.5,data=Plot_pros)+
+    geom_point(aes(x=week_seq,y=outbreak_probability*ratio_DB2,col="Outbreak probability"),size=2.5,pch=15,data=Plot_pros)+
+    geom_point(aes(x=week_seq,y=outbreak_probability_Signal*ratio_DB2,col="Alarm signal"),size=2.5,pch=8,data=Plot_pros)+
+    geom_line(aes(x=week_seq,y=alarm_threshold*ratio_DB2,col="Alarm threshold"),linewidth=0.5,data=Plot_pros)+
+    theme_bw()+
+    scale_fill_manual(values=c("Endemic channel"='#90CCE3',
+                               "Prediction Interval"="#9C7BAF"))+
+    scale_color_manual(values =c("Predicted"='red1',
+                                 "Observed rate"='#46353A',
+                                 "Alarm signal"='#AA3377',
+                                 "Outbreak probability"='blue',
+                                 "Alarm threshold"="forest green"))+
+    scale_y_continuous(name = "Incidence Rate\n per 100000",sec.axis =sec_axis(~ . /ratio_DB2,name="Probability"))+
+    scale_x_continuous(breaks=Plot_pros$week_seq,label=Plot_pros$plot_lab)+
+    theme(panel.grid.major.x =element_blank(),
+          panel.grid.minor.x =element_blank(),
+          panel.grid.major.y =element_line(linetype=2),
+          panel.grid.minor.y =element_blank(),
+          axis.line.x.top =element_blank(),
+          strip.text =element_text(size=20,face='bold'),
+          strip.background =element_rect(fill="#CCBB44"),
+          axis.text.x.bottom =element_text(angle =90,size=14,vjust=0.5),
+          panel.border =element_blank(),
+          axis.line.y =element_line(linetype=1,colour="grey",linewidth=0.4,lineend="butt"),
+          axis.line.x =element_line(linetype=1,colour="grey",linewidth=0.4,lineend="butt"),
+          legend.position ="top",
+          axis.title =element_text(size=18),
+          axis.text.y =element_text(size=20,face='bold'),
+          legend.text =element_text(size=14)
+          
+    )+
+    guides(fill=guide_legend(title =NULL,nrow=2),
+           color=guide_legend(title =NULL,nrow=2))+
+    xlab("Prediction \nYear_Week")
+  
+  plot4<-ggplot(aes(x=week_seq,y=response_cat),data=Plot_pros)+geom_point(pch=21,size=2.5)+
+    geom_hline(yintercept =0.5,col="yellowgreen",linewidth=0.8)+
+    geom_hline(yintercept =1,col="orange",linewidth=0.8)+
+    geom_hline(yintercept =1.5,col="brown",linewidth=0.8)+
+    geom_hline(yintercept =2,col="red",linewidth=0.8)+
+    geom_text(aes(x=x,y=y,label=response_cat,
+                  size=8,
+                  col=response_cat),data=dat_lab,
+              show.legend =F,hjust=0,nudge_x =0.2)+
+    theme_bw()+
+    facet_wrap(~pred_Distance)+
+    
+    
+    scale_x_continuous(breaks=Plot_pros$week_seq,label=Plot_pros$plot_lab)+
+    
+    scale_color_manual(values=c("No response"='yellowgreen',
+                                "Initial response"='orange',
+                                "Early response"='brown',
+                                "Late/emergency response"='red'))+
+    
+    theme(panel.grid.minor.y =element_blank(),
+          panel.grid.major.y =element_blank(),
+          panel.grid.major.x =element_blank(),
+          panel.grid.minor.x =element_blank(),
+          panel.border =element_blank(),
+          strip.background =element_rect(fill="#CCBB44"),
+          axis.line.x =element_line(linetype=1,
+                                    colour="grey",
+                                    linewidth=0.4,
+                                    lineend="butt"),
+          axis.text.x.bottom =element_text(angle =90,size=14,vjust=0.5),
+          axis.title.y =element_blank(),
+          strip.text =element_text(size=20,face='bold'),
+          axis.text.y=element_blank(),
+          axis.ticks.y =element_blank(),
+          legend.text =element_text(size=14))+
+    coord_fixed(6,ylim =c(0.3,3),xlim = c(-20,Week_seQF))+
+    xlab("Prediction \nYear_Week")
+  
+  meta_Prediction<-tribble(~var,~Value,
+                           "Alarm indicators",paste0(alarm_vars_pros,collapse ='\n'),
+                           "Selected lags",paste0(Selected_lag_Vars_pros,collapse ='\n'),
+                           "Prediction distance",paste0(as.character(Computed_pred_Distance),' Weeks'),
+                           "Z outbreak",as.character(selected_zvalue_pros),
+                           "Alarm threshold",as.character(Selected_out_threshold),
+                           
+  )
+  
+  factor_vars<-c("Alarm indicators",
+                 "Selected lags",
+                 "Prediction distance",
+                 "Z outbreak",
+                 "Alarm threshold")
+  
+  meta_Prediction1<-meta_Prediction |> 
+    dplyr::mutate(var=factor(var,levels=factor_vars),
+                  id=1)
+  
+  meta_Prediction_wide<-meta_Prediction1 |> 
+    dplyr::group_by(id) |> 
+    tidyr::spread(var,'Value') |> 
+    dplyr::ungroup() |> 
+    dplyr::select(-id)
+  
+  border_prop<-officer::fp_border(width=0.5)
+  
+  meta_Prediction_wide |> 
+    qflextable() |> 
+    #flextable::autofit(add_w=0,add_h=10,unit='mm',part='body') |> 
+    flextable::set_caption(as_paragraph(paste('District ',District_Now)),
+                           fp_p=officer::fp_par(text.align = "left")) |> 
+    flextable::fit_to_width(max_width =12,unit='in') |> 
+    flextable::fontsize(part='header',size=14) |> 
+    flextable::fontsize(part='body',size=12) |> 
+    flextable::font(part='all',fontname ="Arial") |> 
+    flextable::padding(part="body",padding = 2) |> 
+    flextable::bold(i=1,part ="header") |> 
+    flextable::border_inner_h(border =border_prop) |> 
+    flextable::color(i=1,color="#875C7A",part="header") |> 
+    flextable::color(i=1,j=5,color="#EE6677",part="body") |> 
+    flextable::bg(i=1,bg="grey",part="header") |> 
+    #flextable::border_remove() |> 
+    flextable::align(part='all',align ="center") |> 
+    flextable::hline() |> 
+    flextable::vline() |> 
+    flextable::vline_left() |> 
+    flextable::hline_top() 
+  
+  
+  pred_Metadata_tab<-meta_Prediction1[,-3] |> 
+    qflextable() |> 
+    flextable::set_caption(as_paragraph(list_values=paste0("\n District ",District_Now,'\n \n ')),
+                           fp_p=officer::fp_par(text.align = "left")) |> 
+    
+    flextable::fit_to_width(max_width =12,unit='in') |> 
+    flextable::fontsize(part='header',size=14) |> 
+    flextable::fontsize(part='body',size=12) |> 
+    flextable::font(part='all',fontname ="Arial") |> 
+    flextable::padding(part="body",padding = 2) |> 
+    flextable::bold(j=1,part ="body") |> 
+    flextable::border_inner_h(border =border_prop) |> 
+    flextable::color(j=1,color="#875C7A",part="body") |> 
+    flextable::color(i=5,j=2,color="#EE6677",part="body") |> 
+    flextable::bg(j=1,bg="grey",part="body") |> 
+    #flextable::border_remove() |> 
+    flextable::align(part='all',align ="left") |> 
+    flextable::hline() |> 
+    flextable::vline() |> 
+    flextable::vline_left() |> 
+    flextable::hline_top() |> 
+    flextable::delete_part("header") |> 
+    flextable::hline_top()
+  
+  pred_Metadata_tab
+  
+
+  vars_Tab_out<-c('district','year.x','week.x','week_seq','plot_lab','outbreak_moving',
+                  'outbreak_moving_sd','outbreak_moving_limit','endemic_chanel',
+                  'predicted_cases','predicted_cases_lci','predicted_cases_uci',
+                  'predicted_rate','predicted_rate_lci','predicted_rate_uci',
+                  'endemic_threshold','outbreak','outbreak_rate','prob_exceed_threshold',
+                  'alarm_threshold','outbreak_probability','outbreak_period','alarm_signal')
+  
+  #paste0("'",names(Plot_pros),"'",collapse =',')
+  
+  table_Out_pros1<-Plot_pros |> 
+    dplyr::select(all_of(vars_Tab_out)) |> 
+    dplyr::rename(year=`year.x`,
+                  week=`week.x`)
+  
+  ## link with user Input data
+  
+  #names(all_Pros_Predictions_Week_a)
+  
+  select_User_vars<-c("district","week_seq",alarm_vars_pros,"Cases","population","observed_rate")
+  select_User_vars2<-c("district","year","week",alarm_vars_pros,"Cases","population","observed_rate")
+  
+  
+  all_Pros_Predictions_Week_Link<-all_Pros_Predictions_Week_a |> 
+    dplyr::select(all_of(select_User_vars))
+  
+  all_Pros_Predictions_Week_Link2<-all_Pros_Predictions_Week_a |> 
+    dplyr::select(all_of(select_User_vars2))
+  
+  ## save DB2_output
+  
+  
+  table_Out_pros2<-table_Out_pros1 |> 
+    dplyr::left_join(all_Pros_Predictions_Week_Link,by=c("district","week_seq"))
+  
+  paste0("'",names(table_Out_pros2),"'",collapse =',')
+  
+  vars_Tab_all_Out<-c('district','year','week','week_seq','plot_lab',
+                      alarm_vars_pros,'Cases','population','observed_rate',
+                      'outbreak_moving','outbreak_moving_sd','outbreak_moving_limit','endemic_chanel',
+                      'predicted_cases','predicted_cases_lci','predicted_cases_uci',
+                      'predicted_rate','predicted_rate_lci','predicted_rate_uci','endemic_threshold',
+                      'outbreak','outbreak_rate','prob_exceed_threshold','alarm_threshold',
+                      'outbreak_probability','outbreak_period','alarm_signal'
+  )
+  
+  table_Out_pros<-table_Out_pros2[,vars_Tab_all_Out]
+  
+  db2_Output<-list(Plot_pros=Plot_pros,
+                   meta_Prediction_wide=meta_Prediction_wide,
+                   meta_Prediction=meta_Prediction,
+                   table_Out_pros=table_Out_pros,
+                   Plot_obs_rate=Plot_obs_rate,
+                   ratio_DB2=ratio_DB2,
+                   dat_lab=dat_lab)
+  
+  ewars_json_Objects_pros<-list(Plot_pros=Plot_pros,
+                                alarm_vars_pros=alarm_vars_pros,
+                                select_User_vars2=select_User_vars2,
+                                all_Pros_Predictions_Week_Link=all_Pros_Predictions_Week_Link2,
+                                meta_Prediction_wide=meta_Prediction_wide,
+                                meta_Prediction=meta_Prediction,
+                                table_Out_pros=table_Out_pros,
+                                Plot_obs_rate=Plot_obs_rate,
+                                ratio_DB2=ratio_DB2,
+                                dat_lab=dat_lab)
+  
+  
+  
+  ewars_json_Objects_pros_json<-toJSON(ewars_json_Objects_pros)
+  
+  #dbII_obj_name_save<-file.path(shinyDBII_obj_pth,"Shiny_DBII_Objs.rds")
+ # saveRDS(db2_Output,dbII_obj_name_save,compress =T)
+  
+  #generate the report Document
+  
+  grob_Fun<-function(p_lot){
+    if(class(p_lot)[1]=="gg"){
+      ggplot2::ggplotGrob(p_lot)
+    }else{
+      p_lot
+    }
+  }
+  
+  plot3_Grobs<-list(grob_Fun(plot3))
+  plot4_Grobs<-list(grob_Fun(plot4))
+  
+  # For_book_pros<-list(Pred_met_data=pred_Metadata_tab,
+  #                #plot1=plot1,
+  #                #plot2=plot2,
+  #                Prediction_plot=plot3,
+  #                Response_cat=plot4,
+  #                ratio_DB2=ratio_DB2
+  #                )
+  
+  For_book_pros<-list(Pred_met_data=pred_Metadata_tab,
+                      #plot1=plot1,
+                      #plot2=plot2,
+                      Prediction_plot=plot3_Grobs,
+                      Response_cat=plot4_Grobs,
+                      ratio_DB2=ratio_DB2
+  )
+  
+  
+  path_mkDB2<-file.path(reporT_pAth,"Markdown_pros")
+  
+
+  #if(!dir.exists(report_pth)) dir.create(report_pth,recursive =T)
+  if(!dir.exists(path_mkDB2)) dir.create(path_mkDB2,recursive =T)
+  
+  file.copy("_quarto_pros.yml",path_mkDB2,overwrite =T)
+  file.rename(file.path(path_mkDB2,"_quarto_pros.yml"),file.path(path_mkDB2,"_quarto.yml"))
+
+  suppressWarnings(saveRDS(For_book_pros,file.path(reporT_pAth,"report_obj_pros.rds")))
+  write(ewars_json_Objects_pros_json,file.path(reporT_pAth,"ewars_json_Objects_prospective.json"))
+  saveRDS(ewars_json_Objects_pros,file.path(reporT_pAth,"ewars_pros_Pred_Objects.rds"))
+  
+  
+  #header_fl<-"book_header_File.qmd"
+  header_fl<-"book_header_File.txt"
+  
+  
+  heade_File<-read.csv(header_fl)
+  names(heade_File)<-"var"
+  
+  
+  
+
+  n_pred_meta<-length(For_book_pros$Pred_met_data)
+  n_Prediction_Plot<-1#length(For_book_pros$Prediction_plot)
+  n_Response_plot<-1#length(For_book_pros$Response_cat)
+  
+  
+  tribble_Meta_qmd<-tribble(~var,~type,~header_name,~N,
+                            "Pred_met_data","Table","# Prediction meta data {#meta-dat}",1,
+                            "Prediction_plot","Plot","# Prediction plot {#pred_plots}",n_Prediction_Plot,
+                            "Response_cat","Plot","# Response {#response_plot}",n_Response_plot,
+                            
+  )
+  
+  mm<-2
+  
+  for (mm in 1:nrow(tribble_Meta_qmd)){
+    
+    tribble_Meta_qmd_Sub<-tribble_Meta_qmd[mm,]
+    
+    quarto_cmd0<-tribble(~var,
+                         tribble_Meta_qmd_Sub$header_name,
+                         " ",
+                         "```{r}")
+    
+    quarto_cmd1<-tribble(~var,
+                         paste0('report_pth<-"',reporT_pAth,'"'),
+                         paste0('report_Obj<-readRDS(file.path(report_pth,"report_obj_pros.rds"))'),
+                         #paste0('Descriptive_table1<-report_Obj$Descriptive_table1'),
+                         paste0(tribble_Meta_qmd_Sub$var,'<-report_Obj$',tribble_Meta_qmd_Sub$var),
+                         "ratio_DB2<-report_Obj$ratio_DB2",
+                         "```"
+    )
+    
+    quarto_cmd2<-tribble(~var,
+                         " ",
+                         " ",
+                         "```{r}",
+                         "#| echo: false",
+                         "#| message: false",
+                         "#| warning: false",
+                         "#| comment: ' '" ,
+    )
+    
+    plot_layout_cmd<-tribble(~var,
+                             "#| layout-ncol: 2"
+    )
+    
+    plot_fig_width<-tribble(~var,
+                            "#| fig-width: 13" ,
+                            "#| out-width: 13in" ,
+    )
+    
+    # determine the output the tribble
+    
+    if(tribble_Meta_qmd_Sub$type=="Table"){
+      quarto_cmd3<-tribble(~var,
+                           tribble_Meta_qmd_Sub$var  
+      )
+    }else if(tribble_Meta_qmd_Sub$type=="Plot"){
+      
+     
+        # quarto_cmd3_0<-tribble(~var,
+        #                        tribble_Meta_qmd_Sub$var  
+        # )
+        plot_Con<-function(bb){
+          
+          var_Plot0<-paste0(tribble_Meta_qmd_Sub$var,"[[",bb,"]]")
+          
+          tribble(~var,
+                  paste0("if(class(",var_Plot0,")[1]=='gtable'){"),
+                  paste0("plot(",var_Plot0,")"),
+                  "}else{",
+                  var_Plot0,
+                  "}"
+          )
+        }
+        quarto_cmd3_0<-foreach(aa=1:tribble_Meta_qmd_Sub$N,.combine =rbind)%do% plot_Con(aa)
+        quarto_cmd3<-rbind(plot_fig_width,quarto_cmd3_0)
+     
+    }
+    quarto_Last<-tribble(~var,
+                         "```")
+    
+    unlink(file.path(path_mkDB2,paste0( tribble_Meta_qmd_Sub$var,'.qmd')))
+    
+    cat(c(quarto_cmd0$var,
+          heade_File$var,
+          quarto_cmd1$var,
+          quarto_cmd2$var,
+          quarto_cmd3$var,
+          quarto_Last$var),
+        file =file.path(path_mkDB2,paste0( tribble_Meta_qmd_Sub$var,'.qmd')),
+        sep="\n")
+    
+    
+    
+    
+  }
+  # organize the report into section
+  
+  tribble_Sections_pros<-tribble(~var,~type,~header_name,~N,
+                            "index","text",paste0("# Prospective prediction district ",District_Now," {.unnumbered}"),1,
+                            "Meta_data","text","# Prediction meta data {.unnumbered}",1,
+                            "Prediction_plots","text","# Prediction plots  {.unnumbered}",1,
+                            "Respose_category","text","# Response category{.unnumbered}",1,
+                            
+  )
+  
+  
+  for (ss in 1:nrow(tribble_Sections_pros)){
+    
+    tribble_Sections_Sub<-tribble_Sections_pros[ss,]
+    
+    quarto_cmd0<-tribble(~var,
+                         tribble_Sections_Sub$header_name,
+                         " ")
+    cat(quarto_cmd0$var,
+        file =file.path(path_mkDB2,paste0( tribble_Sections_Sub$var,'.qmd')),
+        sep="\n")
+    
+  }
+  
+  qmd_order<-c("index",
+               "Meta_data",
+               "Pred_met_data",
+               "Prediction_plots",
+               "Prediction_plot",
+               "Respose_category",
+               "Respose_cat"
+  )
+  
+  cat(paste0('- ',qmd_order,'.qmd',sep='\n'))
+  
+  
+  #?quarto_render
+  if(generate_DBII_report_html==1){
+    
+  quarto_render(input=path_mkDB2,as_job=F)
+    
+  }
+  
+  }else{
+    Message_pred<-paste0("Please generate prediction weights for district ..",District_Now," in DBI")
+    cat(Message_pred,sep='\n')
+  }
+  
+  
+}
+

--- a/external_models/ewars_plus_api_patch/Dockerfile
+++ b/external_models/ewars_plus_api_patch/Dockerfile
@@ -5,6 +5,7 @@ FROM maquins/ewars_plus_api:Upload
 # per-year frames with different _LAG{N} column names can be stacked.
 # See: https://dhis2.atlassian.net/browse/CLIM-617
 COPY --chown=app:app Lag_Model_selection_ewars_By_District_api.R /home/app/Lag_Model_selection_ewars_By_District_api.R
+COPY --chown=app:app DBII_predictions_Vectorized_API.R /home/app/DBII_predictions_Vectorized_API.R
 COPY --chown=app:app tests /home/app/tests
 
 LABEL org.opencontainers.image.source="https://github.com/dhis2-chap/chap-core" \

--- a/external_models/ewars_plus_api_patch/Dockerfile
+++ b/external_models/ewars_plus_api_patch/Dockerfile
@@ -1,0 +1,11 @@
+FROM maquins/ewars_plus_api:Upload
+
+# CHAP patch (CLIM-617): replace foreach(.combine = rbind) at the CV-assembly
+# step in Lag_Model_selection_ewars_By_District_api.R with dplyr::bind_rows so
+# per-year frames with different _LAG{N} column names can be stacked.
+# See: https://dhis2.atlassian.net/browse/CLIM-617
+COPY --chown=app:app Lag_Model_selection_ewars_By_District_api.R /home/app/Lag_Model_selection_ewars_By_District_api.R
+
+LABEL org.opencontainers.image.source="https://github.com/dhis2-chap/chap-core" \
+      org.opencontainers.image.description="ewars_plus_api with CLIM-617 get_preds bind_rows fix on top of maquins/ewars_plus_api:Upload" \
+      org.opencontainers.image.base.name="docker.io/maquins/ewars_plus_api:Upload"

--- a/external_models/ewars_plus_api_patch/Dockerfile
+++ b/external_models/ewars_plus_api_patch/Dockerfile
@@ -5,6 +5,7 @@ FROM maquins/ewars_plus_api:Upload
 # per-year frames with different _LAG{N} column names can be stacked.
 # See: https://dhis2.atlassian.net/browse/CLIM-617
 COPY --chown=app:app Lag_Model_selection_ewars_By_District_api.R /home/app/Lag_Model_selection_ewars_By_District_api.R
+COPY --chown=app:app tests /home/app/tests
 
 LABEL org.opencontainers.image.source="https://github.com/dhis2-chap/chap-core" \
       org.opencontainers.image.description="ewars_plus_api with CLIM-617 get_preds bind_rows fix on top of maquins/ewars_plus_api:Upload" \

--- a/external_models/ewars_plus_api_patch/Lag_Model_selection_ewars_By_District_api.R
+++ b/external_models/ewars_plus_api_patch/Lag_Model_selection_ewars_By_District_api.R
@@ -1,0 +1,2077 @@
+
+
+
+base_vars<-c("district","year","week")
+boundary_file<-pp
+alarm_vars<-alarm_variables
+
+population<-population_var
+pop.var.dat<-population_var
+alarm_indicators<-alarm_variables
+alarm_vars<-alarm_indicators
+other_alarm_indicators<-other_alarm_variables
+number_of_cases<-number_of_cases_var
+new_model_Year_validation<-end.year
+nlag<-nlag
+
+covar_to_Plot<-c(number_of_cases,pop.var.dat,alarm_indicators)
+names_cov_Plot<-c("Cases","Population",alarm_indicators)
+
+sel_var_endemic<-c(base_vars,number_of_cases,population)
+#cat(names_cov_Plot,sep=' \n')
+#stop("helo")
+
+covar_to_Plot<-c(number_of_cases,pop.var.dat,alarm_indicators)
+
+##Compute endemic Channel
+
+years_dat<-sort(unique(data_augmented0$year))
+
+year_ranges<-range(years_dat)
+date_Beg<-as.Date(paste0(year_ranges[1],'-01-01'))
+date_end<-as.Date(paste0(year_ranges[2],'-12-31'))
+
+
+beg.year<-year_ranges[1]
+end.year<-year_ranges[2]
+
+
+dates_year_Week<-data.frame(date=seq.Date(date_Beg,date_end,by="week")) |> 
+  dplyr::mutate(year=year(date),
+                week=week(date))
+#new_model_Year_validation
+
+get_endemic<-function(Dat_end,Year){
+  
+  Cases_90_pctn<-quantile(Dat_end$Cases,0.85,na.rm=T)
+  
+  Dat_end %>% 
+    dplyr::mutate(Cases=case_when(Cases>=Cases_90_pctn~NA,
+                                  TRUE~Cases)) |> 
+    dplyr::filter(!year==Year & !is.na(Cases) ) %>% 
+    #dplyr::filter(year<new_model_Year_validation ) %>% 
+    dplyr::mutate(rate=(Cases/Pop)*1e5) %>% 
+    dplyr::group_by(district,week) %>% 
+    dplyr::summarise(.groups="drop",
+                     mean_cases=mean(Cases,na.rm =T),
+                     mean_rate=mean(rate,na.rm =T),
+                     sd_cases=sd(Cases,na.rm =T),
+                     sd_rate=sd(rate,na.rm =T)) %>% 
+    dplyr::mutate(year=Year) %>% 
+    dplyr::select(district,year,week,mean_cases,sd_cases,mean_rate,sd_rate)
+}
+
+all_endemic<-foreach(Yr=years_dat,.combine =rbind)%do% get_endemic(data_augmented0,Yr)
+
+data_augmented<-data_augmented0 |> 
+  dplyr::left_join(all_endemic,by=c("district","year","week")) |> 
+  dplyr::left_join(dates_year_Week,by=c("year","week"))
+
+
+Dist_IDS<-boundary_file@data |> 
+  dplyr::mutate(district=as.numeric(district),
+                ID_spat=1:n(),
+                ID_spat1=1:n(),
+                ID_spat2=1:n()) |> 
+  dplyr::select(district,ID_spat,ID_spat1,ID_spat2)
+
+
+
+Year_IDS<-data.frame(year=sort(unique(data_augmented$year))) |> 
+  dplyr::mutate(ID_year=(1:n()),
+                ID_year1=(1:n()),
+                ID_year2=(1:n()))
+
+summary_combs<-data.frame(beg=seq(1,12,4),
+                          end=seq(4,12,4))
+
+get_lag_Summaries<-function(pp,Lag_Matrix,lag_Pref){
+  
+  col_idx<-summary_combs[pp,1]:summary_combs[pp,2]
+  lag_beg<-summary_combs[pp,1]
+  lag_end<-summary_combs[pp,2]
+  Lag_name<-paste0(lag_Pref,lag_beg,'_',lag_end)
+  
+  if(lag_Pref=="meantemperature"){
+    var.sum<-apply(Lag_Matrix[,col_idx],1,FUN=function(x) mean(x,na.rm=T))
+  }else{
+    var.sum<-apply(Lag_Matrix[,col_idx],1,FUN=function(x) sum(x,na.rm=T))
+    
+  }
+  var_sum<-data.frame(var=var.sum)
+  names(var_sum)<-Lag_name
+  var_sum
+}
+
+
+
+vars_Base<-c("district","year","week","date","Cases",
+             "mean_cases","sd_cases",
+             "mean_rate","sd_rate",
+             "Pop","log_Pop")
+
+
+Min_lag<-4
+
+Max_lag<-12
+
+
+Get_alarm_vars<-function(pp){
+  
+  dat_Lg<-data_augmented |> 
+    #dplyr::filter(data_augmented[[alarm_vars[pp]]]==0) |> 
+    dplyr::rename(alarm_var=alarm_vars[pp]) |> 
+    dplyr::select(district,year,week,alarm_var)
+  names(dat_Lg)
+  
+  Var_lags<-tsModel::Lag(dat_Lg$alarm_var, group = dat_Lg$district, k = Min_lag:Max_lag) |> 
+    data.frame()
+  
+  names(Var_lags)<-paste0(alarm_vars[pp],"_LAG",Min_lag:Max_lag)
+  
+  ## compute Lags Summaries
+  
+  #Var_lag_summaries<-foreach(aa=1:nrow(summary_combs),.combine =cbind)%do% get_lag_Summaries(aa,Var_lags,paste0(alarm_vars[pp],"_LAG"))
+  
+  if(pp==1){
+    #all_Lags<-cbind(data_augmented[,vars_Base],Var_lags,Var_lag_summaries)
+    all_Lags<-cbind(data_augmented[,vars_Base],Var_lags)
+    
+    
+  }else{
+    #all_Lags<-cbind(Var_lags,Var_lag_summaries)
+    all_Lags<-Var_lags
+    
+    
+  }
+  all_Lags
+  
+}
+
+cat(alarm_vars,sep='\n')
+
+Model_data_lags<-foreach(aa=1:length(alarm_vars),.combine =cbind)%do% Get_alarm_vars(aa)
+
+## Compute by district here
+
+Dat_mod<-Model_data_lags |> 
+  #data.frame() |> 
+  dplyr::left_join(Dist_IDS,by="district") |> 
+  dplyr::left_join(Year_IDS,by="year")
+
+
+#cat(names(Dat_mod),sep='\n')
+
+
+alarm_vars<-alarm_indicators
+
+
+## run by District
+
+all_districts<-unique(data_augmented$district)
+#all_districts<-unique(data_augmented$district)[1:2]
+
+
+#DD<-1
+
+DIC1_run<-T
+DIC2_run<-T
+CV_run<-T
+Weight_save<-T
+Run_sel_Z<-T
+Run_Dlnm<-F
+
+
+#out_Path<-file.path(getwd(),'Outputs')
+out_Path<-out_path
+
+
+all_files_Path<-file.path(out_Path,"For_Shiny","All_district")
+
+
+
+fold_CR1<-file.path(out_Path,"For_Shiny","All_district")
+if(!dir.exists(fold_CR1)){
+  dir.create(fold_CR1,recursive =T)
+}
+
+
+# inla_Strategy<-"simplified.laplace"
+# inla_Strategy<-'adaptive'
+
+#inla_Strategy<-'adaptive'
+#inla_Strategy<-'auto'
+#inla_Strategy<-"laplace"
+
+inla_Strategy<-"simplified.laplace"
+Threads_Inla<-"2:1"
+
+control_VB=list(enable=T,
+                strategy="mean",
+                verbose=T,
+                iter.max=28,
+                emergency=50)
+
+Time_one_Dist<-system.time({
+  
+  
+  
+  for (DD in 1:length(all_districts)){
+    
+    District_Now<-all_districts[DD]
+    
+    one_of_dist_str<-paste0('(',DD,' of ',length(all_districts),' districts)')
+    
+    
+    
+    #pp<-1
+    #names(data_augmented)
+    
+    Dat_mod_sub<-Dat_mod |> 
+      dplyr::filter(district==District_Now)
+    
+    Model_data_lags_sub<-Model_data_lags |> 
+      dplyr::filter(district==District_Now)
+    
+    
+    get_Model<-function(form_mod,mod_Family,Dat_m) {
+      
+      mod<-inla(form_mod,
+                offset =log_Pop,
+                data=Dat_m,
+                family =mod_Family,
+                #control.inla = list(strategy = 'adaptive'), 
+                control.inla = list(strategy = inla_Strategy,
+                                    parallel.linesearch=F,
+                                    improved.simplified.laplace=T,
+                                    control.vb=control_VB), 
+                control.compute = list(dic = TRUE, 
+                                       config = T, 
+                                       cpo = TRUE, 
+                                       waic=T,
+                                       #po=T,
+                                       return.marginals = F,
+                                       smtp="taucs"
+                ),
+                num.threads=Threads_Inla,
+                control.predictor = list(link = 1, compute = F), 
+                verbose = F)
+      mod
+    }
+    
+    form_baseline<- Cases ~ 1 +
+      f(ID_spat,model='iid',replicate=ID_year)+
+      f(week,model='rw1',cyclic=T,scale.model =T)
+    
+    
+    #Dat_mod_sub_c<<-Dat_mod_sub
+    
+    # list_out_mod<<-list(form_baseline=form_baseline,
+    #                    Dat_mod_sub=Dat_mod_sub,
+    #                    get_Model=get_Model)
+    
+    baseline_model<-get_Model(form_baseline,"nbinomial",Dat_mod_sub)
+    
+    summary(baseline_model)
+    
+    baseline_model$summary.hyperpar$mean
+    
+    
+    ## compare different 
+    
+    theta_beg<-baseline_model$internal.summary.hyperpar
+    
+    
+    Sel_Vars<-function(form_mod,mod_Family,mod.Data,Theta_Start,start_again) {
+      
+      mod<-inla(form_mod,
+                offset =log_Pop,
+                data=mod.Data,
+                family =mod_Family,
+                control.inla = list(strategy = inla_Strategy,
+                                    parallel.linesearch=F,
+                                    improved.simplified.laplace=T,
+                                    control.vb=control_VB), 
+                control.compute = list(dic = TRUE, 
+                                       config = T, 
+                                       cpo = TRUE, 
+                                       waic=T,
+                                       #po=T,
+                                       return.marginals = F,
+                                       smtp="taucs"
+                ),
+                num.threads=Threads_Inla,
+                control.mode = list(theta = Theta_Start, restart = start_again),
+                control.predictor = list(link = 1, compute = F), 
+                verbose = F)
+      mod
+    }
+    
+    
+    id_lag<-grep("LAG",names(Model_data_lags_sub),ignore.case =T)
+    
+    lag.vars<-names(Model_data_lags_sub)[id_lag]
+    
+    
+    folders_Create<-c("Lag_selection","Lag_Comb_selection","Weekly_crossValidations","For_Shiny","For_Shiny_DBII","Pred_Weights_objs","Prediction_weights","z_value_selection","Report_objs")
+    folder_Vars<-c("path_dic1","path_dic2","cv_path","shiny_obj_pth","shinyDBII_obj_pth","pred_weights_objs_pth","pred_weights_pth","z_value_sel_pth","report_pth")
+    
+    #ff<-1
+    
+    for (ff in 1:length(folders_Create)){
+      
+      dist_padded<-stringr::str_pad(District_Now,width =3,pad=0,side='left')
+      
+      dist_Folder<-paste0("District_",dist_padded)
+      
+      dir_Now<-file.path(out_Path,folders_Create[ff],dist_Folder)
+      
+      if(!dir.exists(dir_Now)){
+        dir.create(dir_Now,recursive =T)
+      }
+      
+      assign(folder_Vars[ff],dir_Now)
+      
+    }
+    
+    
+    #unlink(list.files(path_dic1,full.names =T))
+    
+    Run_DIC1<-DIC1_run
+    
+    if(Run_DIC1){
+      time_dic1<-system.time({
+        #compare_DIC<-function(ss){
+        #Header_progress<-paste0("Running lags district:",District_Now,'br()',one_of_dist_str,'br()'
+        
+        cat("Running lags ...",sep='\n')
+        
+        for(ss in 1 :length(lag.vars)){
+          gc()
+         # cat(ss,sep='\n')
+          cat(paste0(ss," "),sep=' ')
+          
+          form_str <- as.formula(paste("Cases ~ 1 +f(ID_spat,model='iid',replicate=ID_year)+f(week,model='rw1',cyclic=T,scale.model =T)+",
+                                       lag.vars[ss],collapse =""))
+          
+          model_Out<-Sel_Vars(form_str,"nbinomial",Dat_mod_sub,Theta_Start=theta_beg$mean,T)
+          summary(model_Out)
+          
+          Dic_tab<-data.frame(var=lag.vars[ss],DIC=model_Out$dic$dic,
+                              coeff=model_Out$summary.fixed$mean[2],
+                              low=model_Out$summary.fixed$`0.025quant`[2],
+                              high=model_Out$summary.fixed$`0.975quant`[2],
+                              logcpo=-mean( log(model_Out$cpo$cpo) ,na.rm=T)
+          )
+          ob_nam<-paste0("Lag_Dic_tab",ss)
+          saveRDS(Dic_tab,file.path(path_dic1,ob_nam))
+          one_of_str<-paste0('(',ss,' of ',length(lag.vars),')')
+          mess_lag<-paste0(lag.vars[ss],' ',one_of_str)
+          #p_progress$set(value = ss, detail = mess_lag)
+        }
+        #p_progress$close()
+      })
+      time_dic1[3]/60
+    }
+    
+    #time_dic1<-system.time({
+    
+    #})
+    
+    
+    
+    #Lag_dic_comp<-foreach(aa=1:length(lag.vars),.combine =rbind)%do% compare_DIC(aa)
+    Lag_dic_comp<-foreach(aa=1:length(lag.vars),.combine =rbind)%do% readRDS(file.path(path_dic1,paste0("Lag_Dic_tab",aa)))
+    
+    
+    Var_ext_lag0<-paste(alarm_vars,collapse ="|")
+    Var_ext_Lag<-paste(paste0(alarm_vars,'_LAG'),collapse ="|")
+    
+    
+    Lag_dic_comp1<-Lag_dic_comp |> 
+      dplyr::mutate(Variable=str_extract(var,paste(alarm_vars,collapse ="|")),
+                    lag=str_remove(var,Var_ext_Lag)
+      ) |> 
+      #dplyr::arrange(Variable,DIC) |> 
+      dplyr::arrange(Variable,logcpo) |> 
+      #dplyr::filter(lag=="0") |> 
+      dplyr::group_by(Variable) |> 
+      dplyr::mutate(Rank=1:n())
+    
+    
+    ## get best combination of LAG
+    
+    
+    lag_Var_Dat<-data.frame(var=lag.vars) |> 
+      dplyr::mutate(Variable=str_extract(var,Var_ext_Lag),
+                    lag=str_remove(var,Var_ext_Lag))
+    
+    
+    names(Lag_dic_comp1)
+    
+    ## chosen lags 
+    
+    Selected_lags<-Lag_dic_comp1 |> 
+      dplyr::filter(Rank==1)
+    
+    
+    
+    #if(length(alarm_vars)==2){
+    #if(length(alarm_vars)>1){
+      if(length(alarm_vars)>0){
+        
+      
+      Lags_to_Comb<-2
+      
+      Selected_lags_Comb<-Lag_dic_comp1 |> 
+        dplyr::filter(Rank %in% 1:Lags_to_Comb)
+      
+      # Lag_Vars1<-Selected_lags_Comb$var[Selected_lags_Comb$Variable==alarm_vars[1]]
+      # Lag_Vars2<-Selected_lags_Comb$var[Selected_lags_Comb$Variable==alarm_vars[2]]
+      # 
+      # 
+      # combs<-rbind(c(1,1),combn2(1:Lags_to_Comb),c(Lags_to_Comb,Lags_to_Comb))
+      # 
+      # lag_combs<-data.frame(var1=Lag_Vars1[combs[,1]],
+      #                       var2=Lag_Vars2[combs[,2]])
+      
+      
+      lag_vars<-sapply(1:length(alarm_vars),FUN =function(x) Selected_lags_Comb$var[Selected_lags_Comb$Variable==alarm_vars[x]])
+      
+      
+      #combs<-rbind(c(1,1),combn2(1:Lags_to_Comb),c(Lags_to_Comb,Lags_to_Comb))
+      
+      lag_combs_a<-expand.grid(data.frame(lag_vars,stringsAsFactors =F))
+      
+      lag_var_Tab<-names(lag_combs_a)
+      
+      lag_combs<-lag_combs_a |>
+        mutate_at(.vars=lag_var_Tab,.funs =function(x) as.character(x))
+      
+      
+      #unlink(list.files(path_dic2,full.names =T))
+      
+      Run_DIC2<-DIC2_run
+      ##ss<-1
+      if(Run_DIC2){
+        time_dic2<-system.time({
+          #compare_DIC_lag_Combs<-function(ss){
+          # Header_progress<-paste0("Running lag Combs district:",District_Now,' ',one_of_dist_str)
+          # p_progress <- Progress$new(min=0,max=nrow(lag_combs))
+          # p_progress$set(message =Header_progress ,value=0)
+          
+          cat("",sep='\n')
+          cat("Running Lag combs ...",sep='\n')
+          
+          for (ss in 1 :nrow(lag_combs)){
+            cat(paste0(ss," "),sep=',')
+            gc()
+            comb_str<-paste0(lag_combs[ss,],collapse ="+")
+            form_str <- as.formula(paste("Cases ~ 1 +f(ID_spat,model='iid',replicate=ID_year)+f(week,model='rw1',cyclic=T,scale.model =T)+",
+                                         comb_str,collapse =""))
+            
+            
+            #cat(ss,sep='\n')
+           
+            
+            ## select suitable lags based on  CV for 2019
+            
+            model_Out<-Sel_Vars(form_str,"nbinomial",Dat_mod_sub,theta_beg$mean, T)
+            summary(model_Out)
+            
+            Dic_tab<-data.frame(Lag_Comb=comb_str,
+                                DIC=model_Out$dic$dic,
+                                coeff=model_Out$summary.fixed$mean[2],
+                                low=model_Out$summary.fixed$`0.025quant`[2],
+                                high=model_Out$summary.fixed$`0.975quant`[2],
+                                logcpo=-mean( log(model_Out$cpo$cpo) ,na.rm=T)
+            )
+            ob_nam<-paste0("Lag_comb_Dic_tab",ss)
+            saveRDS(Dic_tab,file.path(path_dic2,ob_nam))
+            #mess_lag<-paste0(ss,' of ',nrow(lag_combs))
+            #p_progress$set(value = ss, detail = mess_lag)
+            
+          }
+          #p_progress$close()
+        })
+        
+        time_dic2[3]/60
+      }
+      
+      nrow(lag_combs)
+      #compare_DIC_lag_Combs(44)
+      
+      
+      Lag_combinations_dic<-foreach(aa=1:nrow(lag_combs),.combine =rbind)%do% readRDS(file.path(path_dic2,paste0("Lag_comb_Dic_tab",aa)))
+      
+      
+      (Lag_combinations_dic1<-Lag_combinations_dic |> 
+          #dplyr::arrange(DIC)) |> 
+          dplyr::arrange(logcpo))
+      
+      #Lag_combinations_dic1[1,]
+      
+      Selected_lag_Vars_a<-as.character(stringr::str_split(Lag_combinations_dic1$Lag_Comb[1],'[+]',simplify =T))
+      
+    }else{
+      
+      Selected_lag_Vars_a<-Selected_lags$var
+    }
+    
+    Min_Sel_Lag<-min(as.numeric(str_extract(Selected_lag_Vars_a,'[:number:]+')))
+    Max_Sel_Lag<-max(as.numeric(str_extract(Selected_lag_Vars_a,'[:number:]+')))
+    sel_lag_max<-max(as.numeric(Selected_lags$lag))
+    
+    Selected_lag_Vars<-str_replace(Selected_lag_Vars_a,'[:number:]+',as.character(sel_lag_max))
+    
+    vars_Base1<-c("district",'ID_spat',"year",'ID_year',"week","date","Cases",
+                  "mean_cases","sd_cases",
+                  "mean_rate" ,"sd_rate",
+                  "Pop","log_Pop")
+    
+    
+    Vars_Final<-c(vars_Base1,Selected_lag_Vars)
+    
+    names(Dat_mod)
+    
+    Dat_mod_Selected<-Dat_mod_sub |> 
+      dplyr::select(all_of(Vars_Final))
+    
+    df_spline<-4
+    
+    # ns_test<-list(Dat_mod_Selected=Dat_mod_Selected,
+    #                Selected_lag_Vars=Selected_lag_Vars)
+    cat("",sep='\n')
+    
+    Var_inla_Grps_ls<-vector(mode ='list',length =length(alarm_vars))
+    
+    Inla_grp_Nsize<-10
+    
+    for (gg in 1:length(alarm_vars)){
+      
+      Inla_grp_Var_Obj<-paste0('Var',gg,'_Inla_group')
+      
+      Var_ns_pref<-paste0('Var',gg)
+      
+      Var_Cre_bs1<-Dat_mod_Selected[,Selected_lag_Vars[gg]]
+      
+      
+      inla_grp_Var<-data.frame(var=inla.group(Var_Cre_bs1,n=Inla_grp_Nsize,method ="quantile"))
+      
+      names(inla_grp_Var)<-Inla_grp_Var_Obj
+      
+      Var_inla_Grps_ls[[gg]]<-inla_grp_Var
+      
+    }
+    
+    Comb_Var_inla_Grps<-do.call(cbind,Var_inla_Grps_ls)
+    
+    #unique(Comb_Var_inla_Grps$Var1_Inla_group)
+    
+    pp<-1
+    
+    Inla_group_save<-function(pp){
+      
+      Inla_grp_Var_Obj<-paste0('Var',pp,'_Inla_group')
+      
+      #Var_Cre_bs1<-Dat_mod_Selected[,Selected_lag_Vars[gg]]
+      
+      Var_Cre_bs1_0<-Dat_mod_Selected |> 
+        #data.frame() |> 
+        dplyr::mutate(var_sp=.data[[Selected_lag_Vars[pp]]]) |> 
+        dplyr::select(var_sp) 
+      
+      Var_Cre_bs1<-Var_Cre_bs1_0$var_sp
+      
+      #probs_p<-c(0, ppoints(Inla_grp_Nsize -1), 1)
+      
+      #aq<-unique(quantile(Var_Cre_bs1,probs_p,na.rm=T ))
+      
+      #a_cuts <- cut(Var_Cre_bs1, breaks = as.numeric(aq), include.lowest = TRUE)
+      
+      #inla_grp_Var<-data.frame(inla_var=inla.group(Var_Cre_bs1,n=Inla_grp_Nsize,method ="quantile"))
+      
+      inla_grp_Var_e<-data.frame(orig_var=Var_Cre_bs1,
+                                 inla_var=inla.group(Var_Cre_bs1,n=Inla_grp_Nsize,method ="quantile"))
+      
+      
+      
+      inla_grp_Var1<-inla_grp_Var_e |> 
+        dplyr::group_by(inla_var) |> 
+        dplyr::filter(!is.na(inla_var)) |> 
+        dplyr::summarise(.groups="drop",int_beg=min(orig_var,na.rm =T),
+                         int_end=max(orig_var,na.rm =T),
+                         mid_point=median(orig_var,na.rm =T)) |> 
+        data.frame()
+      
+      
+      # inla_grp_Var1<-inla_grp_Var |> 
+      #   dplyr::mutate(Interval=a_cuts) |> 
+      #   dplyr::filter(!is.na(inla_var)) |> 
+      #   unique() |> 
+      #   dplyr::arrange(inla_var)
+      
+      
+      
+      names(inla_grp_Var1)[1]<-Inla_grp_Var_Obj
+      
+      kn_out<-list(inla_var_Intervals=inla_grp_Var1)
+      
+      names(kn_out)<-paste0('Var',pp,"_Inla_group_Intervals")
+      kn_out
+      
+      
+      
+    }
+    
+    Inlagrp_Vars<-foreach(aa=1:length(alarm_vars),.combine =c)%do% Inla_group_save(aa)
+    
+    
+    ##create the model formula
+    
+    Inla_RW_vars<-paste0('Var',1:length(alarm_vars),'_Inla_group')
+    
+    Select_Lag_Comb<-paste(Selected_lag_Vars,collapse ="+")
+    
+    
+    Select_Lag_Comb_rw<-paste("f(",Inla_RW_vars,",model='rw2')",collapse ="+")
+    
+    selected_Model_form <- as.formula(paste("Cases ~ 1 +f(ID_spat,model='iid',replicate=ID_year)+f(week,model='rw1'
+                                        ,cyclic=T,scale.model =T)+",Select_Lag_Comb,collapse =""))
+    
+    
+    selected_Model_form_rw <- as.formula(paste("Cases ~ 1 +f(ID_spat,model='iid',replicate=ID_year)+f(week,model='rw1'
+                                           ,cyclic=T,scale.model =T)+",Select_Lag_Comb_rw,collapse =""))
+    
+    
+    
+    Dat_mod_Selected_with_Inla_groups<-cbind(Dat_mod_Selected,Comb_Var_inla_Grps)
+    
+    model_final_Lin<-get_Model(selected_Model_form,"nbinomial",Dat_mod_Selected)
+    model_final_rw<-get_Model(selected_Model_form_rw,"nbinomial",Dat_mod_Selected_with_Inla_groups)
+    
+    summary(model_final_rw)
+    summary(model_final_Lin)
+    
+    #model_final_rw$summary.random$Var1_Inla_group
+    
+    theta_beg_Rw<-model_final_rw$internal.summary.hyperpar$mean
+    
+    #plot(model_final_rw$summary.random$Var1_Inla_group$mean,type='l')
+    
+    #plot(model_final_rw$summary.random$Var2_Inla_group$mean,type='l')
+    
+    #summary(Dat_mod_Selected$rainsum_LAG10)
+    
+    #summary(model_final_rw$summary.fitted.values$mean)
+    
+    
+    ## run csv 
+    
+    #summary(model_final_Lin)
+    
+   # summary(model_final_rw)
+    
+    
+    sort(c(DIC_lin=model_final_Lin$dic$dic,
+           DIC_rw=model_final_rw$dic$dic))
+    
+    sort(c(WAIC_lin=model_final_Lin$waic$waic,
+           WAIC_rw=model_final_rw$waic$waic))
+    
+    ## perform the weekly CV /test Yearly
+    
+    
+    Max_yrm<-range(data_augmented$year)[2]
+    
+    ## week=1, month=4,quarter=16,month,year=52
+    
+    #52/13
+    
+    
+    
+    #Intervals<-c(1,4,13,52)
+    Intervals<-c(4,13)
+    
+    get_CV_work<-function(WeekIntreval){
+      
+      week_Intervals<-WeekIntreval
+      beg_week<-seq(1,52,week_Intervals)
+      end_week<-seq(week_Intervals,52,week_Intervals)
+      length_Beg<-length(beg_week)
+      length_End<-length(end_week)
+      
+      if(length_End<length_Beg){
+        end_week1<-c(end_week,52)
+      }else{
+        end_week1<-end_week
+        end_week1[length_Beg]<-52
+      }
+      
+      int_padded<-str_pad(week_Intervals,width=2,side='left',pad=0)
+      
+      data.frame(year=Max_yrm,
+                 week_Interval=week_Intervals,
+                 beg_week=beg_week,
+                 end_week=end_week1) |> 
+        dplyr::mutate(beg_pad=str_pad(beg_week,width=2,side='left',pad=0),
+                      end_pad=str_pad(end_week,width=2,side='left',pad=0),
+                      Name_out=paste0('Weekly_Cross_validations_',
+                                      year,'_Interval(',int_padded,')_',
+                                      beg_pad,'_',end_pad))
+      
+    }
+    
+    
+    #work_CV<<-get_CV_work(4)
+    
+    # work_CV_ls<-vector(length(Intervals),mode='list')
+    # 
+    # for(tt in 1:length(Intervals)){
+    #   work_CV_ls[[tt]]<-get_CV_work(Intervals[tt])
+    # }
+    
+    #cat("contents CV work::\n")
+    
+    #print(work_CV)
+    
+    #work_CV<-do.call(rbind,work_CV_ls)
+    
+    
+    #work_CV<-expand.grid(Week=1:52,year=Max_yrm)
+    
+    # test_CV<<-list(Dat_mod_Selected=Dat_mod_Selected,
+    #                work_CV=work_CV,
+    #                selected_Model_form_ns=selected_Model_form_ns,
+    #                Sel_Vars=Sel_Vars)
+    
+    #unlink(list.files(cv_path,full.names =T))
+    
+    #work_CV<-foreach(aa=Intervals,.combine =rbind)%do% get_CV_work(aa)
+    work_CV<-get_CV_work(4)
+    
+    
+    
+    Run_CV<-CV_run
+    
+    if(Run_CV){
+      
+      time_CV<-system.time({
+        #cc<-1
+
+        # Header_progress<-paste0("Cross validations district:",District_Now,' ',one_of_dist_str)
+        # p_progress <- Progress$new(min=0,max=nrow(work_CV))
+        # p_progress$set(message =Header_progress ,value=0)
+        cat("",sep='\n')
+        cat("Running Cross validations ...",sep='\n')
+        
+        for (cc in 1:nrow(work_CV)){
+         
+          
+          #cat(paste("CV::",cc),sep='\n')
+          cat(paste0(cc," "),sep=',')
+          
+          week_Sub<-work_CV$beg_week[cc]:work_CV$end_week[cc]
+          
+          CV_data<-Dat_mod_Selected_with_Inla_groups |> 
+            dplyr::mutate(Cases=case_when((year==work_CV$year[cc] & week %in% week_Sub)~NA,
+                                          TRUE~Cases
+            ))
+          #cat(paste0('cv_data exists::',exists("CV_data")),sep='\n')
+          
+          last_Dat_Year<-max(CV_data$year,na.rm=T)
+          
+          
+          #cv_idx<-with(CV_data,which(year==work_CV$year[cc] & week%in% week_Sub))
+          
+          cv_idx<-which(CV_data$year==work_CV$year[cc] & CV_data$week%in% week_Sub)
+          
+          
+          
+          model_CV<-Sel_Vars(selected_Model_form_rw,"nbinomial",CV_data,theta_beg_Rw,T)
+          
+          #cat(paste0('model_CV exists::',exists("model_CV")),sep='\n')
+          
+          #summary(model_CV)
+          
+          Nsamples<-1000
+          
+          xx <- inla.posterior.sample(Nsamples,model_CV,num.threads ="1:1",seed =123166552467)
+          
+          xx.size<-inla.posterior.sample.eval(function(...) c(theta[1]), xx)
+          xx.s<-inla.posterior.sample.eval(function(...) c(Predictor), xx)[cv_idx,]
+          gc()
+          
+          #xx.s<-xx.Pred[cv_idx,]
+          
+          mpred<-length(cv_idx)
+          y.pred <- matrix(NA, mpred, Nsamples)
+          
+          #s.idx<-1
+          
+          for(s.idx in 1:Nsamples) {
+            xx.sample <- xx.s[, s.idx]
+            xx.size.sample<-xx.size[s.idx]
+            #cat(xx.sample,sep='\n')
+            y.pred[, s.idx] <- rnbinom(mpred, mu = exp(xx.sample), size = xx.size.sample)
+          }
+          
+          
+          #names(Dat_mod_Selected)
+          preds<-Dat_mod_Selected[cv_idx,] |> 
+            dplyr::select(all_of(Vars_Final)) |> 
+            dplyr::mutate(idx.pred = cv_idx, 
+                          mean = apply(y.pred, 1, function(x) mean(x,na.rm=T)), 
+                          median = apply(y.pred, 1, function(x) median(x,na.rm=T)),
+                          lci = apply(y.pred, 1, function(x) quantile(x,c(0.025),na.rm=T)),
+                          uci = apply(y.pred, 1, function(x) quantile(x,c(0.975),na.rm=T)))
+          
+          
+          rownames(preds)<-NULL
+          
+          
+          
+          out_ls<-list(preds=preds,
+                       y.pred=y.pred,
+                       xx.s=xx.s)
+          
+          # out_ls_pred_wts<-list(model_CV=model_CV,
+          #              y.pred=y.pred,
+          #              post_Samples=xx)
+          
+          out_ls_pred_wts<-list(model_CV=summary(model_CV),
+                                y.pred=y.pred,
+                                post_Samples=xx)
+          
+          
+          
+          save_name<-file.path(cv_path,paste0(work_CV$Name_out[cc],'.rds'))
+          
+          cv_cc_pref<-str_pad(cc,pad=0,side='left',width=2)
+          
+
+          save_name_pred_wts<-file.path(pred_weights_objs_pth,paste0('For_Pred_weights_',last_Dat_Year,'_',cv_cc_pref,'.rds'))
+          
+          
+          unlink(save_name)
+          saveRDS(out_ls,save_name,compress = T)
+          
+          unlink(save_name_pred_wts)
+          suppressWarnings(saveRDS(out_ls_pred_wts,save_name_pred_wts,compress = T))
+          
+          pctn_done<-paste0(round((cc/nrow(work_CV))*100,1),' %')
+          
+          one_of_str<-paste0(cc,' of ',nrow(work_CV))
+          
+          mess_cv<-paste0(one_of_str,' (',pctn_done,")")
+          #p_progress$set(value = cc, detail = mess_cv)
+          
+          
+        }
+        
+        #p_progress$close()
+        
+        #Cross_Validation(1)
+        
+        #foreach(aa=1:nrow(work_CV))%do% Cross_Validation(aa)
+      })
+      
+      time_CV[3]/60
+    }
+    
+    
+    all_files_Cv<-data.frame(fname=list.files(cv_path),
+                             fullpath=list.files(cv_path,full.names =T)) |> 
+      dplyr::filter(str_detect(fname,"Interval"))
+    #aa<-1
+    
+    get_preds<-function(aa){
+      
+      Interval_wk<-str_remove(str_extract(all_files_Cv$fname[aa],"Interval[(][:number:]+"),"Interval[(]")
+      
+      preds<-readRDS(all_files_Cv$fullpath[aa])$preds |> 
+        dplyr::mutate(week_Interval=Interval_wk)
+      preds
+    }
+    
+    get_Ypreds<-function(aa){
+      
+      Interval_wk<-str_remove(str_extract(all_files_Cv$fname[aa],"Interval[(][:number:]+"),"Interval[(]")
+      Year_wk<-as.numeric(str_remove(str_extract(all_files_Cv$fname[aa],"validations_[:number:]+"),"validations_"))
+      Weeks.Int<-as.numeric(str_split(str_extract(all_files_Cv$fname[aa],"[:number:]+_[:number:]+"),'_',simplify =T))
+      Weeks_dat<-Weeks.Int[1]:Weeks.Int[2]
+      
+      dat_Meta<-data.frame(year=Year_wk,week=Weeks_dat) |> 
+        dplyr::mutate(week_Interval=Interval_wk)
+      
+      y.pred0<-data.frame(dat_Meta,readRDS(all_files_Cv$fullpath[aa])$y.pred)
+      y.pred_Long<-reshape2::melt(y.pred0,c("year","week","week_Interval"))
+      y.pred_Long
+    }
+    
+    # CHAP patch (CLIM-617): lag-selection picks different optimal lags per
+    # year, so per-year frames carry different _LAG{N} column names. base R
+    # rbind refuses to stack frames with mismatched columns, which broke the
+    # original foreach(.combine = rbind). dplyr::bind_rows fills the missing
+    # columns with NA; downstream code does not read the lag-suffixed columns.
+    all_cv <- dplyr::bind_rows(lapply(seq_len(nrow(all_files_Cv)), get_preds))
+
+    y.PREDS <- dplyr::bind_rows(lapply(seq_len(nrow(all_files_Cv)), get_Ypreds))
+    
+    ## save weights here
+    
+    #source("Save_Prediction_Weights.R",local=T)
+    #source("Save_Prediction_Weights_Loop.R",local=T)
+    source("Save_Prediction_Weights_vectorized.R",local=T)
+    
+    ## Convert pred to long datasets
+    
+    #names(all_cv)
+    
+    z_value<-1.2
+    
+    dat_Plot<-all_cv |> 
+      dplyr::select(district,date,Cases,Pop,mean,lci,uci,mean_rate,sd_rate,week_Interval) |> 
+      dplyr::mutate(obs_rate=(Cases/Pop)*1e5,
+                    Threshold=mean_rate+(sd_rate*z_value),
+                    pred_rate=(mean/Pop)*1e5,
+                    pred_rate_lower=(lci/Pop)*1e5,
+                    pred_rate_Upper=(uci/Pop)*1e5) |> 
+      dplyr::select(-mean,-lci,-uci,-mean_rate,-sd_rate)
+    
+    
+    ggplot(aes(x=date,y=obs_rate),data=dat_Plot)+
+      facet_wrap(~week_Interval,ncol=2,scales ="free_y")+
+      geom_ribbon(aes(ymin=pred_rate_lower,
+                      ymax=pred_rate_Upper,
+                      fill="CI"),
+                  alpha=0.8)+
+      geom_line(aes(col="Observed"),linewidth=1.2)+
+      geom_line(aes(y=pred_rate,col="Predicted"),linewidth=1.2)+
+      
+      #geom_line(aes(x=date,y=pred_rate_lower),col='red')+
+      #geom_line(aes(x=date,y=pred_rate_Upper),col='red')+
+      
+      #scale_x_continuous(breaks=1:12)+
+      scale_x_date(date_breaks = "1 months",
+                   labels=function(x) format.Date(x,"%b %Y"))+
+      
+      scale_colour_manual(values=c('Observed'='#7b3241','Predicted'='#32327b'))+
+      scale_fill_manual(values=c('CI'='grey90'))+
+      
+      theme_bw()+
+      ylab("Dengue \nincidence rate \n per 100000")+
+      guides(col=guide_legend(title=NULL),
+             fill=guide_legend(title=NULL))+
+      theme(
+        legend.box ="horizantol")+
+      theme(axis.text.x =element_text(size=8,angle=45))
+    
+    unique(dat_Plot$week_Interval)
+    
+    dat_Plot_Subset<-dat_Plot |> 
+      dplyr::filter(!week_Interval=="52")
+    
+    names(dat_Plot_Subset)
+    
+    Cases_pl<-dat_Plot_Subset |> 
+      dplyr::select(district,date,obs_rate) |> 
+      unique() |> 
+      dplyr::rename(Rate=obs_rate) |> 
+      dplyr::mutate(Cat="Observed")
+    
+    Cases_p2<-dat_Plot_Subset |> 
+      dplyr::select(district,date,pred_rate,week_Interval) |> 
+      unique() |> 
+      dplyr::rename(Rate=pred_rate) |> 
+      dplyr::mutate(Cat=paste0("Interval",week_Interval)) |> 
+      dplyr::select(-week_Interval)
+    
+    Intervals_Comp<-rbind(Cases_pl,Cases_p2)
+    
+    Intervals_Comp_Wide<-Intervals_Comp |> 
+      dplyr::group_by(date) |> 
+      tidyr::spread(Cat,Rate)
+    
+    names(Intervals_Comp_Wide)
+    
+    #summary(lm(Interval01~Interval13,data=Intervals_Comp_Wide))
+    #summary(lm(Observed~Interval01,data=Intervals_Comp_Wide))
+    summary(lm(Observed~Interval04,data=Intervals_Comp_Wide))
+    
+    # cbind(
+    #   #hydroGOF::gof(Intervals_Comp_Wide$Observed,Intervals_Comp_Wide$Interval01),
+    #   hydroGOF::gof(Intervals_Comp_Wide$Observed,Intervals_Comp_Wide$Interval04),
+    #   #hydroGOF::gof(Intervals_Comp_Wide$Observed,Intervals_Comp_Wide$Interval13)
+    # )
+    hydroGOF::gof(Intervals_Comp_Wide$Observed,Intervals_Comp_Wide$Interval04)
+    
+    ggplot(aes(x=date,y=Rate),data=Intervals_Comp)+
+      
+      geom_line(aes(col=Cat),linewidth=1.2)+
+      
+      scale_x_date(date_breaks = "1 months",
+                   labels=function(x) format.Date(x,"%b %Y"))+
+      
+      
+      theme_bw()+
+      ylab("Dengue \nincidence rate \n per 100000")+
+      guides(col=guide_legend(title=NULL),
+             fill=guide_legend(title=NULL))+
+      theme(
+        legend.box ="horizantol")+
+      theme(axis.text.x =element_text(size=8,angle=90))
+    
+    
+    # Compute  for Probabilities
+    
+    names(all_cv)
+    
+    dat_Sensitivity<-all_cv |> 
+      dplyr::select(district,year,week,Cases,mean_rate,sd_rate,week_Interval,Pop) |> 
+      dplyr::mutate(obs_rate=(Cases/Pop)*1e5,
+                    Threshold=mean_rate+(sd_rate*z_value)
+      ) |> 
+      dplyr::filter(!week_Interval=="52")
+    
+    Combined_sensitivy<-dat_Sensitivity |> 
+      dplyr::left_join(y.PREDS,by=c("year","week","week_Interval")) |> 
+      dplyr::rename(pred_Cases=value) |> 
+      dplyr::mutate(pred_rate=(pred_Cases/Pop)*1e5,
+                    Outbreak=as.numeric(obs_rate>Threshold),
+                    exceed=as.numeric(pred_rate>Threshold)) 
+    
+    ## compute probabilities
+    
+    probs_Exceed<-Combined_sensitivy |> 
+      dplyr::group_by(year,week,week_Interval) |> 
+      dplyr::summarise(.groups ="drop",
+                       Outbreak=mean(Outbreak),
+                       total=n(),
+                       total_Exceed=sum(exceed),
+                       exceed_prob=mean(exceed))
+    
+    # probs_Exceed_01<-probs_Exceed |> 
+    #   dplyr::filter(week_Interval=="01")
+
+    probs_Exceed_04<-probs_Exceed |>
+      dplyr::filter(week_Interval=="04")
+    
+    # probs_Exceed_13<-probs_Exceed |> 
+    #   dplyr::filter(week_Interval=="13")
+    # 
+    
+    # reportROC(gold=probs_Exceed_01$Outbreak,
+    #           predictor=probs_Exceed_01$exceed_prob,
+    #           important="se")
+    # 
+   
+    
+    suppressMessages(suppressWarnings(try(reportROC(gold=probs_Exceed_04$Outbreak,
+                                                     predictor=probs_Exceed_04$exceed_prob,
+                                                     important="se"),
+                                           outFile =warning("ROC_error_pred_04.txt"))))
+
+    # reportROC(gold=probs_Exceed_13$Outbreak,
+    #           predictor=probs_Exceed_13$exceed_prob,
+    #           important="se")
+    
+    
+    ## automatically select best through data driven process
+    
+    z_test<-seq(1.1,3.2,0.02)
+    length(z_test)
+    
+    #ZValue<-0.8
+    
+    select_Z_values<-function(ZValue){
+      
+      gc()
+      
+      dat_Sensitivity<-all_cv |> 
+        dplyr::select(district,year,week,Cases,mean_rate,sd_rate,week_Interval,Pop) |> 
+        dplyr::mutate(obs_rate=(Cases/Pop)*1e5,
+                      Threshold=mean_rate+(sd_rate*ZValue)
+        ) |> 
+        dplyr::filter(!week_Interval=="52")
+      
+      Combined_sensitivy<-dat_Sensitivity |> 
+        dplyr::left_join(y.PREDS,by=c("year","week","week_Interval")) |> 
+        dplyr::rename(pred_Cases=value) |> 
+        dplyr::mutate(pred_rate=(pred_Cases/Pop)*1e5,
+                      Outbreak=as.numeric(obs_rate>Threshold),
+                      exceed=as.numeric(pred_rate>Threshold)) 
+      
+      ## compute probabilities
+      
+      probs_Exceed<-Combined_sensitivy |> 
+        dplyr::group_by(year,week,week_Interval) |> 
+        dplyr::summarise(.groups ="drop",
+                         Outbreak=mean(Outbreak,na.rm=T),
+                         total=n(),
+                         total_Exceed=sum(exceed,na.rm=T),
+                         exceed_prob=mean(exceed,na.rm=T))
+      
+      probs_Exceed_Sub<-probs_Exceed |> 
+        dplyr::filter(week_Interval=="04") |> 
+        dplyr::filter(!is.na(Outbreak))
+      
+    
+      #probs_Exceed_13$exceed_prob
+      
+
+      roc_try<-suppressMessages(suppressWarnings(try(reportROC(gold=probs_Exceed_Sub$Outbreak,
+                             predictor=probs_Exceed_Sub$exceed_prob,
+                             important="se"),
+                   outFile =warning("ROC_error.txt"))))
+      
+      if(class(roc_try) %in% c("NULL","try-error")){
+        data_ztest<-data.frame(zvalue=ZValue,
+                               Cutoff=NA,
+                               AUC=NA,
+                               sens=NA,
+                               spec=NA,
+                               ppv=NA,
+                               npv=NA,
+                               Accuracy=NA)
+      }else{
+        sen_score<-suppressMessages(suppressWarnings(reportROC(gold=probs_Exceed_Sub$Outbreak,
+                             predictor=probs_Exceed_Sub$exceed_prob,
+                             important="se")))
+        data_ztest<-data.frame(zvalue=ZValue,
+                               Cutoff=sen_score$Cutoff,
+                               AUC=sen_score$AUC,
+                               sens=sen_score$SEN,
+                               spec=sen_score$SPE,
+                               ppv=sen_score$PPV,
+                               npv=sen_score$NPV,
+                               Accuracy=sen_score$ACC)
+      }
+      rm(Combined_sensitivy)
+      gc()
+      data_ztest
+      
+    }
+    
+    ssample_z_Select<-20
+    set.seed(345656)
+    z_test_Sample<-sample(z_test,size=ssample_z_Select)
+    
+    #zvalue_sel<-foreach(aa=z_test_Sample,.combine =rbind)%do%select_Z_values(aa)
+    
+    zvalue_sel_ls<-vector(ssample_z_Select,mode='list')
+    
+    # Header_progress<-paste0("Z_value selection:",District_Now,' ',one_of_dist_str)
+    # p_progress <- Progress$new(min=0,max=ssample_z_Select)
+    # p_progress$set(message =Header_progress ,value=0)
+    
+    cat("",sep='\n')
+    cat("selecting Z value ...",sep='\n')
+    #Run_sel_Z<-
+    
+    if(Run_sel_Z){
+    
+    for(zz in 1:ssample_z_Select){
+      
+      cat(paste0(zz," "),sep=',')
+      
+      zvalue_sel_ls[[zz]]<-select_Z_values(z_test_Sample[zz])
+      
+      pctn_done<-paste0(round((zz/ssample_z_Select)*100,1),' %')
+      
+      one_of_str<-paste0(zz,' of ',ssample_z_Select)
+      
+      #mess_z<-paste0(one_of_str,' (',pctn_done,")")
+      mess_z<-paste0('Done.. (',pctn_done,")")
+      
+      #p_progress$set(value = zz, detail = mess_z)
+      
+    }
+    
+    #p_progress$close()
+    
+    zvalue_sel0<-do.call(rbind,zvalue_sel_ls)
+    
+    save_zv_name<-file.path(z_value_sel_pth,"zvalue_sel.rds")
+    saveRDS(zvalue_sel0,save_zv_name)
+    
+    }
+    
+    zvalue_sel<-readRDS(file.path(z_value_sel_pth,"zvalue_sel.rds"))
+    
+    zvalue_sel_Ordered1<-zvalue_sel |> 
+      dplyr::arrange(desc(AUC))
+    
+    zvalue_sel_Ordered<-zvalue_sel |> 
+      dplyr::mutate(AUC=as.numeric(AUC),
+                    ppv=as.numeric(AUC),
+                    spec=as.numeric(AUC),
+                    sens=as.numeric(sens),
+                    npv=as.numeric(npv),
+                    Accuracy=as.numeric(Accuracy),
+                    score=AUC+ppv+spec+sens+npv+Accuracy) |> 
+      #dplyr::filter(!(sens==1|spec==1)) |> 
+      dplyr::filter(!AUC==1) |> 
+      #dplyr::arrange(-AUC) 
+      dplyr::arrange(-AUC) 
+    
+    
+    selected_zvalue<-zvalue_sel_Ordered$zvalue[1]
+    
+    # do the Plots 
+    
+    #district_new<-15
+    
+    data_one<-data_augmented|> 
+      dplyr::filter(district==District_Now) |> 
+      #dplyr::mutate(DIR=.data[[number_of_cases]]/get(pop.var.dat))*1e5)
+      dplyr::mutate(DIR=(.data[[number_of_cases]]/.data[[pop.var.dat]])*1e5)
+    
+    
+    
+    vars_get_summary<-c(number_of_cases,pop.var.dat,alarm_indicators)
+    var.sum<-c("district","year","week",vars_get_summary)
+    
+    
+    dat_sum<-data_one[,var.sum]
+    
+    dat_sum_long<-reshape2::melt(dat_sum,c("district","year","week"))
+    
+    dat_kl<-dat_sum_long %>% 
+      dplyr::group_by(variable,year) %>% 
+      dplyr::summarise(.groups="drop",min=min(value,na.rm =T),
+                       max=max(value,na.rm =T),
+                       mean=mean(value,na.rm =T),
+                       median=quantile(value,0.5,na.rm =T),
+                       p25=quantile(value,0.25,na.rm =T),
+                       p75=quantile(value,0.75,na.rm =T),
+                       pctn_missing=paste0(round((sum(is.na(value))/n())*100,1),"%"))%>% 
+      
+      dplyr::mutate_at(.vars=c("min","max","mean","p25","median","p75"),
+                       .funs = function(x) ifelse(x %in% c(Inf,-Inf),NA,x)) %>% 
+      dplyr::mutate_at(.vars=c("min","max","mean","p25","median","p75"),
+                       .funs = function(x) round(x,1))
+    
+    names(dat_kl)<-c("Variable","Year","Min","Max","Mean","Median","25th Percentile",
+                     "75th Percentile","% Missing")
+    
+    
+    get_packed_st<-function(x){
+      paste0("pack_rows('",x,"'",',',min(which(dat_kl$Variable==x)),',',max(which(dat_kl$Variable==x)),')')
+    }
+
+    all_kl<-foreach(a=as.character(unique(dat_kl$Variable)),.combine =c)%do% get_packed_st(a)
+
+    all_kl_cmd<-paste(c("function() { dat_kl[,-1]","kbl(format='html',caption = paste('District ',unique(dat_sum_long$district)))","kable_styling('striped', full_width = F)",
+                        "column_spec(8,background='#94a323')",all_kl),collapse ='%>%\n')
+
+
+    all_kl_cmd<-paste(all_kl_cmd,'}\n',collapse ='')
+    # 
+    # eval(parse(text=all_kl_cmd))
+    # 
+    # dat_kl[,-1]%>%
+    #   kbl(format='html',caption = paste('District ',unique(dat_sum_long$district)))%>%
+    #   kable_styling('striped', full_width = F)%>%
+    #   column_spec(8,background='#94a323')%>%
+    #   pack_rows('weekly_hospitalised_cases',1,6)%>%
+    #   pack_rows('population',7,12)%>%
+    #   pack_rows('rainsum',13,18)%>%
+    #   pack_rows('meantemperature',19,24)
+    
+    ## use flextable
+    
+    
+    #use tabulator and flextable
+    names(dat_kl)
+    
+    dat_kl1<-dat_kl |> 
+      dplyr::mutate(Year=as.character(Year))
+    
+    dat_kl_Long<-reshape2::melt(dat_kl1,c("Variable","Year"))
+    
+    names(dat_kl_Long)
+    
+    tab_Dat<-tabulator(x=dat_kl_Long,
+                       rows=c("Variable","Year"),
+                       columns=c("variable"),
+                       ystats=as_paragraph(value)
+    )
+    
+    
+    #bright <- khroma::color("bright")
+    #bright(7)
+    #scales::show_col(bright(7))
+    
+    #?font
+    
+    border_prop<-officer::fp_border(width=0.5)
+    
+    tab_Dat |> 
+      as_flextable() |> 
+      #flextable::autofit(add_w=0,add_h=10,unit='mm',part='body') |> 
+      flextable::set_caption(as_paragraph(paste('District ',unique(dat_sum_long$district))),
+                             fp_p=officer::fp_par(text.align = "left")) |> 
+      flextable::fit_to_width(max_width =12,unit='in') |> 
+      flextable::fontsize(part='header',size=14) |> 
+      flextable::fontsize(part='body',size=10) |> 
+      flextable::font(part='all',fontname ="Courier") |> 
+      flextable::padding(part="body",padding = 4) |> 
+      flextable::bold(i=1,part ="header") |> 
+      flextable::border_inner_h(border =border_prop) |> 
+      flextable::color(i=1,color="#CCBB44",part="header") |> 
+      flextable::bg(j=16,bg="#94a323") |> 
+      flextable::align(part='all',align ="left")
+    
+    ## Lag Selection
+    
+    #Lag_dic_comp1
+    
+    #names(Lag_dic_comp1)
+    levels_Rank<-sort(str_pad(unique(Lag_dic_comp1$Rank),width=2,pad=0,side="left"))
+    levels_Var<-Lag_dic_comp1$var
+    
+    
+    Lag_dic_comp2<-Lag_dic_comp1 |> 
+      dplyr::mutate(DIC=round(DIC,3),
+                    coeff=round(coeff,3),
+                    low=round(low,3),
+                    high=round(high,3),
+                    logcpo=round(logcpo,3),
+                    Rank=str_pad(Rank,width=2,pad=0,side="left"),
+                    var=factor(var,levels=levels_Var))
+    
+    Lag_dic_comp1_Long<-reshape2::melt(Lag_dic_comp2,c("var","Variable")) 
+    #names(Lag_dic_comp1_Long)
+    #?tabulator
+    
+    tab_Dat_lag<-tabulator(x=Lag_dic_comp1_Long,
+                           rows=c("Variable","var"),
+                           columns=c("variable"),
+                           ystats=as_paragraph(value)
+    )
+    
+    rows_01<-which(Lag_dic_comp2$Rank=="01")
+    
+    tab_Dat_lag |> 
+      as_flextable() |> 
+      #flextable::autofit(add_w=0,add_h=10,unit='mm',part='body') |> 
+      flextable::set_caption(as_paragraph(paste('District ',unique(dat_sum_long$district))),
+                             fp_p=officer::fp_par(text.align = "left")) |> 
+      flextable::fit_to_width(max_width =12,unit='in') |> 
+      flextable::fontsize(part='header',size=12) |> 
+      flextable::fontsize(part='body',size=8) |> 
+      flextable::font(part='all',fontname ="Courier") |> 
+      flextable::padding(part="body",padding = 4) |> 
+      flextable::bold(i=1,part ="header") |> 
+      flextable::border_inner_h(border =border_prop) |> 
+      flextable::color(i=1,color="#CCBB44",part="header") |> 
+      flextable::bg(i=rows_01,j=2:16,bg="#4477AA",part="body") |> 
+      flextable::align(part='all',align ="left")
+    
+    
+    #p<-1
+    plot_desc<-function(p){
+      
+      
+      data_n<-data_one[,c("year","week",vars_get_summary[p])] 
+      names(data_n)[3]<-'var'
+      
+      beg.year<-min(data_n$year)
+      end.year<-max(data_n$year)
+      
+      plo1<-ggplot(data=data_n)+
+        #geom_raster(aes(x=week,y=year,fill=var))+
+        geom_tile(aes(x=week,y=year,fill=var))+
+        #coord_fixed()+
+        scale_fill_gradientn(name =vars_get_summary[p], colours = rev(brewer.pal(11, "RdBu"))) + 
+        scale_y_continuous(breaks =beg.year:end.year,expand =c(0,0))+
+        scale_x_continuous(breaks=seq(0,52,4),expand =c(0,0))+
+        #coord_fixed()+
+        ylab("Year")+
+        xlab("Week")+
+        theme_bw()+
+        ggtitle(paste('District:',unique(data_one$district)))+
+        theme(legend.position ="bottom",
+              legend.title =element_text(face="italic"))+
+        guides(fill=guide_colorbar(title =vars_get_summary[p],
+                                   title.hjust =0.5,
+                                   barwidth=grid::unit(6,'cm'),
+                                   barheight=grid::unit(0.3,'cm'),
+                                   title.position ="top"))
+      list(plo1)
+      
+    }
+    #?guide_colorbar 
+    plot_List0<-foreach(a=1:length(vars_get_summary),.combine =c)%do% plot_desc(a)
+    cat(paste("Summary variables ::\n"),paste(vars_get_summary,collapse =','),'\n\n')
+    #prrrrr<<-plot_List
+    ## render Plots in a loop
+    
+    all_vars<-c(base_vars,number_of_cases,pop.var.dat,alarm_indicators)
+    
+    
+    dat_Sel<-data_augmented[,all_vars]
+    
+    
+    melted_dat<-reshape2::melt(dat_Sel,base_vars) |> 
+      mutate(year_week=paste0(year,'_',str_pad(week,side ="left",pad =0,width =2))) |> 
+      dplyr::select(district,year_week,variable,value)
+    
+    wide_for_dygraph<-melted_dat |> 
+      dplyr::group_by(variable,year_week) |> 
+      tidyr::spread(district,value)
+    
+    dates_s<-seq.Date(as.Date(paste0(beg.year,'-01-01')),
+                      as.Date(paste0(end.year,'-12-31')),
+                      by='day')
+    
+    
+    
+    data_Weeks<-data.frame(date=dates_s,
+                           year_week=format.Date(dates_s,"%Y_%W"),
+                           year=year(dates_s),
+                           stringsAsFactors =F,
+                           week=week(dates_s)) %>% 
+      mutate(Week=str_split_fixed(year_week,pattern ='_',n=2)[,2]) %>% 
+      dplyr::filter(as.numeric(Week)%in% 1:52)
+    
+    weeks.in.data<-data_augmented0 %>% 
+      dplyr::mutate(year_week=paste0(year,'-',str_pad(week,side ="left",pad =0,width =2))) 
+    
+    year_week_S<-data_Weeks %>% dplyr::group_by(year,Week) %>% 
+      dplyr::summarise(.groups="drop",date_Beg=min(date)) %>% 
+      dplyr::mutate(year_week=format.Date(date_Beg,"%Y-%W"))%>% 
+      dplyr::filter(year_week %in% weeks.in.data$year_week)
+    
+    get_xts_dat<-function(p){
+      dat_n<-wide_for_dygraph %>% dplyr::filter(variable==covar_to_Plot[p])
+      dat_n<-dat_n[,-2]
+      dat_n1<-dat_n[,-1]
+      dat_n2<-xts(dat_n1,order.by =as.Date(as.character(year_week_S$date_Beg)),
+                  frequency=52)
+      plo<-dygraph(dat_n2,xlab ="Year week",ylab=covar_to_Plot[p]) %>%
+        #dyMultiColumn()
+        dySeries() %>% 
+        dyRangeSelector() %>% 
+        dyLegend(show = "follow") %>% 
+        dyHighlight(highlightCircleSize =2, 
+                    highlightSeriesBackgroundAlpha = 0.2,
+                    hideOnMouseOut = T)
+      aa<-list(plo)
+      names(aa)<-names_cov_Plot[p]
+      aa
+    }
+    
+    all_xts_Plots<-foreach(a=1:length(covar_to_Plot),.combine =c)%do% get_xts_dat(a)
+    
+    
+    ## get spatial_Plots
+    melted_dat_wide<-melted_dat %>% 
+      dplyr::group_by(district,variable) %>% 
+      tidyr::spread(year_week,value)
+    
+    get_Spatial_poly_dat<-function(p){
+      dat_n<-melted_dat_wide %>% dplyr::filter(variable==covar_to_Plot[p])
+      merge_Poly<-merge(boundary_file,dat_n,by="district",sort=F,all.x=T)
+      aa<-list(merge_Poly)
+      names(aa)<-names_cov_Plot[p]
+      aa
+    }
+    
+    all_Plot_Poly<-foreach(a=1:length(covar_to_Plot),.combine =c)%do% get_Spatial_poly_dat(a)
+    
+    
+    var_p<-names_cov_Plot
+    cat(paste0('\nvar_p:\n'),paste(var_p,sep=' '),'\n\n')
+    
+    #new_model_Year_plot<-input$new_model_Year_plot
+    new_model_Year_plot<-end.year
+    new_model_Week_plot_spat<-26
+    
+    yr_week<-paste0(new_model_Year_plot,'_',str_pad(new_model_Week_plot_spat,side ="left",pad =0,width =2))
+    yr_week1<-paste0(new_model_Year_plot,':',str_pad(new_model_Week_plot_spat,side ="left",pad =0,width =2))
+    
+    yr_week_input<-paste0(new_model_Year_plot,":",str_pad(new_model_Week_plot_spat,side ="left",pad =0,width =2))
+    yr_week_input1<-paste0(new_model_Year_plot,"_",str_pad(new_model_Week_plot_spat,side ="left",pad =0,width =2))
+    
+    
+    cat(paste("\nfrom input ::",yr_week_input,'\n\n'))
+    
+    p<-1
+    
+    plot_Func<-function(p){
+      #browser()
+      plot_Now<-all_Plot_Poly[[var_p[p]]]
+      week.idx<-which(names(plot_Now)==yr_week)
+      week_slice<-plot_Now[,c("district",yr_week)]
+      
+      lng1<-as.numeric(week_slice@bbox[,1][1])
+      lat1<-as.numeric(week_slice@bbox[,1][2])
+      lng2<-as.numeric(week_slice@bbox[,2][1])
+      lat2<-as.numeric(week_slice@bbox[,2][2])
+      
+      labels <- sprintf(
+        "<strong>%s</strong><br/>%g",
+        week_slice$district, eval(parse(text=paste0("week_slice$`",yr_week,"`")))
+      ) %>% lapply(htmltools::HTML)
+      
+      
+      legend_title<-sprintf(
+        "<strong>%s</strong><br/>%s",
+        var_p[p],yr_week1 
+      ) %>% lapply(htmltools::HTML)
+      
+      id.summ<-str_detect(names(week_slice),"[:number:]+_[:number:]+")
+      
+      dom_comp<-unique(as.numeric(unlist((week_slice[,id.summ]@data))))
+      
+      len.dom<-length(dom_comp)
+      if(len.dom==1){
+        if(is.na(dom_comp)){
+          dom_range<-c(eval(parse(text=paste0("week_slice$`",yr_week,"`"))),1)
+          
+        }else{
+          dom_range<-c(eval(parse(text=paste0("week_slice$`",yr_week,"`"))))
+          
+        }
+      }else{
+        dom_range<-eval(parse(text=paste0("week_slice$`",yr_week,"`")))
+      }
+      pal <- colorNumeric("YlOrRd", 
+                          domain =dom_range,
+                          reverse=F) 
+      plo1<-leaflet(week_slice[,yr_week]) %>% 
+        leaflet::addTiles() %>% 
+        leaflet::addProviderTiles(providers$OpenStreetMap) %>% 
+        leaflet::fitBounds(lng1,lat1,lng2,lat2) %>% 
+        #addPolylines() %>% 
+        leaflet::addPolygons(fillColor = eval(parse(text=paste0("~pal(`",yr_week,"`)"))),
+                             color = "black",weight =0.8,
+                             dashArray = " ",
+                             fillOpacity = 0.9,
+                             highlight = highlightOptions(
+                               weight = 5,
+                               color = "green",
+                               dashArray = "2",
+                               fillOpacity = 0.7,
+                               bringToFront = TRUE),
+                             label = labels,
+                             labelOptions = labelOptions(
+                               style = list("font-weight" = "normal", padding = "3px 8px"),
+                               textsize = "15px",
+                               direction = "auto")) %>% 
+        leaflet::addLegend(pal = pal, values = eval(parse(text=paste0("~`",yr_week,"`"))), 
+                           opacity = 0.7, title = legend_title,
+                           position = "bottomright") 
+      list(plo1)
+      
+    }
+    
+    plot_List<-foreach(a=1:length(var_p),.combine =c)%do% plot_Func(a)
+    
+    
+    #plot SIR
+    
+    #model_final_rw
+    
+    SIR_dat<-data_augmented[,base_vars] %>% 
+      dplyr::filter(district==District_Now) |> 
+      mutate(Fitted_cases=model_final_rw$summary.fitted.values$mean,
+             year_week=paste0(year,'_',str_pad(week,side ="left",pad =0,width =2)))%>% 
+      dplyr::select(district,year_week,Fitted_cases)
+    
+    SIR_wide<-SIR_dat %>% 
+      dplyr::group_by(district) %>% 
+      tidyr::spread(year_week,Fitted_cases)
+    
+    ##merge to polygons for plotting
+    SIR_Poly<-merge(boundary_file,SIR_wide,by="district",sort=F,all.x=T)
+    
+    
+    yr_week<-paste0(new_model_Year_plot,'_',str_pad(new_model_Week_plot_spat,side ="left",pad =0,width =2))
+    yr_week1<-paste0(new_model_Year_plot,':',str_pad(new_model_Week_plot_spat,side ="left",pad =0,width =2))
+    
+    yr_week_input<-paste0(new_model_Year_plot,":",str_pad(new_model_Week_plot_spat,side ="left",pad =0,width =2))
+    yr_week_input1<-paste0(new_model_Year_plot,"_",str_pad(new_model_Week_plot_spat,side ="left",pad =0,width =2))
+    
+    
+    #print(paste("from input ::",yr_week_input))
+    names_Plots_s<-paste(names(SIR_Poly),collapse =" ")
+    
+    first_pos_SIR<-which(stringr::str_detect(names(SIR_Poly),'[:number:]+_[:number:]+'))[1]
+    
+    first_YR_week<-stringr::str_extract(names(SIR_Poly)[first_pos_SIR],'[:number:]+_[:number:]+')
+    first_YR_week1<-str_replace(first_YR_week,'_',":")
+    
+    if(stringr::str_detect(names_Plots_s,yr_week_input1)==FALSE){
+      yr_week1<-first_YR_week1
+      yr_week<-first_YR_week
+      
+    }else{
+      yr_week1<-yr_week_input
+      yr_week<-yr_week_input1
+    }
+    
+    
+    
+    ## Extract weekly effects
+    #district_seas<-Shiny_Input$district_seas
+    
+    weekly_effects <- data.table(cbind(rep(District_Now, each = 52),
+                                       model_final_rw$summary.random$week))
+    names(weekly_effects)[1:2] <- c("district", "Week")
+    
+    weekly_effects_check<-weekly_effects
+    weekly_effects_sub<-weekly_effects %>% 
+      dplyr::filter(district ==District_Now)
+    #dplyr::filter(district ==23)
+    plot.seas<-weekly_effects_sub %>% 
+      ggplot() + 
+      geom_ribbon(aes(x = Week, ymin = `0.025quant`, ymax = `0.975quant`), 
+                  fill = "cadetblue4", alpha = 0.5) + 
+      geom_line(aes(x = Week, y = `mean`), col = "cadetblue4") +
+      geom_hline(yintercept = 0, linetype = "dashed", color = "grey70") +
+      #facet_wrap(~district,ncol =4)+
+      xlab("Week") +
+      ggtitle(paste("District:",District_Now))+
+      ylab("Contribution to log(DIR)") +
+      scale_y_continuous() +
+      scale_x_continuous(breaks = seq(0,52,5)) +
+      theme_bw()+
+      theme(axis.text =element_text(size=14),
+            axis.title =element_text(size=16))
+    
+    
+    ## do the lag plots
+    #nlag<-input$nlag
+    
+    if(Run_Dlnm){
+    
+    Dat_mod_for_dlnn<-data_augmented |> 
+      dplyr::left_join(Dist_IDS,by="district") |> 
+      dplyr::left_join(Year_IDS,by="year") |> 
+      dplyr::filter(district==District_Now) |> 
+      dplyr::arrange(district,year,week)
+    N_LAG<-nlag
+    
+    #all_basis_vars<-foreach(a=alarm_vars,.combine =c)%do% get_cross_basis(a,data_b=Dat_mod_for_dlnn,nlag=nlag)
+    all_basis_vars<-foreach(a=alarm_vars,.combine =c)%do% get_cross_basis(a,data_b=Dat_mod_for_dlnn,nlag=N_LAG)
+    
+    n_district <- length(unique(Dat_mod_for_dlnn$district))
+    
+    ## create district index 
+    
+    Dat_mod_Selected1<-Dat_mod_Selected
+    
+    #fixe_alarm_vars<-input$other_alarm_indicators_New_model
+    fixe_alarm_vars<-other_alarm_variables
+    
+    add.var<-fixe_alarm_vars[which(!fixe_alarm_vars%in% alarm_vars & fixe_alarm_vars%in% vars)]
+    
+    vars_Base1
+    cat(paste(paste0('"',vars_Base1,'"'),collapse =','))
+    
+    Var_for_Dlnm<-c("district","ID_spat",
+                    "year","ID_year","week",
+                    "date","Cases",
+                    "Pop","log_Pop")
+    
+    names(data_augmented)
+    
+    if(length(add.var)>0){
+      sel_mod.vars<-c(Var_for_Dlnm,alarm_vars,add.var)
+    }else{
+      sel_mod.vars<-c(Var_for_Dlnm,alarm_vars)
+      
+    }
+    #cat(names(data_augmented),sep='..\n')
+    #stop("xxx")
+    
+    # check_Noow<<-list(Dat_mod_for_dlnn=Dat_mod_for_dlnn,
+    #                   sel_mod.vars=sel_mod.vars)
+    
+    Data_dlnm<-Dat_mod_for_dlnn[,sel_mod.vars] |> 
+      dplyr::arrange(district,year,week)
+    
+    basis_var_n<-paste0('all_basis_vars$',names(all_basis_vars))
+    
+    baseformula<- "Cases ~ 1 +
+      f(ID_spat,model='iid',replicate=ID_year)+
+      f(week,model='rw1',cyclic=T,scale.model =T)"
+    
+    ## assign basis var to objects
+    
+    for (bb in 1:length(basis_var_n)){
+      assign(paste0("basis_var",bb),all_basis_vars[[bb]])
+    }
+    
+    
+    
+    #basis_var_Comb<-paste0(add.var,basis_var_n,collapse ="+")
+    
+    basis_var_Comb<-paste0("basis_var",1:length(basis_var_n),collapse ="+")
+    
+    form_base_part<-c("Cases ~ 1","f(ID_spat,model='iid',replicate=ID_year)","f(week,model='rw1',cyclic=T,scale.model =T)")
+    
+
+    #formula0.2<-paste0(c(form_base_part,basis_var_Comb),collapse ='+')
+
+    #cat(paste0(baseformula,paste0(add.var,basis_var_n,collapse ="+")))
+    
+    #add.var<-"temp"
+    #rm(add.var)
+    #add.var<-NULL
+    
+    if(length(add.var)>0){
+      formula0.2<-as.formula(paste0(c(form_base_part,basis_var_Comb,add.var),collapse ='+'))
+    }else{
+      formula0.2<-as.formula(paste0(c(form_base_part,basis_var_Comb),collapse ='+'))
+      
+    }
+    
+    dlnm_Inla<-function(form_mod,mod_Family,mod.Data,start_again) {
+      
+      mod<-inla(form_mod,
+                offset =log_Pop,
+                data=mod.Data,
+                family =mod_Family,
+                control.inla = list(strategy = inla_Strategy,
+                                    parallel.linesearch=F,
+                                    improved.simplified.laplace=T,
+                                    control.vb=control_VB), 
+                control.compute = list(dic = TRUE, 
+                                       config = T, 
+                                       cpo = TRUE, 
+                                       waic=T,
+                                       #po=T,
+                                       return.marginals = F,
+                                       smtp="taucs"
+                ),
+                control.fixed = list(correlation.matrix = TRUE),
+                num.threads="2:1",
+                control.mode = list(theta = theta_beg$mean, restart = start_again),
+                control.predictor = list(link = 1, compute = TRUE), 
+                verbose = F)
+      mod
+    }
+    
+    
+    N_trial<-0
+    Lincol_good<-0
+    
+    
+    while(N_trial<6 &  Lincol_good==0){
+      
+            dlnm_Model0<-dlnm_Inla(formula0.2,"nbinomial",Data_dlnm,T)
+            
+            dlnm_Model<-inla.rerun(dlnm_Model0)
+            
+            #dlnm_Model$lincomb.derived.covariance.matrix
+            
+            #print(dlnm_Model$misc$lincomb.derived.covariance.matrix)
+            
+            Lincol_status<-as.numeric(!is.null(dlnm_Model$misc$lincomb.derived.covariance.matrix))
+            
+            Lincol_good<-Lincol_good+Lincol_status
+            
+            N_trial<-N_trial+1
+      
+     
+      
+      cat(paste0("lincomb.derived.covariance.matrix Not Null? ...",Lincol_good),sep='\n')
+      
+    }
+    
+    cat("",sep='\n')
+    
+    cat(paste0("Number of trials DLNN model ...",N_trial),sep='\n')
+    
+    }
+    
+    #summary(dlnm_Model)
+    
+    if(DIC1_run){
+      tim_dic1<-time_dic1
+    }else{
+      tim_dic1<-NA
+    }
+    
+    if(DIC2_run){
+      tim_dic2<-time_dic2
+    }else{
+      tim_dic2<-NA
+    }
+    
+    if(CV_run){
+      tim_CV<-time_CV
+    }else{
+      tim_CV<-NA
+    }
+    
+    grob_Fun<-function(p_lot){
+      if(class(p_lot)[1]=="gg"){
+        ggplot2::ggplotGrob(p_lot)
+      }else{
+        p_lot
+      }
+    }
+    
+    Seasonality_Grobs<-grob_Fun(plot.seas)
+    
+    dist_Out_tribble<-tribble(~obj_out,~dlnm_flag,
+                              "data_augmented=data_augmented",0,
+                              "all_endemic=all_endemic",0,
+                              "Dist_IDS=Dist_IDS",0,
+                              "Year_IDS=Year_IDS",0,
+                              "rows_01=rows_01",0,
+                              " summary_combs=summary_combs",0,
+                              "vars_Base=vars_Base",0,
+                              " Model_data_lags=Model_data_lags",0,
+                              "Dat_mod=Dat_mod",0,
+                              "Dat_mod_Selected=Dat_mod_Selected",0,
+                              " Dat_mod_Selected_with_Inla_groups=Dat_mod_Selected_with_Inla_groups",0,
+                              " Dat_mod_sub=Dat_mod_sub",0,
+                              "Model_data_lags_sub=Model_data_lags_sub",0,
+                              'form_baseline=paste0(as.character(as.formula(form_baseline))[-1],collapse ="~")',0,
+                              #baseline_model=baseline_model,
+                              " theta_beg=theta_beg",0,
+                              "id_lag=id_lag",0,
+                              "path_dic1=path_dic1",0,
+                              "path_dic2=path_dic2",0,
+                              "cv_path=cv_path",0,
+                              "all_cv=all_cv",0,
+                              "y.PREDS=y.PREDS",0,
+                              " shiny_obj_pth=shiny_obj_pth",0,
+                              " report_pth=report_pth",0,
+                              "time_dic1=tim_dic1",0,
+                              "time_dic2=tim_dic2",0,
+                              "Lag_dic_comp=Lag_dic_comp",0,
+                              " Var_ext_lag0=Var_ext_lag0",0,
+                              "Var_ext_Lag=Var_ext_Lag",0,
+                              " Lag_dic_comp1=Lag_dic_comp1",0,
+                              "lag_Var_Dat=lag_Var_Dat",0,
+                              "Selected_lags=Selected_lags",0,
+                              " Lag_combinations_dic=Lag_combinations_dic",0,
+                              " Lag_combinations_dic1=Lag_combinations_dic1",0,
+                              " Selected_lag_Vars=Selected_lag_Vars",0,
+                              " Comb_Var_inla_Grps=Comb_Var_inla_Grps",0,
+                              "Inlagrp_Vars=Inlagrp_Vars",0,
+                              " Inla_RW_vars=Inla_RW_vars",0,
+                              #knots_Vars=knots_Vars,
+                              " vars_Base1=vars_Base1",0,
+                              " Vars_Final=Vars_Final",0,
+                              #Dat_mod_Selected=Dat_mod_Selected,
+                              "Select_Lag_Comb=Select_Lag_Comb",0,
+                              "Select_Lag_Comb_rw=Select_Lag_Comb_rw",0,
+                              ########
+                              #selected_Model_form=selected_Model_form,
+                              'selected_Model_form=paste0(as.character(as.formula(selected_Model_form))[-1],collapse ="~")',0,
+                              
+                              #selected_Model_form_rw=selected_Model_form_rw,
+                              'selected_Model_form_rw=paste0(as.character(as.formula(selected_Model_form_rw))[-1],collapse ="~")',0,
+                              
+                              ## suppressed 2024-04-23
+                              #model_final_Lin=model_final_Lin,
+                              #model_final_rw=model_final_rw,
+                              "model_final_rw_fitted_Values=model_final_rw$summary.fitted.values",0,
+                              " work_CV=work_CV",0,
+                              " time_CV=tim_CV",0,
+                              "all_files_Cv=all_files_Cv",0,
+                              "zvalue_sel_Ordered=zvalue_sel_Ordered",0,
+                              "selected_zvalue=selected_zvalue",0,
+                              "data_one=data_one",0,
+                              ##
+                              #tab_Dat=tab_Dat,
+                              #tab_Dat_lag=tab_Dat_lag,
+                              " dat_kl_Long=dat_kl_Long",0,
+                              " Lag_dic_comp1_Long=Lag_dic_comp1_Long",0,
+                              ###
+                              "summary_plots=plot_List0",0,
+                              #all_xts_Plots=all_xts_Plots,
+                              "all_Plot_Poly=all_Plot_Poly",0,
+                              "leaflet_plots=plot_List",0,
+                              "seasonal_plot=Seasonality_Grobs",0,
+                              "nlag=nlag",0,
+                              " all_basis_vars=all_basis_vars",1,
+                              "n_district=n_district",1,
+                              "Var_for_Dlnm=Var_for_Dlnm",1,
+                              "Dat_mod_for_dlnn=Dat_mod_for_dlnn",1,
+                              "Data_dlnm=Data_dlnm",1,
+                              " basis_var_n=basis_var_n",1,
+                              #formula0.2=formula0.2,0,
+                              'formula0.2=paste0(as.character(as.formula(formula0.2))[-1],collapse ="~")',1,
+                              
+                              #dlnm_Model=dlnm_Model,
+                              "dlnm_coef=dlnm_Model$summary.fixed$mean",1,
+                              "dlnm_vcov=dlnm_Model$misc$lincomb.derived.covariance.matrix",1,
+                              "dlnm_names_fixed=dlnm_Model$names.fixed",1,
+                              #Total_Run_time=Time_one_Dist,
+                              "dat_kl=dat_kl",0,
+                              "all_kl=all_kl",0,
+                              "all_kl_cmd=all_kl_cmd",0,
+                              "vars_get_summary=vars_get_summary",0,
+                              "covar_to_Plot=covar_to_Plot",0,
+                              "alarm_vars=alarm_vars",0,
+                              "names_cov_Plot=names_cov_Plot",0,
+                              "df_spline=df_spline",0,
+                              "population_var=population",0,
+                              "pop.var.dat=pop.var.dat",0,
+                              "other_alarm_indicators=other_alarm_indicators",0,
+                              "number_of_cases=number_of_cases",0,
+                              "new_model_Year_validation=new_model_Year_validation",0,
+                              "weeks.in.data=weeks.in.data",0,
+                              "year_week_S=year_week_S",0,
+                              "wide_for_dygraph=wide_for_dygraph",0,
+                              "Inla_grp_Nsize=Inla_grp_Nsize",0,
+                              "theta_beg_Rw=theta_beg_Rw",0,
+    )
+    
+    if(!Run_Dlnm){
+    
+    dist_Out_tribble_sub<-dist_Out_tribble |> 
+      dplyr::mutate(obj=str_split(obj_out,"=",simplify =T )[,1]) |> 
+      dplyr::filter(!dlnm_flag==1)
+    }else{
+      dist_Out_tribble_sub<-dist_Out_tribble 
+    }
+    
+    district_Objs_save<-eval(parse(text=paste0("list(",paste0(dist_Out_tribble_sub$obj_out,collapse =','),')'))) 
+    
+    file_name_save<-file.path(shiny_obj_pth,"Shiny_Objs.rds")
+    
+    suppressWarnings(saveRDS(district_Objs_save,file_name_save,compress =T))
+    
+    system(paste0("echo done district:",District_Now," ",DD,' of ',length(all_districts),' districts \n'))
+    
+    
+    one_of_dist_str<-paste0('(',DD,' of ',length(all_districts),' districts)')
+    
+  }
+})
+
+Time_one_Dist[3]/60
+
+Time_dist_all<-round(Time_one_Dist[3]/60,2)
+
+system(paste0("echo .. Took ",Time_dist_all,' mins to run all the ',length(all_districts), ' Districts\n'))
+
+
+  
+  #Save district sepecif objects
+
+All_dist_Out_tribble<-tribble(~obj_out,~dlnm_flag,
+                              "all_endemic=all_endemic",0,
+                              " report_pth=report_pth",0,
+                              "data_augmented=data_augmented",0,
+                              " Dist_IDS=Dist_IDS",0,
+                              "Year_IDS=Year_IDS",0,
+                              "summary_combs=summary_combs",0,
+                              "vars_Base=vars_Base",0,
+                              "Model_data_lags=Model_data_lags",0,
+                              "Dat_mod=Dat_mod",0,
+                              "Dat_mod_sub=Dat_mod_sub",0,
+                              "Model_data_lags_sub=Model_data_lags_sub",0,
+                              #form_baseline=form_baseline,
+                              'form_baseline=paste0(as.character(as.formula(form_baseline))[-1],collapse ="~")',0,
+                              
+                              "baseline_model=summary(baseline_model)",0,
+                              "sel_var_endemic=sel_var_endemic",0,
+                              #theta_beg=theta_beg,
+                              "id_lag=id_lag",0,
+                              #path_dic1=path_dic1,
+                              #path_dic2=path_dic2,
+                              #cv_path=cv_path,
+                              #shiny_obj_pth=shiny_obj_pth,
+                              #time_dic1=time_dic1,
+                              #time_dic2=time_dic2,
+                              #time_dic1=3.9,
+                              #Lag_dic_comp=Lag_dic_comp,
+                              "Var_ext_lag0=Var_ext_lag0",0,
+                              " Var_ext_Lag=Var_ext_Lag",0,
+                              #Lag_dic_comp1=Lag_dic_comp1,
+                              #lag_Var_Dat=lag_Var_Dat,
+                              #Selected_lags=Selected_lags,
+                              #Lag_combinations_dic=Lag_combinations_dic,
+                              #Lag_combinations_dic1=Lag_combinations_dic1,
+                              #Selected_lag_Vars=Selected_lag_Vars,
+                              "vars_Base1=vars_Base1",0,
+                              "Vars_Final=Vars_Final",0,
+                              "Dat_mod_Selected=Dat_mod_Selected",0,
+                              "Dat_mod_Selected_with_Inla_groups=Dat_mod_Selected_with_Inla_groups",0,
+                              #Select_Lag_Comb=Select_Lag_Comb,
+                              #Select_Lag_Comb_ns=Select_Lag_Comb_ns,
+                              #selected_Model_form=selected_Model_form,
+                              'selected_Model_form=paste0(as.character(as.formula(selected_Model_form))[-1],collapse ="~")',0,
+                              
+                              #selected_Model_form_rw=selected_Model_form_rw,
+                              'selected_Model_form_rw=paste0(as.character(as.formula(selected_Model_form_rw))[-1],collapse ="~")',0,
+                              
+                              #model_final_Lin=model_final_Lin,
+                              #model_final_ns=model_final_ns,
+                              #work_CV=work_CV,
+                              #time_CV=time_CV,
+                              "all_files_Cv=all_files_Cv",0,
+                              #zvalue_sel_Ordered=zvalue_sel_Ordered,
+                              #selected_zvalue=selected_zvalue,
+                              #data_one=data_one,
+                              #tab_Dat=tab_Dat,
+                              #tab_Dat_lag=tab_Dat_lag,
+                              #summary_plots=plot_List0,
+                              "all_xts_Plots=all_xts_Plots",0,
+                              "all_Plot_Poly=all_Plot_Poly",0,
+                              "leaflet_plots=plot_List",0,
+                              #seasonal_plot=plot.seas,
+                              "nlag=nlag",0,
+                              "all_basis_vars=all_basis_vars",1,
+                              "n_district=n_district",1,
+                              "Var_for_Dlnm=Var_for_Dlnm",1,
+                              "Dat_mod_for_dlnn=Dat_mod_for_dlnn",1,
+                              "Data_dlnm=Data_dlnm",1,
+                              "basis_var_n=basis_var_n",1,
+                              #formula0.2=formula0.2,
+                              'formula0.2=paste0(as.character(as.formula(formula0.2))[-1],collapse ="~")',1,
+                              #dlnm_Model=dlnm_Model,
+                              "dlnm_coef=dlnm_Model$summary.fixed$mean",1,
+                              "dlnm_vcov=dlnm_Model$misc$lincomb.derived.covariance.matrix",1,
+                              "dlnm_names_fixed=dlnm_Model$names.fixed",1,
+                              #Total_Run_time=Time_one_Dist,
+                              #dat_kl=dat_kl,
+                              #all_kl=all_kl,
+                              #all_kl_cmd=all_kl_cmd,
+                              "vars_get_summary=vars_get_summary",0,
+                              "covar_to_Plot=covar_to_Plot",0,
+                              "alarm_vars=alarm_vars",0,
+                              "names_cov_Plot=names_cov_Plot",0,
+                              "Total_Run_time=Time_one_Dist",0,
+                              "population_var=population",0,
+                              "pop.var.dat=pop.var.dat",0,
+                              " other_alarm_indicators=other_alarm_indicators",0,
+                              "number_of_cases=number_of_cases",0,
+                              "new_model_Year_validation=new_model_Year_validation",0,
+)
+
+
+
+if(!Run_Dlnm){
+  
+  All_dist_Out_tribble_sub<-All_dist_Out_tribble |> 
+    dplyr::mutate(obj=str_split(obj_out,"=",simplify =T )[,1]) |> 
+    dplyr::filter(!dlnm_flag==1)
+}else{
+  All_dist_Out_tribble_sub<-All_dist_Out_tribble 
+}
+
+All_Objs_save<-eval(parse(text=paste0("list(",paste0(All_dist_Out_tribble_sub$obj_out,collapse =','),')'))) 
+
+
+file_name_DBI_districts<-file.path(all_files_Path,"Districts_DBI_surve_Dat.rds")
+
+suppressWarnings(saveRDS(unique(all_endemic$district),file_name_DBI_districts,compress =T))
+  
+  
+file_name_save_all<-file.path(all_files_Path,"Shiny_Objs_all.rds")
+suppressWarnings(saveRDS(All_Objs_save,file_name_save_all,compress =T))
+
+
+system("echo done runnng all districts... \n")

--- a/external_models/ewars_plus_api_patch/README.md
+++ b/external_models/ewars_plus_api_patch/README.md
@@ -44,8 +44,27 @@ ewars_plus:
 
 `docker compose up -d ewars_plus` will build the image on first run.
 
+## Regression test
+
+`tests/test_bind_rows_assembly.R` exercises the assembly logic on synthetic
+per-year frames (no real CV needed). It asserts the old
+`foreach(.combine = rbind)` errors with the original message and the new
+`dplyr::bind_rows` produces the expected union-of-columns shape.
+
+Run the full smoke from the repo root:
+
+```sh
+tests/test_ewars_plus_api_patch.sh
+```
+
+which builds the image and runs the test inside it. The test is also baked
+into the image, so `docker run --rm chap-core/ewars_plus_api:clim-617
+Rscript /home/app/tests/test_bind_rows_assembly.R` works on the existing
+container too.
+
 ## Updating the upstream base
 
 If a new `maquins/ewars_plus_api` tag is published, update the `FROM` line in
-`Dockerfile` and re-test against the v3 Malawi reproduction payload (see
-CLIM-615 / CLIM-617 for details).
+`Dockerfile`, re-run `tests/test_ewars_plus_api_patch.sh`, and re-verify
+end-to-end against the Malawi reproduction payload (see CLIM-615 / CLIM-617
+for details).

--- a/external_models/ewars_plus_api_patch/README.md
+++ b/external_models/ewars_plus_api_patch/README.md
@@ -1,0 +1,51 @@
+# ewars_plus_api patch
+
+Local Dockerfile that overlays a one-file fix on top of
+`maquins/ewars_plus_api:Upload`. Tracked in chap-core so the patched image
+builds reproducibly from `docker compose up -d ewars_plus` without needing a
+separate registry.
+
+## What it fixes
+
+In `Lag_Model_selection_ewars_By_District_api.R`, the per-fold CV predictions
+are stacked with `foreach(aa, .combine = rbind) %do% get_preds(aa)`. The
+upstream lag-selection step picks a different optimal lag per year, so each
+per-year frame carries differently-named lag-suffixed covariate columns
+(`mean_temperature_LAG12` vs `_LAG10` vs `_LAG7`). Base R `rbind` refuses to
+stack frames with mismatched column names, so the call aborts with:
+
+```
+<simpleError in get_preds(aa): names do not match previous names>
+```
+
+and the wrapper surfaces it as `RuntimeError: EWARS API error from /Ewars_run:
+500 - Internal server error`.
+
+The patch replaces the two assembly calls with `dplyr::bind_rows(lapply(...))`,
+which fills missing columns with `NA`. Downstream code does not read the
+lag-suffixed columns, so the extra NAs are harmless.
+
+See [CLIM-617](https://dhis2.atlassian.net/browse/CLIM-617) for the full
+investigation and verification.
+
+## How it's used
+
+`compose.override.yml(.example)` points the `ewars_plus` service at this
+directory:
+
+```yaml
+ewars_plus:
+  build: ./external_models/ewars_plus_api_patch
+  image: chap-core/ewars_plus_api:clim-617
+  container_name: ewars_plus
+  ports:
+    - "3288:3288"
+```
+
+`docker compose up -d ewars_plus` will build the image on first run.
+
+## Updating the upstream base
+
+If a new `maquins/ewars_plus_api` tag is published, update the `FROM` line in
+`Dockerfile` and re-test against the v3 Malawi reproduction payload (see
+CLIM-615 / CLIM-617 for details).

--- a/external_models/ewars_plus_api_patch/tests/test_bind_rows_assembly.R
+++ b/external_models/ewars_plus_api_patch/tests/test_bind_rows_assembly.R
@@ -1,0 +1,95 @@
+# Regression test for CLIM-617.
+#
+# The CV step in Lag_Model_selection_ewars_By_District_api.R writes one RDS
+# per (year, weekly-window) fold. Lag-selection picks a different optimal
+# lag per year, so each per-year frame carries differently-named lag-suffixed
+# columns. The original `foreach(.combine = rbind)` assembly refused to stack
+# frames with mismatched column names; the patch switches to
+# `dplyr::bind_rows(lapply(...))` which fills missing columns with NA.
+#
+# This test exercises the assembly logic directly on synthetic per-year
+# frames so it does not require a full CV run. Old path is asserted to
+# fail with the original error; new path is asserted to succeed and
+# produce the union-of-columns shape expected by downstream code.
+#
+# Run inside the patched image:
+#   docker run --rm chap-core/ewars_plus_api:clim-617 \
+#     Rscript /home/app/tests/test_bind_rows_assembly.R
+
+suppressPackageStartupMessages({
+  library(foreach)
+  library(dplyr)
+})
+
+# ---- fixtures ------------------------------------------------------------
+# Three per-year frames, each with a different optimal-lag suffix on the two
+# alarm-variable columns. Common columns mirror the real CV output (subset).
+make_year_frame <- function(year, lag_n) {
+  weeks <- 1:4
+  df <- data.frame(
+    district           = 1L,
+    year               = year,
+    week               = weeks,
+    Cases              = c(10L, 12L, 11L, 13L),
+    Pop                = 1e6,
+    mean               = c(11.0, 12.5, 10.8, 13.2),
+    lci                = c(2,    3,    2,    3),
+    uci                = c(38,   42,   35,   44),
+    mean_rate          = c(1.0, 1.1, 1.0, 1.2),
+    sd_rate            = c(0.4, 0.5, 0.4, 0.5),
+    week_Interval      = "01_04",
+    stringsAsFactors   = FALSE
+  )
+  # The columns that drift across years.
+  df[[paste0("mean_temperature_LAG", lag_n)]] <- c(25.1, 26.0, 27.4, 28.1)
+  df[[paste0("rainfall_std_LAG",     lag_n)]] <- c(-0.7, -0.3, 0.5, 1.4)
+  df
+}
+
+frames <- list(
+  make_year_frame(2022, 12L),
+  make_year_frame(2023, 10L),
+  make_year_frame(2024,  7L)
+)
+
+stopifnot(length(frames) == 3L)
+
+# ---- 1. old path: must fail with the historical error message -------------
+old_res <- tryCatch(
+  foreach(i = seq_along(frames), .combine = rbind) %do% frames[[i]],
+  error = function(e) e
+)
+
+if (!inherits(old_res, "error")) {
+  stop("REGRESSION: old foreach(.combine = rbind) unexpectedly succeeded; ",
+       "the bug we were guarding against is no longer reproducing — review ",
+       "the test or upstream changes")
+}
+if (!grepl("names do not match", conditionMessage(old_res), fixed = TRUE)) {
+  stop("Old path failed but with an unexpected message: ",
+       conditionMessage(old_res))
+}
+cat("OK old path failed as expected: ", conditionMessage(old_res), "\n", sep = "")
+
+# ---- 2. new path: must succeed and produce union-of-columns ---------------
+new_res <- dplyr::bind_rows(frames)
+
+stopifnot(nrow(new_res) == 12L)                                # 3 years x 4 weeks
+stopifnot(all(c("district","year","week","Cases","Pop","mean",
+                "lci","uci","mean_rate","sd_rate","week_Interval") %in% names(new_res)))
+
+# All three lag-suffix variants should coexist; each is non-NA only for its
+# originating year and NA elsewhere. This is the property downstream code
+# relies on (it does not read the lag-suffixed columns).
+for (lag_n in c(12L, 10L, 7L)) {
+  for (col in c(paste0("mean_temperature_LAG", lag_n),
+                paste0("rainfall_std_LAG",     lag_n))) {
+    stopifnot(col %in% names(new_res))
+    stopifnot(sum(!is.na(new_res[[col]])) == 4L)               # one year worth
+    stopifnot(sum( is.na(new_res[[col]])) == 8L)               # the other two
+  }
+}
+cat("OK new path produced rows=", nrow(new_res),
+    " cols=", ncol(new_res), "\n", sep = "")
+
+cat("PASS: CLIM-617 regression test\n")

--- a/external_models/ewars_plus_api_patch/tests/test_idx_end_match.R
+++ b/external_models/ewars_plus_api_patch/tests/test_idx_end_match.R
@@ -1,0 +1,111 @@
+# Regression test for CLIM-617 (predict-side: non-conformable arrays).
+#
+# In DBII_predictions_Vectorized_API.R the prospective threshold is built by
+# looking up each prospective week's row in the precomputed endemic-channel
+# table:
+#
+#   idx.end_all <- foreach(aa = Prospective_Data_with_inla_grp$week,
+#                          .combine = c) %do% which(endemic_channel_Use$week == aa)
+#
+# When a prospective week is not in the endemic table, `which(...)` returns
+# integer(0) and `foreach(.combine = c)` silently drops it. idx.end_all
+# becomes shorter than the prospective row count; downstream the threshold
+# matrix is also shorter; the elementwise comparison
+#
+#   prob_Exceed_mat <- ypred_NB_1000_rate_all > week_rate_threshold_all
+#
+# crashes with `<simpleError ... non-conformable arrays>` and the wrapper
+# surfaces it as `RuntimeError: EWARS API error from /Ewars_predict: 500`.
+#
+# The patch replaces the foreach idiom with `match()`, which preserves
+# length: unmatched weeks become NA_integer_, the threshold cell becomes
+# NA_real_, and the comparison harmlessly produces NA in those rows.
+#
+# This test exercises that lookup logic on synthetic frames so it does not
+# require a real /Ewars_predict run.
+#
+# Run inside the patched image:
+#   docker run --rm chap-core/ewars_plus_api:clim-617 \
+#     Rscript /home/app/tests/test_idx_end_match.R
+
+suppressPackageStartupMessages({
+  library(foreach)
+})
+
+# ---- fixtures ------------------------------------------------------------
+# Prospective weeks include 999, which is intentionally not in the endemic
+# table — that is the failure trigger.
+Prospective_Data_with_inla_grp <- data.frame(
+  week = c(13L, 14L, 15L, 999L, 16L)
+)
+endemic_channel_Use <- data.frame(
+  week           = 1:52,
+  threshold_rate = seq(1.0, by = 0.1, length.out = 52)
+)
+n_prospective <- nrow(Prospective_Data_with_inla_grp)
+
+# Stand-in for the predicted-rate matrix; the values do not matter for the
+# regression — only the shape does.
+ypred_NB_1000_rate_all <- matrix(1.5,
+                                 nrow = n_prospective,
+                                 ncol = 1000)
+
+# ---- 1. old path: must reproduce the historical "non-conformable arrays" ---
+old_idx <- foreach(aa = Prospective_Data_with_inla_grp$week, .combine = c) %do%
+             which(endemic_channel_Use$week == aa)
+
+if (length(old_idx) == n_prospective) {
+  stop("REGRESSION: the old foreach(.combine=c)+which idiom no longer drops ",
+       "unmatched weeks; this test (and the CLIM-617 bug) no longer reproduce")
+}
+stopifnot(length(old_idx) == n_prospective - 1L)  # week=999 was dropped
+
+old_threshold0 <- endemic_channel_Use$threshold_rate[old_idx]
+old_threshold  <- replicate(1000, old_threshold0, simplify = "matrix")
+
+old_compare <- tryCatch(
+  ypred_NB_1000_rate_all > old_threshold,
+  error = function(e) e
+)
+if (!inherits(old_compare, "error")) {
+  stop("REGRESSION: old comparison unexpectedly succeeded; the bug ",
+       "we were guarding against is no longer reproducing")
+}
+if (!grepl("non-conformable arrays", conditionMessage(old_compare),
+           fixed = TRUE)) {
+  stop("Old path failed but with an unexpected message: ",
+       conditionMessage(old_compare))
+}
+cat("OK old path failed as expected: ",
+    conditionMessage(old_compare), "\n", sep = "")
+
+# ---- 2. new path: must succeed and produce NAs for the unmatched week ----
+new_idx <- match(Prospective_Data_with_inla_grp$week,
+                 endemic_channel_Use$week)
+
+stopifnot(length(new_idx) == n_prospective)
+stopifnot(is.na(new_idx[4]))                    # week=999
+stopifnot(!any(is.na(new_idx[-4])))
+
+new_threshold0 <- endemic_channel_Use$threshold_rate[new_idx]
+stopifnot(length(new_threshold0) == n_prospective)
+stopifnot(is.na(new_threshold0[4]))
+
+new_threshold <- replicate(1000, new_threshold0, simplify = "matrix")
+stopifnot(identical(dim(new_threshold), dim(ypred_NB_1000_rate_all)))
+
+new_compare <- ypred_NB_1000_rate_all > new_threshold
+stopifnot(identical(dim(new_compare), c(n_prospective, 1000L)))
+stopifnot(all(is.na(new_compare[4, ])))         # week=999 row → NAs
+stopifnot(!any(is.na(new_compare[-4, ])))       # other rows → real values
+
+# Downstream uses apply(..., mean) per row; with na.rm=TRUE that should
+# return NaN/NA for the unmatched row but a real value for the others —
+# check that the comparison shape is consumable without further crashes.
+row_means <- apply(new_compare, 1, function(x) mean(x, na.rm = TRUE))
+stopifnot(length(row_means) == n_prospective)
+
+cat("OK new path produced ", n_prospective, "x", ncol(new_compare),
+    " comparison with NA at row 4 (week=999)\n", sep = "")
+
+cat("PASS: CLIM-617 predict-side regression test\n")

--- a/tests/test_ewars_plus_api_patch.sh
+++ b/tests/test_ewars_plus_api_patch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Smoke test for the ewars_plus_api CLIM-617 patch.
+#
+# Builds the patched image and runs the in-image regression test that
+# exercises the per-year-lag bind_rows assembly fix on synthetic fixtures.
+# Independent of compose; safe to run in CI.
+
+set -e
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+
+echo "=== Building chap-core/ewars_plus_api:clim-617 ==="
+docker build \
+  -t chap-core/ewars_plus_api:clim-617 \
+  "$repo_root/external_models/ewars_plus_api_patch"
+
+echo "=== Running in-image regression test (test_bind_rows_assembly.R) ==="
+docker run --rm \
+  chap-core/ewars_plus_api:clim-617 \
+  Rscript /home/app/tests/test_bind_rows_assembly.R
+
+echo "=== ewars_plus_api patch smoke test PASSED ==="

--- a/tests/test_ewars_plus_api_patch.sh
+++ b/tests/test_ewars_plus_api_patch.sh
@@ -19,4 +19,9 @@ docker run --rm \
   chap-core/ewars_plus_api:clim-617 \
   Rscript /home/app/tests/test_bind_rows_assembly.R
 
+echo "=== Running in-image regression test (test_idx_end_match.R) ==="
+docker run --rm \
+  chap-core/ewars_plus_api:clim-617 \
+  Rscript /home/app/tests/test_idx_end_match.R
+
 echo "=== ewars_plus_api patch smoke test PASSED ==="


### PR DESCRIPTION
## Summary

- Adds `external_models/ewars_plus_api_patch/` — a tiny Dockerfile that overlays a one-file fix on top of `maquins/ewars_plus_api:Upload`, plus the patched R file and a README pointing at CLIM-617.
- Switches the `ewars_plus` service in `compose.override.yml.example` from `image: maquins/ewars_plus_api:Upload` to `build: ./external_models/ewars_plus_api_patch` so users running the override automatically get the patched image (no registry credentials needed).

## Why

The `ewars_plus` model's R-side cross-validation saves one RDS file per (year, weekly-window) fold. Lag-selection picks a different optimal lag per year, so each per-year frame carries differently-named lag-suffixed columns (`mean_temperature_LAG12` vs `_LAG10` vs `_LAG7`). The original `foreach(.combine = rbind)` at the assembly step refuses frames with mismatched column names and aborts with:

```
<simpleError in get_preds(aa): names do not match previous names>
```

which the wrapper surfaces as `RuntimeError: EWARS API error from /Ewars_run: 500`. The patch replaces the two assembly calls with `dplyr::bind_rows(lapply(...))`, which fills missing columns with `NA`. Downstream code does not read the lag-suffixed columns, so the extra NAs are harmless. Full investigation: [CLIM-615](https://dhis2.atlassian.net/browse/CLIM-615); fix tracked under [CLIM-617](https://dhis2.atlassian.net/browse/CLIM-617).

## Verification

- Unit-style R test loading the 39 saved CV files: old `foreach(.combine=rbind)` fails as expected with the original error; new `dplyr::bind_rows` succeeds (156 rows × 25 cols, with NA-filled lag columns outside their originating year).
- End-to-end run with the patched image built via compose: district 1 of 5 completes its full `Lag_Model_selection` pipeline (CV + assembly + downstream) cleanly in ~6 min 22 s. No `simpleError`; control flow moves on to district 2 normally.

## Test plan

- [ ] `docker compose up -d ewars_plus` builds `chap-core/ewars_plus_api:clim-617` locally without errors.
- [ ] `docker exec ewars_plus grep -nE "bind_rows|CHAP patch" /home/app/Lag_Model_selection_ewars_By_District_api.R` shows the patched lines.
- [ ] Submit a backtest with a single-district payload (e.g. the Malawi `EWARS.json` from CLIM-615) via `POST /v1/analytics/create-backtest-with-data/` and confirm the job reaches `SUCCESS` instead of failing at `/Ewars_run`.

[CLIM-615]: https://dhis2.atlassian.net/browse/CLIM-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ