### PR TITLE
feat: expose configured user options on configured-models list (CLIM-588)

### DIFF
--- a/chap_core/database/model_spec_tables.py
+++ b/chap_core/database/model_spec_tables.py
@@ -37,6 +37,8 @@ class ModelSpecRead(ModelSpecBase):
     target: FeatureType
     archived: bool = False
     uses_chapkit: bool = False
+    user_option_values: dict | None = None
+    additional_continuous_covariates: list[str] = []
 
 
 target_type = FeatureType(name="disease_cases", display_name="Disease Cases", description="Disease Cases")

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -196,7 +196,7 @@ def test_list_configured_models(celery_session_worker, dependency_overrides):
         logger.info(m)
     assert len(response.json()) > 0
     assert "id" in response.json()[0]
-    for attr_name in ("displayName", "id", "description"):
+    for attr_name in ("displayName", "id", "description", "userOptionValues", "additionalContinuousCovariates"):
         """Check these here to make sure camelCase in response"""
         assert attr_name in response.json()[0], response.json()[0].keys()
     models = [ModelSpecRead.model_validate(m) for m in response.json()]
@@ -205,6 +205,7 @@ def test_list_configured_models(celery_session_worker, dependency_overrides):
     assert "population" in (f.name for f in ewars_model.covariates)
     assert ewars_model.source_url is not None
     assert ewars_model.source_url.startswith("https:/")
+    assert isinstance(ewars_model.additional_continuous_covariates, list)
 
 
 def test_list_model_templates(celery_session_worker, dependency_overrides):


### PR DESCRIPTION
## Summary
- Add `user_option_values` and `additional_continuous_covariates` to `ModelSpecRead` so `GET /v1/crud/configured-models` exposes the same configured-option fields the DETAIL endpoint already returns.
- Both fields are optional with safe defaults (`None` / `[]`); other endpoints that serialize `ModelSpecRead` are unaffected.
- No restructure of the existing wire shape — purely additive, non-breaking.

## Before
```json
{ "id": 1, "name": "chap_ewars_monthly", "displayName": "...", "supportedPeriodType": "month", ... }
```

## After
```json
{ "id": 1, "name": "chap_ewars_monthly", "displayName": "...", "supportedPeriodType": "month", ...,
  "userOptionValues": { "n_lags": 3, "precision": 1 },
  "additionalContinuousCovariates": ["rainfall", "mean_temperature"] }
```

## Test plan
- [x] `test_list_configured_models` extended to assert both new fields are present.
- [x] Full `tests/integration/rest_api/test_db_endpoints.py` suite passes (28 passed, 10 skipped — pre-existing skips for unrelated tests).
- [x] `make lint` clean (mypy + ruff; pre-existing pyright warnings unrelated to this change).
- [x] Manual: `curl -s http://localhost:8000/v1/crud/configured-models | jq '.[0]'` after restarting the dev server, confirm both new fields appear.