### PR TITLE
fix: return 200 + ImportSummaryResponse on dry-run total rejection (CLIM-582)

### DIFF
--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal, overload
 
 import numpy as np
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
@@ -84,8 +84,14 @@ def make_dataset(
     return ImportSummaryResponse(id=job.id, imported_count=imported_count, rejected=rejections)
 
 
-def _read_dataset(request):
+@overload
+def _read_dataset(request, *, dry_run: Literal[False] = False) -> tuple[list[str], DataSet]: ...
+@overload
+def _read_dataset(request, *, dry_run: bool) -> tuple[list[str], DataSet | None]: ...
+def _read_dataset(request, *, dry_run: bool = False) -> tuple[list[str], DataSet | None]:
     if not request.provided_data:
+        if dry_run:
+            return [], None
         raise HTTPException(status_code=400, detail="No observation data provided.")
     feature_names = list({entry.feature_name for entry in request.provided_data})
     dataclass = create_tsdataclass(feature_names)
@@ -122,14 +128,24 @@ def _find_locations_with_complete_covariates(
     return locations_to_keep, rejected_list
 
 
+@overload
 def _validate_full_dataset(
-    feature_names, provided_data, target_name="disease_cases"
-) -> tuple[DataSet, list[ValidationError]]:
+    feature_names, provided_data, target_name: str = "disease_cases", *, dry_run: Literal[False] = False
+) -> tuple[DataSet, list[ValidationError]]: ...
+@overload
+def _validate_full_dataset(
+    feature_names, provided_data, target_name: str = "disease_cases", *, dry_run: bool
+) -> tuple[DataSet | None, list[ValidationError]]: ...
+def _validate_full_dataset(
+    feature_names, provided_data, target_name="disease_cases", *, dry_run: bool = False
+) -> tuple[DataSet | None, list[ValidationError]]:
     n_locations = len(provided_data.locations())
     locations_to_keep, rejected_list = _find_locations_with_complete_covariates(
         provided_data, feature_names, target_name
     )
     if not locations_to_keep:
+        if dry_run:
+            return None, rejected_list
         raise HTTPException(
             status_code=400,
             detail={
@@ -583,8 +599,14 @@ async def create_backtest_with_data(
     database_url: str = Depends(get_database_url),
     worker_settings=Depends(get_settings),
 ):
-    feature_names, provided_data_processed = _read_dataset(request)
-    provided_data_processed, rejections = _validate_full_dataset(feature_names, provided_data_processed)
+    feature_names, provided_data_processed = _read_dataset(request, dry_run=dry_run)
+    if provided_data_processed is None:
+        return ImportSummaryResponse(id=None, imported_count=0, rejected=[])
+    provided_data_processed, rejections = _validate_full_dataset(
+        feature_names, provided_data_processed, dry_run=dry_run
+    )
+    if provided_data_processed is None:
+        return ImportSummaryResponse(id=None, imported_count=0, rejected=rejections)
     backtest_params = BackTestParams(**request.model_dump())
     train_set, _ = train_test_generator(
         provided_data_processed, backtest_params.n_periods, backtest_params.n_splits, stride=backtest_params.stride

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -594,6 +594,40 @@ def test_backtest_with_empty_provided_data(dependency_overrides, create_backtest
     assert "No observation data provided" in response.json()["detail"]
 
 
+def test_backtest_dry_run_with_empty_provided_data_returns_summary(
+    dependency_overrides, create_backtest_with_data_request
+):
+    request_payload = create_backtest_with_data_request.model_dump()
+    request_payload["provided_data"] = []
+    response = client.post("/v1/analytics/create-backtest-with-data?dryRun=true", json=request_payload)
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["id"] is None
+    assert body["importedCount"] == 0
+    assert body["rejected"] == []
+
+
+def test_backtest_dry_run_all_locations_rejected_returns_summary(
+    dependency_overrides, create_backtest_with_data_request
+):
+    request_payload = create_backtest_with_data_request.model_dump()
+    target_period = request_payload["provided_data"][0]["period"]
+    request_payload["provided_data"] = [
+        obs
+        for obs in request_payload["provided_data"]
+        if not (obs["feature_name"] == "rainfall" and obs["period"] == target_period)
+    ]
+    response = client.post("/v1/analytics/create-backtest-with-data?dryRun=true", json=request_payload)
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["id"] is None
+    assert body["importedCount"] == 0
+    rejected_org_units = {r["orgUnit"] for r in body["rejected"]}
+    expected_org_units = {obs["org_unit"] for obs in request_payload["provided_data"]}
+    assert rejected_org_units == expected_org_units
+    assert all(r["featureName"] == "rainfall" for r in body["rejected"])
+
+
 @pytest.mark.parametrize("dry_run", [False, True])
 def test_backtest_with_weekly_data_flow(
     celery_session_worker, dependency_overrides, example_polygons, create_backtest_with_weekly_data_request, dry_run


### PR DESCRIPTION
## Summary
- `POST /create-backtest-with-data/?dryRun=true` now returns **200** with `ImportSummaryResponse(id=None, imported_count=0, rejected=[...])` when the whole dataset is rejected (empty `provided_data` or every location rejected for missing covariates), matching modeling-app expectations and the existing dry-run behavior for partial rejection.
- Plumbed a keyword-only `dry_run` flag through `_read_dataset` and `_validate_full_dataset`. In dry-run mode they return `None` for the dataset instead of raising `HTTPException`; the endpoint short-circuits to an `ImportSummaryResponse`. Non-dry-run behavior is unchanged.
- `@overload` keeps the helper return types non-Optional for the three other callers (`make-dataset`, `make-prediction`, `make-prediction-with-data-source`), so they're untouched.

Jira: [CLIM-582](https://dhis2.atlassian.net/browse/CLIM-582)

## Test plan
- [x] New `test_backtest_dry_run_with_empty_provided_data_returns_summary` — empty `provided_data` + `?dryRun=true` returns 200 / `imported_count=0` / `rejected=[]`
- [x] New `test_backtest_dry_run_all_locations_rejected_returns_summary` — all-orgunit covariate rejection + `?dryRun=true` returns 200 / `imported_count=0` / every orgunit in `rejected` citing the offending feature
- [x] Existing `test_backtest_with_empty_provided_data` (non-dry-run) still returns 400
- [x] `make lint` clean (ruff + mypy + pyright)
- [x] `make test` passes (the only failure is `tests/test_documentation.py::test_docs_python[docs/contributor/rest_api_cleanup_plan.md]`, which is a pre-existing untracked local doc file unrelated to this change)

[CLIM-582]: https://dhis2.atlassian.net/browse/CLIM-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ