### PR TITLE
refactor: standardize on Backtest class naming

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -22,7 +22,7 @@ from chap_core.database.debug import DebugEntry
 from chap_core.database.feature_tables import FeatureSource, FeatureType
 from chap_core.database.model_spec_tables import ModelFeatureLink, ModelSpec
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB, ModelTemplateDB
-from chap_core.database.tables import BackTest, BackTestForecast, BackTestMetric, ConfiguredModelWithDataSource, Prediction, PredictionSamplesEntry
+from chap_core.database.tables import Backtest, BacktestForecast, BacktestMetric, ConfiguredModelWithDataSource, Prediction, PredictionSamplesEntry
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/chap_core/api_types.py
+++ b/chap_core/api_types.py
@@ -80,7 +80,7 @@ class EvaluationEntry(PredictionEntry):
     splitPeriod: str
 
 
-class BackTestParams(DBModel):
+class BacktestParams(DBModel):
     n_periods: int = 3
     n_splits: int = 7
     stride: int = 1

--- a/chap_core/assessment/backtest_plots/__init__.py
+++ b/chap_core/assessment/backtest_plots/__init__.py
@@ -57,7 +57,7 @@ import altair as alt
 if TYPE_CHECKING:
     import pandas as pd
 
-    from chap_core.database.tables import BackTest
+    from chap_core.database.tables import Backtest
 
 # Type alias for Altair chart types that plots can return
 ChartType = alt.Chart | alt.VConcatChart | alt.FacetChart | alt.LayerChart | alt.HConcatChart
@@ -210,18 +210,18 @@ def list_backtest_plots() -> list[dict]:
     ]
 
 
-def create_plot_from_backtest(plot_id: str, backtest: BackTest) -> ChartType:
+def create_plot_from_backtest(plot_id: str, backtest: Backtest) -> ChartType:
     """
-    Create a plot from a BackTest object.
+    Create a plot from a Backtest object.
 
-    This function handles conversion from BackTest to flat DataFrames and
+    This function handles conversion from Backtest to flat DataFrames and
     instantiates the appropriate plot class.
 
     Parameters
     ----------
     plot_id : str
         The unique identifier of the plot to create
-    backtest : BackTest
+    backtest : Backtest
         The backtest object containing forecast and observation data
 
     Returns
@@ -241,7 +241,7 @@ def create_plot_from_backtest(plot_id: str, backtest: BackTest) -> ChartType:
         available = ", ".join(_backtest_plots_registry.keys())
         raise ValueError(f"Unknown plot type: {plot_id}. Available: {available}")
 
-    # Convert BackTest to flat DataFrames via Evaluation
+    # Convert Backtest to flat DataFrames via Evaluation
     evaluation = Evaluation.from_backtest(backtest)
     flat_data = evaluation.to_flat()
 

--- a/chap_core/assessment/backtest_plots/evaluation_plot.py
+++ b/chap_core/assessment/backtest_plots/evaluation_plot.py
@@ -247,5 +247,5 @@ class EvaluationPlot(BacktestPlotBase):
         return (  # type: ignore[no-any-return]
             full_layer.facet(column="split_period:O", row="location:N")
             .resolve_scale(y="independent")
-            .properties(title="BackTest Forecasts with Observations")
+            .properties(title="Backtest Forecasts with Observations")
         )

--- a/chap_core/assessment/data_representation_transforming.py
+++ b/chap_core/assessment/data_representation_transforming.py
@@ -14,10 +14,10 @@ from chap_core.assessment.representations import (
     Samples,
 )
 from chap_core.database.dataset_tables import ObservationBase
-from chap_core.database.tables import BackTestForecast
+from chap_core.database.tables import BacktestForecast
 
 
-def convert_to_multi_location_forecast(backTestList: list[BackTestForecast]) -> dict[str, MultiLocationForecast]:
+def convert_to_multi_location_forecast(backTestList: list[BacktestForecast]) -> dict[str, MultiLocationForecast]:
     # Group samples by location
     all_splitpoint_timeseries = {}
     backTestList = sorted(backTestList, key=lambda x: x.last_seen_period)
@@ -28,7 +28,7 @@ def convert_to_multi_location_forecast(backTestList: list[BackTestForecast]) -> 
     return all_splitpoint_timeseries
 
 
-def convert_single_splitpoint_to_multi_location_forecast(backTestList: list[BackTestForecast]) -> MultiLocationForecast:
+def convert_single_splitpoint_to_multi_location_forecast(backTestList: list[BacktestForecast]) -> MultiLocationForecast:
     location_forecasts: dict[str, list[Samples]] = defaultdict(list)
     for forecast in backTestList:
         location_key = str(forecast.org_unit)  # Or use forecast.backtest.location if available

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -19,7 +19,7 @@ import xarray as xr
 from packaging.version import Version
 
 if TYPE_CHECKING:
-    from chap_core.api_types import BackTestParams
+    from chap_core.api_types import BacktestParams
 
 from chap_core.assessment.flat_representations import (
     FlatForecasts,
@@ -30,10 +30,10 @@ from chap_core.assessment.flat_representations import (
 from chap_core.data import DataSet as _DataSet
 from chap_core.database.dataset_tables import DataSet, Observation, ObservationBase
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
-from chap_core.database.tables import BackTest, BackTestForecast
+from chap_core.database.tables import Backtest, BacktestForecast
 from chap_core.datatypes import SamplesWithTruth
 from chap_core.external.model_configuration import ModelTemplateConfigV2
-from chap_core.rest_api.data_models import BackTestCreate
+from chap_core.rest_api.data_models import BacktestCreate
 from chap_core.time_period import TimePeriod
 
 try:
@@ -218,14 +218,14 @@ class EvaluationBase(ABC):
 
     @classmethod
     @abstractmethod
-    def from_backtest(cls, backtest: "BackTest") -> "EvaluationBase":
+    def from_backtest(cls, backtest: "Backtest") -> "EvaluationBase":
         """
-        Create Evaluation from database BackTest object.
+        Create Evaluation from database Backtest object.
 
         All implementations must support loading from database.
 
         Args:
-            backtest: Database BackTest object (with relationships loaded)
+            backtest: Database Backtest object (with relationships loaded)
 
         Returns:
             Evaluation instance
@@ -238,29 +238,29 @@ class EvaluationBase(ABC):
         evaluation_results: Iterable[_DataSet[SamplesWithTruth]],
         last_train_period: TimePeriod,
         configured_model: ConfiguredModelDB,
-        info: "BackTestCreate",
+        info: "BacktestCreate",
     ) -> "EvaluationBase": ...
 
 
 class Evaluation(EvaluationBase):
     """
-    Evaluation implementation backed by database BackTest model.
+    Evaluation implementation backed by database Backtest model.
 
-    This wraps an existing BackTest object and provides the
+    This wraps an existing Backtest object and provides the
     EvaluationBase interface without modifying the database schema.
     """
 
     def __init__(
         self,
-        backtest: "BackTest",
+        backtest: "Backtest",
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
     ):
         """
-        Initialize Evaluation with a BackTest object.
+        Initialize Evaluation with a Backtest object.
 
         Args:
-            backtest: Database BackTest object (with relationships loaded)
+            backtest: Database Backtest object (with relationships loaded)
             historical_observations: Optional list of Observation objects for historical
                 context (periods before split points, for plotting)
             historical_context_periods: Number of periods of historical context stored
@@ -271,15 +271,15 @@ class Evaluation(EvaluationBase):
         self._flat_data_cache: FlatEvaluationData | None = None
 
     @classmethod
-    def from_backtest(cls, backtest: "BackTest") -> "Evaluation":
+    def from_backtest(cls, backtest: "Backtest") -> "Evaluation":
         """
-        Create Evaluation from database BackTest object.
+        Create Evaluation from database Backtest object.
 
         Args:
-            backtest: Database BackTest object (with relationships loaded)
+            backtest: Database Backtest object (with relationships loaded)
 
         Returns:
-            Evaluation instance wrapping the BackTest
+            Evaluation instance wrapping the Backtest
         """
         return cls(backtest)
 
@@ -289,12 +289,12 @@ class Evaluation(EvaluationBase):
         evaluation_results: Iterable[_DataSet[SamplesWithTruth]],
         last_train_period: TimePeriod,
         configured_model: ConfiguredModelDB,
-        info: BackTestCreate,
+        info: BacktestCreate,
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
     ) -> "Evaluation":
         info.created = datetime.datetime.now()
-        backtest = BackTest(
+        backtest = Backtest(
             **info.model_dump()
             | {"model_db_id": configured_model.id, "model_template_version": configured_model.model_template.version}
         )
@@ -312,7 +312,7 @@ class Evaluation(EvaluationBase):
                     eval_result.period_range, samples_with_truth.samples, samples_with_truth.disease_cases, strict=False
                 ):
                     # add forecast series for this period
-                    forecast = BackTestForecast(
+                    forecast = BacktestForecast(
                         period=period.id,
                         org_unit=location,
                         last_train_period=last_train_period.id,
@@ -364,7 +364,7 @@ class Evaluation(EvaluationBase):
         configured_model: ConfiguredModelDB,
         estimator,
         dataset: _DataSet,
-        backtest_params: "BackTestParams",
+        backtest_params: "BacktestParams",
         backtest_name: str = "evaluation",
         historical_context_years: int = 6,
     ) -> "Evaluation":
@@ -406,7 +406,7 @@ class Evaluation(EvaluationBase):
         )
         last_train_period = train.period_range[-1]
 
-        backtest_info = BackTestCreate(
+        backtest_info = BacktestCreate(
             name=backtest_name,
             dataset_id=0,
             model_id=configured_model.id,
@@ -526,12 +526,12 @@ class Evaluation(EvaluationBase):
 
         return observations
 
-    def to_backtest(self) -> "BackTest":
+    def to_backtest(self) -> "Backtest":
         """
-        Get underlying database BackTest object.
+        Get underlying database Backtest object.
 
         Returns:
-            BackTest database model
+            Backtest database model
         """
         return self._backtest
 
@@ -568,7 +568,7 @@ class Evaluation(EvaluationBase):
 
     def get_org_units(self) -> list[str]:
         """
-        Get locations from BackTest metadata.
+        Get locations from Backtest metadata.
 
         Returns:
             List of location identifiers
@@ -577,7 +577,7 @@ class Evaluation(EvaluationBase):
 
     def get_split_periods(self) -> list[str]:
         """
-        Get split periods from BackTest metadata.
+        Get split periods from Backtest metadata.
 
         Returns:
             List of period identifiers
@@ -624,7 +624,7 @@ class Evaluation(EvaluationBase):
         """
         Load evaluation from NetCDF file.
 
-        Creates an in-memory BackTest object without database persistence.
+        Creates an in-memory Backtest object without database persistence.
 
         Args:
             filepath: Path to NetCDF file
@@ -642,7 +642,7 @@ class Evaluation(EvaluationBase):
         org_units = json.loads(ds.attrs.get("org_units", "[]"))
         historical_context_periods = int(ds.attrs.get("historical_context_periods", 0))
 
-        backtest = BackTest(
+        backtest = Backtest(
             name=f"Loaded from {Path(filepath).name}",
             org_units=org_units,
             split_periods=split_periods,
@@ -652,7 +652,7 @@ class Evaluation(EvaluationBase):
 
         forecasts_df = pd.DataFrame(cast("pd.DataFrame", flat_data.forecasts))
 
-        # Group by (location, time_period, horizon_distance) to create BackTestForecast objects
+        # Group by (location, time_period, horizon_distance) to create BacktestForecast objects
         for (location, time_period, horizon_distance), group in forecasts_df.groupby(
             ["location", "time_period", "horizon_distance"]
         ):
@@ -663,7 +663,7 @@ class Evaluation(EvaluationBase):
             # Get all sample values for this forecast, sorted by sample number
             values = group.sort_values("sample")["forecast"].tolist()
 
-            forecast = BackTestForecast(
+            forecast = BacktestForecast(
                 period=time_period,
                 org_unit=location,
                 last_seen_period=last_seen_period.id,
@@ -734,7 +734,7 @@ class ModelCard:
 
     def __init__(
         self,
-        backtest: "BackTest",
+        backtest: "Backtest",
         description: str | None = None,
     ):
         self.backtest = backtest

--- a/chap_core/assessment/flat_representations.py
+++ b/chap_core/assessment/flat_representations.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from chap_core.database.dataset_tables import ObservationBase
-    from chap_core.database.tables import BackTestForecast
+    from chap_core.database.tables import BacktestForecast
 
 
 class FlatData(DataFrameModel):
@@ -64,13 +64,13 @@ def horizon_diff(period: str, period2: str) -> int:
     return int((tp - tp2) // tp.time_delta) + 1
 
 
-def _convert_backtest_to_flat_forecasts(backtest_forecasts: list[BackTestForecast]) -> pd.DataFrame:
+def _convert_backtest_to_flat_forecasts(backtest_forecasts: list[BacktestForecast]) -> pd.DataFrame:
     """
-    Convert a list of BackTestForecast objects to a flat DataFrame format
+    Convert a list of BacktestForecast objects to a flat DataFrame format
     conforming to ForecastFlatDataSchema.
 
     Args:
-        backtest_forecasts: List of BackTestForecast objects containing forecasts
+        backtest_forecasts: List of BacktestForecast objects containing forecasts
 
     Returns:
         pd.DataFrame with columns: location, time_period, horizon_distance, sample, forecast
@@ -83,7 +83,7 @@ def _convert_backtest_to_flat_forecasts(backtest_forecasts: list[BackTestForecas
         # from the last period we had data for
         horizon_distance = horizon_diff(str(forecast.period), str(forecast.last_seen_period))
 
-        # Each BackTestForecast contains multiple sample values
+        # Each BacktestForecast contains multiple sample values
         # We need to create one row per sample
 
         df = _create_df(forecast, horizon_distance)
@@ -114,7 +114,7 @@ def _convert_backtest_to_flat_forecasts(backtest_forecasts: list[BackTestForecas
     return pd.DataFrame(df)
 
 
-def _create_df(forecast: BackTestForecast, horizon_distance: int):
+def _create_df(forecast: BacktestForecast, horizon_distance: int):
     df = pd.DataFrame(
         {
             "location": str(forecast.org_unit),
@@ -128,7 +128,7 @@ def _create_df(forecast: BackTestForecast, horizon_distance: int):
 
 
 def convert_backtest_to_flat_forecasts(
-    backtest_forecasts: list[BackTestForecast], *, validate: bool = True
+    backtest_forecasts: list[BacktestForecast], *, validate: bool = True
 ) -> pd.DataFrame:
     import numpy as np
     import pandas as pd

--- a/chap_core/assessment/metric_table.py
+++ b/chap_core/assessment/metric_table.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from chap_core.database.tables import BackTestMetric
+from chap_core.database.tables import BacktestMetric
 from chap_core.time_period import TimePeriod
 
 
@@ -11,7 +11,7 @@ def horizon_diff(period: str, period2: str) -> int:
     return int((tp - tp2) // tp.time_delta) + 1
 
 
-def create_metric_table(metrics: list[BackTestMetric]):
+def create_metric_table(metrics: list[BacktestMetric]):
     colnames = ["period", "org_unit", "value", "last_seen_period"]
     df = pd.DataFrame([metric.model_dump() for metric in metrics], columns=colnames)
     df["horizon"] = [horizon_diff(metric.period, metric.last_seen_period) for metric in metrics]

--- a/chap_core/assessment/metrics/__init__.py
+++ b/chap_core/assessment/metrics/__init__.py
@@ -23,7 +23,7 @@ from chap_core.assessment.metrics.base import (
     MetricSpec,
     ProbabilisticMetric,
 )
-from chap_core.database.tables import BackTest
+from chap_core.database.tables import Backtest
 
 logger = logging.getLogger(__name__)
 
@@ -166,12 +166,12 @@ __all__ = [
 ]
 
 
-def compute_all_aggregated_metrics_from_backtest(backtest: BackTest) -> dict[str, float]:
+def compute_all_aggregated_metrics_from_backtest(backtest: Backtest) -> dict[str, float]:
     """
     Compute all available metrics as global aggregated values for a backtest.
 
     Args:
-        backtest: The BackTest object to compute metrics for
+        backtest: The Backtest object to compute metrics for
 
     Returns:
         Dictionary mapping metric_id to the aggregated metric value

--- a/chap_core/cli_endpoints/_common.py
+++ b/chap_core/cli_endpoints/_common.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     import pandas as pd
 
-    from chap_core.api_types import BackTestParams
+    from chap_core.api_types import BacktestParams
     from chap_core.database.model_templates_and_config_tables import ModelConfiguration
     from chap_core.hpo.hpoModel import HpoModel
     from chap_core.hpo.searcher import Searcher
@@ -249,7 +249,7 @@ def get_estimator(
 def get_hpo_estimator(
     template: ModelTemplate,
     model_configuration_yaml: Path | None,
-    backtest_params: BackTestParams,
+    backtest_params: BacktestParams,
     metric: str,
     searcher: Searcher | None = None,
 ) -> HpoModel:

--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Annotated
 
 from cyclopts import Parameter
 
-from chap_core.api_types import BackTestParams, EstimatorMode, EstimatorOptions, RunConfig
+from chap_core.api_types import BacktestParams, EstimatorMode, EstimatorOptions, RunConfig
 from chap_core.cli_endpoints._common import (
     discover_geojson,
     get_estimator,
@@ -45,13 +45,13 @@ def eval_cmd(
         Parameter(help="Path for output NetCDF file containing evaluation results (.nc extension)"),
     ],
     backtest_params: Annotated[
-        BackTestParams,
+        BacktestParams,
         Parameter(
             help="Backtest configuration. Use --backtest-params.n-periods for forecast horizon, "
             "--backtest-params.n-splits for number of train/test splits, "
             "--backtest-params.stride for step size between splits"
         ),
-    ] = BackTestParams(n_periods=3, n_splits=7, stride=1),
+    ] = BacktestParams(n_periods=3, n_splits=7, stride=1),
     run_config: Annotated[
         RunConfig,
         Parameter(

--- a/chap_core/cli_endpoints/generate_modelcard.py
+++ b/chap_core/cli_endpoints/generate_modelcard.py
@@ -12,7 +12,7 @@ from cyclopts import Parameter
 
 if TYPE_CHECKING:
     from chap_core.assessment.evaluation import Evaluation
-    from chap_core.database.tables import BackTest
+    from chap_core.database.tables import Backtest
     from chap_core.external.model_configuration import ModelTemplateConfigV2
 
 CHAP_VERSION = importlib.metadata.version("chap-core")
@@ -237,7 +237,7 @@ def _save_evaluation_plots(evaluation: Evaluation, output_dir: Path, geojson_pat
         mape_map_plot.save(output_dir / "mape_map.html", scale_factor=2.0)
 
 
-def _build_results_summary(backtest: BackTest) -> str:
+def _build_results_summary(backtest: Backtest) -> str:
     from chap_core.assessment.metrics import compute_all_aggregated_metrics_from_backtest
 
     metrics = compute_all_aggregated_metrics_from_backtest(backtest)

--- a/chap_core/cli_endpoints/preference_learn.py
+++ b/chap_core/cli_endpoints/preference_learn.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal, cast
 
 from pydantic import BaseModel
 
-from chap_core.api_types import BackTestParams, RunConfig
+from chap_core.api_types import BacktestParams, RunConfig
 from chap_core.cli_endpoints._common import (
     discover_geojson,
     load_dataset_from_csv,
@@ -71,7 +71,7 @@ def _compute_metrics(evaluation: Evaluation) -> dict:
 def _create_evaluation(
     model_candidate: ModelCandidate,
     dataset,
-    backtest_params: BackTestParams,
+    backtest_params: BacktestParams,
     run_config: RunConfig,
 ) -> Evaluation:
     """
@@ -141,7 +141,7 @@ def preference_learn(
     dataset_csv: Path,
     search_space_yaml: Path | None = None,
     state_file: Path = Path("preference_state.json"),
-    backtest_params: BackTestParams = BackTestParams(n_periods=3, n_splits=7, stride=1),
+    backtest_params: BacktestParams = BacktestParams(n_periods=3, n_splits=7, stride=1),
     run_config: RunConfig = RunConfig(),
     learning_params: PreferenceLearningParams = PreferenceLearningParams(),
 ):

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -30,7 +30,7 @@ from .dataset_tables import DataSet, DataSetCreateInfo, DataSetInfo, Observation
 from .debug import DebugEntry
 from .model_spec_tables import ModelSpecRead
 from .model_templates_and_config_tables import ConfiguredModelDB, ModelConfiguration, ModelTemplateDB
-from .tables import BackTest, Prediction, PredictionSamplesEntry
+from .tables import Backtest, Prediction, PredictionSamplesEntry
 
 logger = logging.getLogger(__name__)
 engine = None
@@ -414,8 +414,8 @@ class SessionWrapper:
             raise ValueError(f"Model template with id {model_template_id} not found")
         return model_template
 
-    def get_backtest_with_truth(self, backtest_id: int) -> BackTest:
-        backtest = self.session.get(BackTest, backtest_id)
+    def get_backtest_with_truth(self, backtest_id: int) -> Backtest:
+        backtest = self.session.get(Backtest, backtest_id)
         if backtest is None:
             raise ValueError(f"Backtest with id {backtest_id} not found")
         dataset = backtest.dataset
@@ -426,7 +426,7 @@ class SessionWrapper:
             raise ValueError(f"No forecasts found for backtest with id {backtest_id}")
         return backtest
 
-    def add_backtest(self, backtest: BackTest) -> None:
+    def add_backtest(self, backtest: Backtest) -> None:
         self.session.add(backtest)
         self.session.commit()
 

--- a/chap_core/database/tables.py
+++ b/chap_core/database/tables.py
@@ -14,7 +14,7 @@ from chap_core.database.dataset_tables import DataSet, DataSetInfo, DataSource, 
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB, ModelConfiguration, ModelTemplateDB
 
 
-class BackTestBase(DBModel):
+class BacktestBase(DBModel):
     dataset_id: int = Field(foreign_key="dataset.id")
     model_id: str
     name: str | None = None
@@ -30,17 +30,17 @@ class DataSetMeta(DataSetInfo):
     # covariates: List[str]
 
 
-class _BackTestRead(BackTestBase):
+class _BacktestRead(BacktestBase):
     id: int
     org_units: list[str] = Field(default_factory=list, sa_column=Column(JSON))
     split_periods: list[PeriodID] = Field(default_factory=list, sa_column=Column(JSON))
 
 
-class BackTest(_BackTestRead, table=True):
+class Backtest(_BacktestRead, table=True):
     id: int | None = Field(primary_key=True, default=None)  # type: ignore[assignment]
     dataset: DataSet = Relationship()
-    forecasts: list["BackTestForecast"] = Relationship(back_populates="backtest", cascade_delete=True)
-    metrics: list["BackTestMetric"] = Relationship(back_populates="backtest", cascade_delete=True)
+    forecasts: list["BacktestForecast"] = Relationship(back_populates="backtest", cascade_delete=True)
+    metrics: list["BacktestMetric"] = Relationship(back_populates="backtest", cascade_delete=True)
     aggregate_metrics: dict[str, float] = Field(default_factory=dict, sa_column=Column(JSON))
     model_db_id: int = Field(foreign_key="configuredmodeldb.id")
     configured_model: Optional["ConfiguredModelDB"] = Relationship()
@@ -79,10 +79,10 @@ class ConfiguredModelWithDataSourceRead(DBModel):
     period_type: str | None
 
 
-OldBackTestRead = _BackTestRead
+OldBacktestRead = _BacktestRead
 
 
-class BackTestRead(_BackTestRead):
+class BacktestRead(_BacktestRead):
     dataset: DataSetMeta
     aggregate_metrics: dict[str, float]
     configured_model: ConfiguredModelRead | None
@@ -148,15 +148,15 @@ class PredictionSamplesEntry(ForecastBase, table=True):
     prediction: "Prediction" = Relationship(back_populates="forecasts")
 
 
-class BackTestForecast(ForecastBase, table=True):
+class BacktestForecast(ForecastBase, table=True):
     id: int | None = Field(primary_key=True, default=None)
     backtest_id: int = Field(foreign_key="backtest.id")
     last_train_period: PeriodID
     last_seen_period: PeriodID
-    backtest: BackTest = Relationship(back_populates="forecasts")
+    backtest: Backtest = Relationship(back_populates="forecasts")
 
 
-class BackTestMetric(DBModel, table=True):
+class BacktestMetric(DBModel, table=True):
     """
     This class has been used when computing metrics per location/time_point/split_point adhoc
     in database.py. This id depcrecated and not used in the new metric system.
@@ -171,26 +171,26 @@ class BackTestMetric(DBModel, table=True):
     last_train_period: PeriodID
     last_seen_period: PeriodID
     value: float
-    backtest: BackTest = Relationship(back_populates="metrics")
+    backtest: Backtest = Relationship(back_populates="metrics")
 
 
 # def test():
 #     engine = create_engine("sqlite://")
 #     DBModel.metadata.create_all(engine)
 #     with Session(engine) as session:
-#         backtest = BackTest(dataset_id="dataset_id", model_id="model_id")
-#         forecast = BackTestForecast(
+#         backtest = Backtest(dataset_id="dataset_id", model_id="model_id")
+#         forecast = BacktestForecast(
 #             period="202101",
 #             org_unity="RegionA",
 #             last_train_period="202012",
 #             last_seen_period="202012",
 #             values=[1.0, 2.0, 3.0],
 #         )
-#         metric = BackTestMetric(
+#         metric = BacktestMetric(
 #             metric_id="metric_id", period="202101", last_train_period="202012", last_seen_period="202012", value=0.5
 #         )
 #         backtest.forecasts.append(forecast)
 #         backtest.metrics.append(metric)
 #         session.add(backtest)
 #         session.commit()
-#         print(session.exec(select(BackTestForecast)).all())
+#         print(session.exec(select(BacktestForecast)).all())

--- a/chap_core/hpo/objective.py
+++ b/chap_core/hpo/objective.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from uuid import uuid4
 
-from chap_core.api_types import BackTestParams
+from chap_core.api_types import BacktestParams
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metrics import calculate_metrics
 from chap_core.database.model_templates_and_config_tables import ModelConfiguration
@@ -17,7 +17,7 @@ class Objective:
     def __init__(
         self,
         model_template: ModelTemplate,
-        backtest_params: BackTestParams,
+        backtest_params: BacktestParams,
         metric: str = "rmse",
         historical_context_years: int = 6,
         eval_output_dir: Path | None = None,

--- a/chap_core/plotting/evaluation_plot.py
+++ b/chap_core/plotting/evaluation_plot.py
@@ -7,7 +7,7 @@ import pandas as pd
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metrics.base import Metric
 from chap_core.database.base_tables import DBModel
-from chap_core.database.tables import BackTest
+from chap_core.database.tables import Backtest
 
 alt.renderers.enable("browser")
 
@@ -298,7 +298,7 @@ class MetricMapV2(MetricPlotV2):
 
 
 def make_plot_from_backtest_object(
-    backtest: BackTest, plotting_class: type[MetricPlotV2], metric: Metric, geojson: dict | None = None
+    backtest: Backtest, plotting_class: type[MetricPlotV2], metric: Metric, geojson: dict | None = None
 ) -> dict:
     # Convert to flat representation using Evaluation abstraction
     evaluation = Evaluation.from_backtest(backtest)

--- a/chap_core/plotting/produce_plots_from_yaml.py
+++ b/chap_core/plotting/produce_plots_from_yaml.py
@@ -145,7 +145,7 @@ def build_from_yaml(yaml_str: str, backtest, **context):
     else:
         if backtest is None:
             raise ValueError(
-                "build_from_yaml: either provide a real BackTest or pass "
+                "build_from_yaml: either provide a real Backtest or pass "
                 "'flat_observations' and 'flat_forecasts' in context."
             )
         evaluation = Evaluation.from_backtest(backtest)
@@ -225,7 +225,7 @@ class DatasetStub:
         self.observations = observations
 
 
-class BackTestStub:
+class BacktestStub:
     def __init__(self, forecasts, dataset):
         self.forecasts = forecasts
         self.dataset = dataset

--- a/chap_core/plotting/yaml_plot.py
+++ b/chap_core/plotting/yaml_plot.py
@@ -7,7 +7,7 @@ import yaml
 
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metrics import available_metrics
-from chap_core.database.tables import BackTest
+from chap_core.database.tables import Backtest
 from chap_core.plotting.evaluation_plot import (
     MetricByHorizonAndLocationMean,
     MetricByHorizonV2Mean,
@@ -151,14 +151,14 @@ def _build_plot_component(comp: dict, context: dict):
     return text_chart(f"Unknown plot kind: {comp_type}", line_length=60)
 
 
-def build_from_yaml(yaml_str: str, backtest: BackTest, **context):
+def build_from_yaml(yaml_str: str, backtest: Backtest, **context):
     configuration = yaml.safe_load(yaml_str)
 
     title = configuration.get("title")
     rows_spec = configuration.get("configuration", [])
 
     if backtest is None:
-        raise ValueError("build_from_yaml requires a real BackTest object.")
+        raise ValueError("build_from_yaml requires a real Backtest object.")
 
     evaluation = Evaluation.from_backtest(backtest)
     flat_data = evaluation.to_flat()

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -1,13 +1,13 @@
 from pydantic import BaseModel
 
-from chap_core.api_types import BackTestParams, FeatureCollectionModel
+from chap_core.api_types import BacktestParams, FeatureCollectionModel
 from chap_core.database.base_tables import DBModel
 from chap_core.database.dataset_tables import DataSetCreateInfo, ObservationBase
 from chap_core.database.model_templates_and_config_tables import (
     ModelTemplateInformation,
     ModelTemplateMetaData,
 )
-from chap_core.database.tables import BackTestBase, BackTestForecast, BackTestMetric, BackTestRead
+from chap_core.database.tables import BacktestBase, BacktestForecast, BacktestMetric, BacktestRead
 
 
 class PredictionBase(BaseModel):
@@ -62,9 +62,9 @@ class ImportSummaryResponse(DBModel):
     rejected: list[ValidationError]
 
 
-class BackTestCreate(BackTestBase):
+class BacktestCreate(BacktestBase):
     # Accept either the configured-model integer primary key or its string
-    # name. The underlying DB column (`BackTestBase.model_id`) is a string,
+    # name. The underlying DB column (`BacktestBase.model_id`) is a string,
     # but the `POST /v1/crud/backtests/` handler resolves an `int` to the
     # corresponding name before persisting so the column stays consistent.
     # See `chap_core.rest_api.v1.routers.crud.create_backtest` for the
@@ -72,9 +72,9 @@ class BackTestCreate(BackTestBase):
     model_id: int | str  # type: ignore[assignment]
 
 
-class BackTestFull(BackTestRead):
-    metrics: list[BackTestMetric]
-    forecasts: list[BackTestForecast]
+class BacktestFull(BacktestRead):
+    metrics: list[BacktestMetric]
+    forecasts: list[BacktestForecast]
 
 
 class BacktestDomain(DBModel):
@@ -94,13 +94,13 @@ class MakePredictionRequest(DatasetMakeRequest, PredictionParams):
     meta_data: dict = {}
 
 
-class MakeBacktestRequest(BackTestParams):
+class MakeBacktestRequest(BacktestParams):
     name: str
     model_id: str
     dataset_id: int
 
 
-class MakeBacktestWithDataRequest(DatasetMakeRequest, BackTestParams):
+class MakeBacktestWithDataRequest(DatasetMakeRequest, BacktestParams):
     name: str
     model_id: str
 
@@ -163,5 +163,5 @@ class PredictionCreate(DBModel):
     n_periods: int
 
 
-class BackTestUpdate(DBModel):
+class BacktestUpdate(DBModel):
     name: str | None = None

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -6,7 +6,7 @@ from typing import get_type_hints
 import numpy as np
 from pydantic import BaseModel
 
-from chap_core.api_types import BackTestParams
+from chap_core.api_types import BacktestParams
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.forecast import forecast_ahead
 from chap_core.assessment.metrics import compute_all_aggregated_metrics_from_backtest
@@ -17,9 +17,9 @@ from chap_core.database.database import SessionWrapper
 from chap_core.database.dataset_tables import DataSetCreateInfo
 from chap_core.datatypes import HealthPopulationData, create_tsdataclass
 from chap_core.log_config import get_status_logger
-from chap_core.rest_api.data_models import BackTestCreate, FetchRequest, PredictionParams
+from chap_core.rest_api.data_models import BacktestCreate, FetchRequest, PredictionParams
 
-# from chap_core.rest_api.v1.routers.crud import BackTestCreate
+# from chap_core.rest_api.v1.routers.crud import BacktestCreate
 from chap_core.rest_api.worker_functions import WorkerConfig, harmonize_health_dataset
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 from chap_core.time_period import Month
@@ -76,7 +76,7 @@ def validate_and_filter_dataset_for_evaluation(
 
 # @convert_dicts_to_models
 def run_backtest(
-    info: BackTestCreate,
+    info: BacktestCreate,
     n_periods: int | None = None,
     n_splits: int = 10,
     stride: int = 1,
@@ -131,7 +131,7 @@ def run_backtest(
     # Populate the global aggregate metric values on the backtest row so that
     # GET /v1/crud/backtests/{id}/full can return CRPS/MAPE/RMSE/etc without
     # the caller needing to round-trip through /v1/visualization/metric-plots.
-    # Per-forecast samples on BackTestForecast remain the source of truth for
+    # Per-forecast samples on BacktestForecast remain the source of truth for
     # the visualization path; a failure here must not tank the whole backtest.
     # This runs AFTER add_backtest because compute_all_aggregated_metrics_from_backtest
     # reads `backtest.dataset.observations` via the Evaluation abstraction, and the
@@ -265,13 +265,13 @@ def run_backtest_from_dataset(
     backtest_name: str,
     model_id: str,
     dataset_info: DataSetCreateInfo,
-    backtest_params: BackTestParams,
+    backtest_params: BacktestParams,
     session: SessionWrapper,
     worker_config=WorkerConfig(),
 ) -> int:
     ds = InMemoryDataSet.from_dict(provided_data_model_dump, create_tsdataclass(feature_names))
     dataset_id = session.add_dataset(dataset_info=dataset_info, orig_dataset=ds, polygons=ds.polygons.model_dump_json())
-    backtest_create_info = BackTestCreate(name=backtest_name, dataset_id=dataset_id, model_id=model_id)
+    backtest_create_info = BacktestCreate(name=backtest_name, dataset_id=dataset_id, model_id=model_id)
     if ds.frequency == "W" and backtest_params.stride < 4:
         logging.warning("Setting stride to 4 since its weekly data")
         backtest_params.stride = 4

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -8,7 +8,7 @@ from sqlmodel import Session, select
 
 import chap_core.rest_api.db_worker_functions as wf
 from chap_core.api_types import (
-    BackTestParams,
+    BacktestParams,
     DataElement,
     DataList,
     EvaluationEntry,
@@ -19,7 +19,7 @@ from chap_core.assessment.dataset_splitting import train_test_generator
 from chap_core.database.dataset_tables import DataSet as DataSetTable
 from chap_core.database.dataset_tables import DataSetCreateInfo, Observation
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
-from chap_core.database.tables import BackTest, BackTestForecast, ConfiguredModelWithDataSource, Prediction
+from chap_core.database.tables import Backtest, BacktestForecast, ConfiguredModelWithDataSource, Prediction
 from chap_core.datatypes import create_tsdataclass
 from chap_core.rest_api.experimental import api_experimental
 from chap_core.spatio_temporal_data.converters import observations_to_dataset
@@ -27,9 +27,9 @@ from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 
 from ...celery_tasks import JOB_NAME_KW, JOB_TYPE_KW, CeleryPool, JobType
 from ...data_models import (
-    BackTestCreate,
+    BacktestCreate,
     BacktestDomain,
-    BackTestRead,
+    BacktestRead,
     ChapDataSource,
     DatasetMakeRequest,
     ImportSummaryResponse,
@@ -183,27 +183,27 @@ def _filter_dataset_by_locations(
     return dataset.__class__(new_data, polygons=dataset.polygons, metadata=dataset.metadata)
 
 
-@router.get("/compatible-backtests/{backtestId}", response_model=list[BackTestRead], tags=["Backtests"])
+@router.get("/compatible-backtests/{backtestId}", response_model=list[BacktestRead], tags=["Backtests"])
 def get_compatible_backtests(
     backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)
 ):
     """Return a list of backtests that are compatible for comparison with the given backtest"""
     logger.info(f"Checking compatible backtests for {backtest_id}")
-    backtest = session.get(BackTest, backtest_id)
+    backtest = session.get(Backtest, backtest_id)
     if backtest is None:
-        raise HTTPException(status_code=404, detail="BackTest not found")
+        raise HTTPException(status_code=404, detail="Backtest not found")
     org_units = set(backtest.org_units)
     split_periods = set(backtest.split_periods)
     res = session.exec(
-        select(BackTest.id, BackTest.org_units, BackTest.split_periods).where(BackTest.id != backtest_id)
+        select(Backtest.id, Backtest.org_units, Backtest.split_periods).where(Backtest.id != backtest_id)
     ).all()
     ids = [bt_id for bt_id, o, s in res if set(o) & org_units and set(s) & split_periods]
     backtests = session.exec(
-        select(BackTest)
-        .where(BackTest.id.in_(ids))  # type: ignore[union-attr, attr-defined]
+        select(Backtest)
+        .where(Backtest.id.in_(ids))  # type: ignore[union-attr, attr-defined]
         .options(
-            selectinload(BackTest.dataset).defer(DataSetTable.geojson),  # type: ignore[arg-type]
-            selectinload(BackTest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
+            selectinload(Backtest.dataset).defer(DataSetTable.geojson),  # type: ignore[arg-type]
+            selectinload(Backtest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
         )
     ).all()
     return backtests
@@ -216,12 +216,12 @@ def get_backtest_overlap(
     session: Session = Depends(get_session),
 ):
     """Return the org units and split periods that are common between two backtests"""
-    backtest1 = session.get(BackTest, backtest_id1)
-    backtest2 = session.get(BackTest, backtest_id2)
+    backtest1 = session.get(Backtest, backtest_id1)
+    backtest2 = session.get(Backtest, backtest_id2)
     if backtest1 is None:
-        raise HTTPException(status_code=404, detail="BackTest 1 not found")
+        raise HTTPException(status_code=404, detail="Backtest 1 not found")
     if backtest2 is None:
-        raise HTTPException(status_code=404, detail="BackTest 2 not found")
+        raise HTTPException(status_code=404, detail="Backtest 2 not found")
     org_units1 = list(set(backtest1.org_units) & set(backtest2.org_units))
     split_periods1 = list(set(backtest1.split_periods) & set(backtest2.split_periods))
     return BacktestDomain(org_units=org_units1, split_periods=split_periods1)
@@ -272,15 +272,15 @@ async def get_evaluation_entries(
         f"Backtest ID: {backtest_id}, Quantiles: {quantiles}, Split Period: {split_period}, Org Units: {org_units} "
     )
     if backtest_id is not None:
-        backtest = session.get(BackTest, backtest_id)
+        backtest = session.get(Backtest, backtest_id)
     if backtest is None:
-        raise HTTPException(status_code=404, detail="BackTest not found")
+        raise HTTPException(status_code=404, detail="Backtest not found")
     org_units_set: set[str] | None = None
     if org_units is not None:
         org_units_set = set(org_units)
         logger.info("Filtering evaluation entries to org_units: %s", org_units_set)
 
-    cls = BackTestForecast
+    cls = BacktestForecast
     expr = select(cls).where(cls.backtest_id == backtest_id)
     if split_period:
         expr = expr.where(cls.last_seen_period == split_period)
@@ -290,7 +290,7 @@ async def get_evaluation_entries(
 
     logger.info(forecasts_result)
 
-    forecasts_list: list[BackTestForecast]
+    forecasts_list: list[BacktestForecast]
     if return_summed:
         # sum forecasts over all regions
         summed_forecasts: dict[tuple[str, str], Any] = {}
@@ -301,7 +301,7 @@ async def get_evaluation_entries(
             summed_forecasts[key] += np.array(forecast.values)
 
         forecasts_list = [
-            BackTestForecast(
+            BacktestForecast(
                 period=key[0],
                 org_unit="adm0",
                 last_seen_period=key[1],
@@ -329,7 +329,7 @@ async def get_evaluation_entries(
 async def create_backtest(request: MakeBacktestRequest, database_url: str = Depends(get_database_url)):
     job = worker.queue_db(
         wf.run_backtest,
-        BackTestCreate(name=request.name, dataset_id=request.dataset_id, model_id=request.model_id),
+        BacktestCreate(name=request.name, dataset_id=request.dataset_id, model_id=request.model_id),
         request.n_periods,
         request.n_splits,
         request.stride,
@@ -464,10 +464,10 @@ async def get_actual_cases(
         # returning sum of forecasts for all regions
         return_summed = True
     if not is_dataset_id:
-        backtest = session.get(BackTest, backtest_id)
+        backtest = session.get(Backtest, backtest_id)
         logger.info(f"Backtest: {backtest}")
         if backtest is None:
-            raise HTTPException(status_code=404, detail="BackTest not found")
+            raise HTTPException(status_code=404, detail="Backtest not found")
         dataset_id = backtest.dataset_id
     else:
         dataset_id = backtest_id
@@ -585,7 +585,7 @@ async def create_backtest_with_data(
 ):
     feature_names, provided_data_processed = _read_dataset(request)
     provided_data_processed, rejections = _validate_full_dataset(feature_names, provided_data_processed)
-    backtest_params = BackTestParams(**request.model_dump())
+    backtest_params = BacktestParams(**request.model_dump())
     train_set, _ = train_test_generator(
         provided_data_processed, backtest_params.n_periods, backtest_params.n_splits, stride=backtest_params.stride
     )
@@ -618,7 +618,7 @@ async def create_backtest_with_data(
             status_code=400, detail="data_to_be_fetched is not supported when providing data for backtest"
         )
 
-    bt_params = BackTestParams(**request.model_dump()).model_dump()
+    bt_params = BacktestParams(**request.model_dump()).model_dump()
     dataset_create_info = DataSetCreateInfo(**request.model_dump()).model_dump()
     dataset_create_info["type"] = "evaluation"
     job = worker.queue_db(

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -42,7 +42,7 @@ from chap_core.database.debug import DebugEntry
 from chap_core.database.model_spec_tables import ModelSpecRead
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB, ModelConfiguration, ModelTemplateDB
 from chap_core.database.tables import (
-    BackTest,
+    Backtest,
     ConfiguredModelWithDataSource,
     ConfiguredModelWithDataSourceRead,
     ConfiguredModelWithDataSourceReadWithPredictions,
@@ -56,9 +56,9 @@ from chap_core.rest_api.experimental import api_experimental
 from chap_core.spatio_temporal_data.converters import observations_to_dataset
 
 from ...data_models import (
-    BackTestCreate,
-    BackTestRead,
-    BackTestUpdate,
+    BacktestCreate,
+    BacktestRead,
+    BacktestUpdate,
     ConfiguredModelInfoRead,
     DataBaseResponse,
     DatasetCreate,
@@ -250,40 +250,40 @@ worker: CeleryPool[Any] = CeleryPool()
 # backtests
 
 
-@router.get("/backtests", response_model=list[BackTestRead], tags=["Backtests"])  # This should be called list
+@router.get("/backtests", response_model=list[BacktestRead], tags=["Backtests"])  # This should be called list
 async def get_backtests(session: Session = Depends(get_session)):
     """
     Returns a list of backtests/evaluations with only the id and name
     """
     backtests = session.exec(
-        select(BackTest).options(
-            selectinload(BackTest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
-            selectinload(BackTest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
+        select(Backtest).options(
+            selectinload(Backtest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
+            selectinload(Backtest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
         )
     ).all()
     return backtests
 
 
-@router_get("/backtests/{backtestId}/full", response_model=BackTest, tags=["Backtests"])
+@router_get("/backtests/{backtestId}/full", response_model=Backtest, tags=["Backtests"])
 async def get_backtest(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
-    backtest = session.get(BackTest, backtest_id)
+    backtest = session.get(Backtest, backtest_id)
     if backtest is None:
-        raise HTTPException(status_code=404, detail="BackTest not found")
+        raise HTTPException(status_code=404, detail="Backtest not found")
     return backtest
 
 
-@router_get("/backtests/{backtestId}/info", response_model=BackTestRead, tags=["Backtests"])
+@router_get("/backtests/{backtestId}/info", response_model=BacktestRead, tags=["Backtests"])
 def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
     backtest = session.exec(
-        select(BackTest)
-        .where(BackTest.id == backtest_id)
+        select(Backtest)
+        .where(Backtest.id == backtest_id)
         .options(
-            selectinload(BackTest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
-            selectinload(BackTest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
+            selectinload(Backtest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
+            selectinload(Backtest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
         )
     ).first()
     if backtest is None:
-        raise HTTPException(status_code=404, detail="BackTest not found")
+        raise HTTPException(status_code=404, detail="Backtest not found")
     return backtest
 
 
@@ -301,9 +301,9 @@ async def get_metrics_csv(
     path is scoped to `/metric/` so it can be extended to accept multiple
     evaluations later without a breaking change.
     """
-    backtest = session.get(BackTest, backtest_id)
+    backtest = session.get(Backtest, backtest_id)
     if backtest is None:
-        raise HTTPException(status_code=404, detail="BackTest not found")
+        raise HTTPException(status_code=404, detail="Backtest not found")
 
     evaluation = Evaluation.from_backtest(backtest)
     df = compute_all_detailed_metrics(evaluation)
@@ -318,8 +318,8 @@ async def get_metrics_csv(
 
 
 @router.post("/backtests", response_model=JobResponse, tags=["Backtests"])
-async def create_backtest(backtest: BackTestCreate, database_url: str = Depends(get_database_url)):
-    # `BackTestCreate.model_id` accepts either the configured-model name
+async def create_backtest(backtest: BacktestCreate, database_url: str = Depends(get_database_url)):
+    # `BacktestCreate.model_id` accepts either the configured-model name
     # (what the DB column actually stores) or the integer primary key (what
     # most API clients reach for because that's what GET /v1/crud/configured-models
     # returns). The worker's run_backtest() normalises int -> name through
@@ -340,23 +340,23 @@ async def create_backtest(backtest: BackTestCreate, database_url: str = Depends(
 async def delete_backtest(
     backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)
 ):
-    backtest = session.get(BackTest, backtest_id)
+    backtest = session.get(Backtest, backtest_id)
     if backtest is None:
-        raise HTTPException(status_code=404, detail="BackTest not found")
+        raise HTTPException(status_code=404, detail="Backtest not found")
     session.delete(backtest)
     session.commit()
     return {"message": "deleted"}
 
 
-@router.patch("/backtests/{backtestId}", response_model=BackTestRead, tags=["Backtests"])
+@router.patch("/backtests/{backtestId}", response_model=BacktestRead, tags=["Backtests"])
 async def update_backtest(
     backtest_id: Annotated[int, Path(alias="backtestId")],
-    backtest_update: BackTestUpdate,
+    backtest_update: BacktestUpdate,
     session: Session = Depends(get_session),
 ):
-    db_backtest = session.get(BackTest, backtest_id)
+    db_backtest = session.get(Backtest, backtest_id)
     if not db_backtest:
-        raise HTTPException(status_code=404, detail="BackTest not found")
+        raise HTTPException(status_code=404, detail="Backtest not found")
 
     update_data = backtest_update.model_dump(exclude_unset=True)
     for key, value in update_data.items():
@@ -367,11 +367,11 @@ async def update_backtest(
 
     # Reload with eager loading to avoid lazy-load issues
     db_backtest = session.exec(
-        select(BackTest)
-        .where(BackTest.id == backtest_id)
+        select(Backtest)
+        .where(Backtest.id == backtest_id)
         .options(
-            selectinload(BackTest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
-            selectinload(BackTest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
+            selectinload(Backtest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
+            selectinload(Backtest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
         )
     ).first()
     return db_backtest
@@ -405,7 +405,7 @@ async def delete_backtest_batch(ids: Annotated[str, Query(alias="ids")], session
             ) from None
 
     for backtest_id in backtest_ids_list:
-        backtest = session.get(BackTest, backtest_id)
+        backtest = session.get(Backtest, backtest_id)
         if backtest is not None:
             session.delete(backtest)
             deleted_count += 1
@@ -700,15 +700,15 @@ async def create_configured_model_with_data_source_from_backtest(
     session: Session = Depends(get_session),
 ):
     backtest = session.exec(
-        select(BackTest)
-        .where(BackTest.id == backtest_id)
+        select(Backtest)
+        .where(Backtest.id == backtest_id)
         .options(
-            selectinload(BackTest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
-            selectinload(BackTest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
+            selectinload(Backtest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
+            selectinload(Backtest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
         )
     ).first()
     if backtest is None:
-        raise HTTPException(status_code=404, detail="BackTest not found")
+        raise HTTPException(status_code=404, detail="Backtest not found")
 
     dataset = backtest.dataset
     record = ConfiguredModelWithDataSource(

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -14,7 +14,7 @@ from chap_core.assessment.backtest_plots import (
 from chap_core.assessment.metrics import available_metrics
 from chap_core.database.base_tables import DBModel
 from chap_core.database.dataset_tables import DataSet
-from chap_core.database.tables import BackTest
+from chap_core.database.tables import Backtest
 from chap_core.plotting.dataset_plot import create_plot_from_dataset, get_dataset_plots_registry, list_dataset_plots
 from chap_core.plotting.evaluation_plot import (
     MetricByHorizonV2Mean,
@@ -80,7 +80,7 @@ def get_available_metrics(backtest_id: int):
 def generate_visualization(
     visualization_name: str, backtest_id: int, metric_id: str, session: Session = Depends(get_session)
 ):
-    backtest = session.get(BackTest, backtest_id)
+    backtest = session.get(Backtest, backtest_id)
     if not backtest:
         return {"error": "Backtest not found"}
 
@@ -127,17 +127,17 @@ def generate_data_plots(visualization_name: str, dataset_id: int, session: Sessi
     return JSONResponse(chart)
 
 
-class BackTestPlotType(DBModel):
+class BacktestPlotType(DBModel):
     id: str
     display_name: str
     description: str = ""
 
 
-@router.get("/backtest-plots/", response_model=list[BackTestPlotType])
+@router.get("/backtest-plots/", response_model=list[BacktestPlotType])
 def list_backtest_plot_types():
     plots = list_backtest_plots()
     return [
-        BackTestPlotType(id=plot["id"], display_name=plot["name"], description=plot["description"]) for plot in plots
+        BacktestPlotType(id=plot["id"], display_name=plot["name"], description=plot["description"]) for plot in plots
     ]
 
 
@@ -148,7 +148,7 @@ def generate_backtest_plots(visualization_name: str, backtest_id: int, session: 
         available = ", ".join(registry.keys())
         return {"error": f"Visualization {visualization_name} not found. Available: {available}"}
 
-    backtest = session.get(BackTest, backtest_id)
+    backtest = session.get(Backtest, backtest_id)
     if not backtest:
         return {"error": "Backtest not found"}
 

--- a/chap_core/simulation/naive_simulator.py
+++ b/chap_core/simulation/naive_simulator.py
@@ -12,7 +12,7 @@ import pydantic
 from numpy.random import normal, poisson
 
 from chap_core.database.dataset_tables import DataSet, Observation
-from chap_core.database.tables import BackTest, BackTestForecast
+from chap_core.database.tables import Backtest, BacktestForecast
 
 
 class SimulationParams(pydantic.BaseModel):
@@ -83,10 +83,10 @@ class BacktestSimulator:
     def __init__(self, params: ForecastParams = ForecastParams()):
         self._params = params
 
-    def simulate(self, dataset: DataSet, dataset_dims: DatasetDimensions) -> BackTest:
+    def simulate(self, dataset: DataSet, dataset_dims: DatasetDimensions) -> Backtest:
         periods = dataset_dims.time_periods[-(self._params.prediction_length + self._params.n_splits - 1) :]
         split_periods = periods[: self._params.n_splits]
-        backtest = BackTest(
+        backtest = Backtest(
             dataset=dataset, model_id="Naive Forecast", org_units=dataset_dims.locations, split_periods=split_periods
         )
         forecasts = []
@@ -107,7 +107,7 @@ class BacktestSimulator:
             rate = np.maximum(rate, 0)
             samples = poisson(rate).astype(float)
             forecasts.append(
-                BackTestForecast(
+                BacktestForecast(
                     values=samples.tolist(),
                     last_seen_period=split_period,
                     last_train_period=split_period,

--- a/docs/contributor/adding_cli_commands.md
+++ b/docs/contributor/adding_cli_commands.md
@@ -67,7 +67,7 @@ Each module exposes a `register_commands(app)` function that the top-level `cli.
 ## Conventions
 
 - Use `pathlib.Path` for file/directory parameters, not `str`.
-- Use Pydantic models grouped under one `Annotated[..., Parameter(...)]` argument when a command takes a cluster of related options (see `BackTestParams` and `RunConfig` in `eval_cmd`). Cyclopts exposes nested fields as `--group.field` flags automatically.
+- Use Pydantic models grouped under one `Annotated[..., Parameter(...)]` argument when a command takes a cluster of related options (see `BacktestParams` and `RunConfig` in `eval_cmd`). Cyclopts exposes nested fields as `--group.field` flags automatically.
 - Call `chap_core.log_config.initialize_logging(debug, log_file)` at the top of any command that produces user-visible output.
 - Keep heavy imports (plotting, model code) inside the function body, not at module top, so `chap --help` stays fast.
 

--- a/docs/contributor/architecture_diagrams.md
+++ b/docs/contributor/architecture_diagrams.md
@@ -130,7 +130,7 @@ sequenceDiagram
     O-->>W: base_url or stored fallback
     W->>M: train + predict per fold
     M-->>W: samples / forecasts
-    W->>DB: insert BackTest + BackTestForecast + BackTestMetric
+    W->>DB: insert Backtest + BacktestForecast + BacktestMetric
     W->>Q: set job_meta status = SUCCESS
 
     FE->>API: GET /v1/jobs/{id}
@@ -144,8 +144,8 @@ sequenceDiagram
 ## Class diagram
 
 Main domain classes and their relationships as persisted in PostgreSQL.
-All tables inherit from `DBModel` (SQLModel + camelCase aliasing). `BackTest`
-and `Prediction` are the two "run" concepts — a `BackTest` is a retrospective
+All tables inherit from `DBModel` (SQLModel + camelCase aliasing). `Backtest`
+and `Prediction` are the two "run" concepts — a `Backtest` is a retrospective
 evaluation over known data, a `Prediction` is a forward forecast. Both carry
 forecast samples and reference the `DataSet` and `ConfiguredModelDB` they were
 produced from.
@@ -184,21 +184,21 @@ classDiagram
         +deleted: bool
     }
 
-    class BackTest {
+    class Backtest {
         +name: str
         +created: datetime
         +aggregationLevel: str
         +splitPeriods: list
     }
 
-    class BackTestForecast {
+    class BacktestForecast {
         +period: str
         +orgUnit: str
         +lastTrainPeriod: str
         +values: list~float~
     }
 
-    class BackTestMetric {
+    class BacktestMetric {
         +metricId: str
         +period: str
         +orgUnit: str
@@ -226,20 +226,20 @@ classDiagram
     DBModel <|-- Observation
     DBModel <|-- ModelTemplateDB
     DBModel <|-- ConfiguredModelDB
-    DBModel <|-- BackTest
-    DBModel <|-- BackTestForecast
-    DBModel <|-- BackTestMetric
+    DBModel <|-- Backtest
+    DBModel <|-- BacktestForecast
+    DBModel <|-- BacktestMetric
     DBModel <|-- Prediction
     DBModel <|-- PredictionSamplesEntry
     DBModel <|-- DebugEntry
 
     DataSet "1" --> "*" Observation : observations
     ModelTemplateDB "1" --> "*" ConfiguredModelDB : configurations
-    DataSet "1" --> "*" BackTest : backtests
+    DataSet "1" --> "*" Backtest : backtests
     DataSet "1" --> "*" Prediction : predictions
-    ConfiguredModelDB "1" --> "*" BackTest : runs
+    ConfiguredModelDB "1" --> "*" Backtest : runs
     ConfiguredModelDB "1" --> "*" Prediction : runs
-    BackTest "1" --> "*" BackTestForecast : forecasts
-    BackTest "1" --> "*" BackTestMetric : metrics
+    Backtest "1" --> "*" BacktestForecast : forecasts
+    Backtest "1" --> "*" BacktestMetric : metrics
     Prediction "1" --> "*" PredictionSamplesEntry : samples
 ```

--- a/docs/contributor/evaluation_abstraction.md
+++ b/docs/contributor/evaluation_abstraction.md
@@ -8,7 +8,7 @@ This document describes the proposed refactoring to create a database-agnostic E
 
 Currently, the codebase has two different approaches to handling model evaluations:
 
-1. **REST API**: Uses the `BackTest` database model (tied to SQLModel/database)
+1. **REST API**: Uses the `Backtest` database model (tied to SQLModel/database)
 2. **CLI**: Uses GluonTS Evaluator directly without database persistence
 
 This duplication leads to:
@@ -20,14 +20,14 @@ This duplication leads to:
 
 ### Database Model Structure
 
-The current BackTest implementation is defined in `chap_core/database/tables.py:39-47`:
+The current Backtest implementation is defined in `chap_core/database/tables.py:39-47`:
 
 ```python
-class BackTest(_BackTestRead, table=True):
+class Backtest(_BacktestRead, table=True):
     id: Optional[int] = Field(primary_key=True, default=None)
     dataset: DataSet = Relationship()
-    forecasts: List["BackTestForecast"] = Relationship(back_populates="backtest", cascade_delete=True)
-    metrics: List["BackTestMetric"] = Relationship(back_populates="backtest", cascade_delete=True)
+    forecasts: List["BacktestForecast"] = Relationship(back_populates="backtest", cascade_delete=True)
+    metrics: List["BacktestMetric"] = Relationship(back_populates="backtest", cascade_delete=True)
     aggregate_metrics: Dict[str, float] = Field(default_factory=dict, sa_column=Column(JSON))
     model_db_id: int = Field(foreign_key="configuredmodeldb.id")
     configured_model: Optional["ConfiguredModelDB"] = Relationship()
@@ -35,11 +35,11 @@ class BackTest(_BackTestRead, table=True):
 
 **Key components:**
 
-1. **BackTestForecast** (`tables.py:113-118`): Stores individual forecast predictions
+1. **BacktestForecast** (`tables.py:113-118`): Stores individual forecast predictions
    - Fields: `period`, `org_unit`, `values` (samples), `last_train_period`, `last_seen_period`
    - One record per location-period-split combination
 
-2. **BackTestMetric** (`tables.py:121-137`): Deprecated, not used in new metric system
+2. **BacktestMetric** (`tables.py:121-137`): Deprecated, not used in new metric system
 
 3. **Related metadata**:
    - `org_units: List[str]` - evaluated locations
@@ -58,20 +58,20 @@ Location: `chap_core/rest_api/v1/routers/analytics.py` and `chap_core/rest_api/d
    └─> Queue worker: run_backtest()
        └─> Load dataset and configured model
        └─> Call _backtest() -> returns Iterable[DataSet[SamplesWithTruth]]
-       └─> session.add_evaluation_results() -> persists to BackTest table
+       └─> session.add_evaluation_results() -> persists to Backtest table
        └─> Returns backtest.id
 ```
 
 **Data Consumption:**
 
 1. **GET /evaluation-entry** (`analytics.py:217-284`):
-   - Queries BackTestForecast records
+   - Queries BacktestForecast records
    - Returns quantiles for specified split_period and org_units
    - Can aggregate to "adm0" level
 
 2. **Metric Computation** (`assessment/metrics/__init__.py:84-102`):
    ```python
-   def compute_all_aggregated_metrics_from_backtest(backtest: BackTest):
+   def compute_all_aggregated_metrics_from_backtest(backtest: Backtest):
        flat_forecasts = convert_backtest_to_flat_forecasts(backtest.forecasts)
        flat_observations = convert_backtest_observations_to_flat_observations(
            backtest.dataset.observations
@@ -83,7 +83,7 @@ Location: `chap_core/rest_api/v1/routers/analytics.py` and `chap_core/rest_api/d
 
 3. **Visualization** (`plotting/evaluation_plot.py:236-243`):
    ```python
-   def make_plot_from_backtest_object(backtest: BackTest, plotting_class, metric):
+   def make_plot_from_backtest_object(backtest: Backtest, plotting_class, metric):
        flat_forecasts = convert_backtest_to_flat_forecasts(backtest.forecasts)
        flat_observations = convert_backtest_observations_to_flat_observations(
            backtest.dataset.observations
@@ -92,7 +92,7 @@ Location: `chap_core/rest_api/v1/routers/analytics.py` and `chap_core/rest_api/d
        return plotting_class(metric_data).plot_spec()
    ```
 
-**Key Pattern**: BackTest DB object → Flat DataFrame representation → Metrics/Visualization
+**Key Pattern**: Backtest DB object → Flat DataFrame representation → Metrics/Visualization
 
 ### CLI Workflow
 
@@ -113,7 +113,7 @@ Location: `chap_core/cli.py:189-309` and `chap_core/assessment/prediction_evalua
 ```
 
 **Key Differences from REST API:**
-- No BackTest database model used
+- No Backtest database model used
 - Results stay in memory as Python dicts/tuples
 - Direct use of GluonTS evaluation
 - CSV export instead of database storage
@@ -149,8 +149,8 @@ region_A  | 2024-02     | 51.5
 
 **Conversion Functions:**
 
-1. `convert_backtest_to_flat_forecasts(backtest_forecasts: List[BackTestForecast])`:
-   - Converts BackTestForecast records to FlatForecasts DataFrame
+1. `convert_backtest_to_flat_forecasts(backtest_forecasts: List[BacktestForecast])`:
+   - Converts BacktestForecast records to FlatForecasts DataFrame
    - Calculates `horizon_distance` from period differences
    - Unpacks sample arrays into individual rows
 
@@ -190,8 +190,8 @@ This is the in-memory format returned by `_backtest()` and then persisted to dat
 │      ↓                                                        │
 │  session.add_evaluation_results()                            │
 │      ↓                                                        │
-│  BackTest (DB) ← ── ── stored in database                    │
-│      ├─> BackTestForecast records                            │
+│  Backtest (DB) ← ── ── stored in database                    │
+│      ├─> BacktestForecast records                            │
 │      └─> DataSet relationship                                │
 │      ↓                                                        │
 │  convert_backtest_to_flat_*()                                │
@@ -292,14 +292,14 @@ class EvaluationBase(ABC):
 
     @classmethod
     @abstractmethod
-    def from_backtest(cls, backtest: "BackTest") -> "EvaluationBase":
+    def from_backtest(cls, backtest: "Backtest") -> "EvaluationBase":
         """
-        Create Evaluation from database BackTest object.
+        Create Evaluation from database Backtest object.
 
         All implementations must support loading from database.
 
         Args:
-            backtest: Database BackTest object (with relationships loaded)
+            backtest: Database Backtest object (with relationships loaded)
 
         Returns:
             Evaluation instance
@@ -309,44 +309,44 @@ class EvaluationBase(ABC):
 
 ### Concrete Implementation: Evaluation
 
-Wraps existing BackTest database model to implement the abstract interface:
+Wraps existing Backtest database model to implement the abstract interface:
 
 ```python
 class Evaluation(EvaluationBase):
     """
-    Evaluation implementation backed by database BackTest model.
+    Evaluation implementation backed by database Backtest model.
 
-    This wraps an existing BackTest object and provides the
+    This wraps an existing Backtest object and provides the
     EvaluationBase interface without modifying the database schema.
     """
 
-    def __init__(self, backtest: BackTest):
+    def __init__(self, backtest: Backtest):
         """
         Args:
-            backtest: Database BackTest object
+            backtest: Database Backtest object
         """
         self._backtest = backtest
         self._flat_data_cache = None
 
     @classmethod
-    def from_backtest(cls, backtest: BackTest) -> "Evaluation":
+    def from_backtest(cls, backtest: Backtest) -> "Evaluation":
         """
-        Create Evaluation from database BackTest object.
+        Create Evaluation from database Backtest object.
 
         Args:
-            backtest: Database BackTest object (with relationships loaded)
+            backtest: Database Backtest object (with relationships loaded)
 
         Returns:
             Evaluation instance
         """
         return cls(backtest)
 
-    def to_backtest(self) -> BackTest:
+    def to_backtest(self) -> Backtest:
         """
-        Get underlying database BackTest object.
+        Get underlying database Backtest object.
 
         Returns:
-            BackTest database model
+            Backtest database model
         """
         return self._backtest
 
@@ -374,11 +374,11 @@ class Evaluation(EvaluationBase):
         return self._flat_data_cache
 
     def get_org_units(self) -> List[str]:
-        """Get locations from BackTest metadata."""
+        """Get locations from Backtest metadata."""
         return self._backtest.org_units
 
     def get_split_periods(self) -> List[str]:
-        """Get split periods from BackTest metadata."""
+        """Get split periods from Backtest metadata."""
         return self._backtest.split_periods
 ```
 
@@ -412,14 +412,14 @@ class InMemoryEvaluation(EvaluationBase):
         self._split_periods = split_periods
 
     @classmethod
-    def from_backtest(cls, backtest: BackTest) -> "InMemoryEvaluation":
+    def from_backtest(cls, backtest: Backtest) -> "InMemoryEvaluation":
         """
-        Create InMemoryEvaluation from database BackTest object.
+        Create InMemoryEvaluation from database Backtest object.
 
         Converts database representation to in-memory format.
 
         Args:
-            backtest: Database BackTest object (with relationships loaded)
+            backtest: Database Backtest object (with relationships loaded)
 
         Returns:
             InMemoryEvaluation instance
@@ -479,18 +479,18 @@ class InMemoryEvaluation(EvaluationBase):
         """Return stored split_periods."""
         return self._split_periods
 
-    def to_backtest(self, session: SessionWrapper, info: BackTestCreate) -> BackTest:
+    def to_backtest(self, session: SessionWrapper, info: BacktestCreate) -> Backtest:
         """
-        Persist to database as BackTest.
+        Persist to database as Backtest.
 
         Args:
             session: Database session wrapper
-            info: Metadata for creating BackTest record
+            info: Metadata for creating Backtest record
 
         Returns:
-            Persisted BackTest object
+            Persisted Backtest object
         """
-        # Convert flat representations to BackTest structure
+        # Convert flat representations to Backtest structure
         # (implementation details omitted for brevity)
         pass
 ```
@@ -528,7 +528,7 @@ split_periods = evaluation.get_split_periods()
 
 ```python
 # Current approach
-def make_plot_from_backtest_object(backtest: BackTest, metric):
+def make_plot_from_backtest_object(backtest: Backtest, metric):
     flat_forecasts = convert_backtest_to_flat_forecasts(backtest.forecasts)
     flat_observations = convert_backtest_observations_to_flat_observations(
         backtest.dataset.observations
@@ -651,7 +651,7 @@ results_cli, results_db = compare_evaluations(eval_from_cli, eval1)
 ┌───────────────┴──────────────┐  ┌──────────┴────────────────────┐
 │   Evaluation         │  │   InMemoryEvaluation          │
 ├──────────────────────────────┤  ├───────────────────────────────┤
-│  - _backtest: BackTest       │  │  - _flat_data:                │
+│  - _backtest: Backtest       │  │  - _flat_data:                │
 │  - _flat_data_cache          │  │      FlatEvaluationData       │
 │                              │  │  - _org_units: List[str]      │
 │                              │  │  - _split_periods: List[str]  │
@@ -666,7 +666,7 @@ results_cli, results_db = compare_evaluations(eval_from_cli, eval1)
          │ wraps                             │ stores
          ▼                                   ▼
 ┌──────────────────────────────┐  ┌───────────────────────────────┐
-│  BackTest (DB Model)         │  │  FlatEvaluationData           │
+│  Backtest (DB Model)         │  │  FlatEvaluationData           │
 │  + forecasts: List[...]      │  │  (in-memory)                  │
 │  + dataset: DataSet          │  │                               │
 │  + org_units: List[str]      │  │                               │
@@ -683,7 +683,7 @@ results_cli, results_db = compare_evaluations(eval_from_cli, eval1)
 3. **Flexibility**: Easy to add new implementations (e.g., for different storage backends, remote APIs, etc.)
 
 4. **Migration Path**: Can introduce gradually without breaking existing code:
-   - Start with Evaluation wrapping existing BackTest
+   - Start with Evaluation wrapping existing Backtest
    - Update visualization/metrics to accept EvaluationBase
    - Later add InMemoryEvaluation for CLI
    - Eventually unify REST API and CLI workflows
@@ -737,16 +737,16 @@ The implementation will be done in phases to minimize risk and allow for increme
    - Abstract classmethod: `from_backtest(backtest) -> EvaluationBase`
 
 3. **`Evaluation`** (concrete implementation):
-   - Constructor: `__init__(self, backtest: BackTest)`
+   - Constructor: `__init__(self, backtest: Backtest)`
    - Classmethod: `from_backtest(backtest) -> Evaluation`
-   - Method: `to_backtest() -> BackTest` (return wrapped object)
+   - Method: `to_backtest() -> Backtest` (return wrapped object)
    - Method: `to_flat() -> FlatEvaluationData` (with caching)
    - Method: `get_org_units() -> List[str]`
    - Method: `get_split_periods() -> List[str]`
 
 **Testing**:
 - Create `tests/test_evaluation.py`
-- Test `Evaluation.from_backtest()` with mock BackTest
+- Test `Evaluation.from_backtest()` with mock Backtest
 - Test `to_flat()` returns correct types and data
 - Test metadata accessors work correctly
 - Verify conversion matches existing `convert_backtest_to_flat_*()` functions
@@ -760,7 +760,7 @@ The implementation will be done in phases to minimize risk and allow for increme
 
 **Success Criteria**:
 - All tests pass
-- Can create `Evaluation` from database `BackTest` object
+- Can create `Evaluation` from database `Backtest` object
 - Can convert to flat representations correctly
 - Code is documented with docstrings
 - No existing code is modified
@@ -825,11 +825,11 @@ The implementation will be done in phases to minimize risk and allow for increme
    - Backtest is already established in codebase
 
 2. **Aggregate Metrics**: Should EvaluationBase include `get_aggregate_metrics()`?
-   - Pro: Matches BackTest schema which has `aggregate_metrics` field
+   - Pro: Matches Backtest schema which has `aggregate_metrics` field
    - Con: Metrics should be computed on-demand, not stored in evaluation
 
 3. **Model Information**: Should Evaluation include model configuration?
-   - Currently BackTest has `model_db_id` and `configured_model` relationship
+   - Currently Backtest has `model_db_id` and `configured_model` relationship
    - For database-agnostic design, should this be optional metadata?
 
 4. **Serialization**: Should we add methods like `to_json()`, `from_json()`?
@@ -845,7 +845,7 @@ The implementation will be done in phases to minimize risk and allow for increme
 
 Key files that would be affected by this refactoring:
 
-- `chap_core/database/tables.py` - BackTest model (unchanged, wrapped by Evaluation)
+- `chap_core/database/tables.py` - Backtest model (unchanged, wrapped by Evaluation)
 - `chap_core/assessment/flat_representations.py` - Conversion functions (reused by implementations)
 - `chap_core/assessment/metrics/` - Metric computation (updated to accept EvaluationBase)
 - `chap_core/plotting/evaluation_plot.py` - Visualization (updated to accept EvaluationBase)

--- a/docs/contributor/evaluation_pipeline.md
+++ b/docs/contributor/evaluation_pipeline.md
@@ -145,6 +145,6 @@ Step-by-step walkthrough of what happens when `Evaluation.create()` is called (e
 4. For each test split, the predictor generates samples and they are **merged with ground truth** into `SamplesWithTruth` objects
 5. Back in `create()`, **`train_test_generator()`** is called again to determine the last training period
 6. **`from_samples_with_truth()`** assembles an `Evaluation` object containing:
-     - `BackTest` with all forecasts and observations
+     - `Backtest` with all forecasts and observations
      - Historical observations for plotting context
 7. The `Evaluation` can then be **exported** to NetCDF, used for metric computation, or visualized

--- a/docs/contributor/evaluation_walkthrough.md
+++ b/docs/contributor/evaluation_walkthrough.md
@@ -212,10 +212,10 @@ attributes with the model metadata needed by the evaluation:
 Run the evaluation:
 
 ```python
-from chap_core.api_types import BackTestParams
+from chap_core.api_types import BacktestParams
 from chap_core.assessment.evaluation import Evaluation
 
-backtest_params = BackTestParams(n_periods=3, n_splits=4, stride=1)
+backtest_params = BacktestParams(n_periods=3, n_splits=4, stride=1)
 evaluation = Evaluation.create(estimator.configured_model_db, estimator, dataset, backtest_params)
 ```
 

--- a/docs/contributor/evaluation_walkthrough_exec.md
+++ b/docs/contributor/evaluation_walkthrough_exec.md
@@ -165,10 +165,10 @@ attributes with the model metadata needed by the evaluation:
 Run the evaluation:
 
 ```python exec="on" session="eval-walkthrough" source="above"
-from chap_core.api_types import BackTestParams
+from chap_core.api_types import BacktestParams
 from chap_core.assessment.evaluation import Evaluation
 
-backtest_params = BackTestParams(n_periods=3, n_splits=4, stride=1)
+backtest_params = BacktestParams(n_periods=3, n_splits=4, stride=1)
 evaluation = Evaluation.create(estimator.configured_model_db, estimator, dataset, backtest_params)
 ```
 

--- a/docs/contributor/rest_api_and_database.md
+++ b/docs/contributor/rest_api_and_database.md
@@ -158,7 +158,7 @@ The tables are spread across several files:
 |------|--------|---------|
 | `base_tables.py` | `DBModel` (base) | Base class with camelCase config |
 | `dataset_tables.py` | `DataSet`, `Observation` | Imported health/climate datasets |
-| `tables.py` | `BackTest`, `Prediction`, `BackTestForecast`, `PredictionSamplesEntry`, `BackTestMetric` | Evaluation and prediction results |
+| `tables.py` | `Backtest`, `Prediction`, `BacktestForecast`, `PredictionSamplesEntry`, `BacktestMetric` | Evaluation and prediction results |
 | `model_templates_and_config_tables.py` | `ModelTemplateDB`, `ConfiguredModelDB` | Model definitions and configurations |
 | `model_spec_tables.py` | `ModelSpecRead` | Read model for backwards-compatible API responses |
 | `debug.py` | `DebugEntry` | Debug/diagnostic entries |
@@ -168,12 +168,12 @@ The tables are spread across several files:
 ```
 ModelTemplateDB  1--*  ConfiguredModelDB
 DataSet          1--*  Observation
-DataSet          1--*  BackTest
+DataSet          1--*  Backtest
 DataSet          1--*  Prediction
-BackTest         1--*  BackTestForecast
-BackTest         1--*  BackTestMetric
+Backtest         1--*  BacktestForecast
+Backtest         1--*  BacktestMetric
 Prediction       1--*  PredictionSamplesEntry
-ConfiguredModelDB 1--* BackTest
+ConfiguredModelDB 1--* Backtest
 ConfiguredModelDB 1--* Prediction
 ```
 
@@ -182,7 +182,7 @@ ConfiguredModelDB 1--* Prediction
 The codebase uses a pattern where table models have companion "read" classes for API
 responses. For example:
 
-- `BackTest` (table) -> `BackTestRead` (API response, includes nested dataset/model info)
+- `Backtest` (table) -> `BacktestRead` (API response, includes nested dataset/model info)
 - `Prediction` (table) -> `PredictionInfo` (API response)
 - `DataSet` (table) -> `DataSetInfo` (list response), `DataSetWithObservations` (detail response)
 
@@ -318,7 +318,7 @@ shortcut to apply this to all GET endpoints.
 | `rest_api/worker_functions.py` | WorkerConfig and related utilities |
 | `database/database.py` | Engine creation, SessionWrapper, migrations |
 | `database/base_tables.py` | DBModel base class with camelCase config |
-| `database/tables.py` | BackTest, Prediction, forecast tables |
+| `database/tables.py` | Backtest, Prediction, forecast tables |
 | `database/dataset_tables.py` | DataSet, Observation tables |
 | `database/model_templates_and_config_tables.py` | ModelTemplateDB, ConfiguredModelDB |
 | `database/model_spec_tables.py` | ModelSpecRead (backwards-compatible read model) |

--- a/tests/evaluation/conftest.py
+++ b/tests/evaluation/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from chap_core.assessment.flat_representations import FlatObserved, FlatForecasts
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.database.dataset_tables import DataSetWithObservations, Observation, DataSet
-from chap_core.database.tables import BackTestRead, OldBackTestRead, BackTestForecast, BackTest, BackTestMetric
+from chap_core.database.tables import BacktestRead, OldBacktestRead, BacktestForecast, Backtest, BacktestMetric
 from chap_core.simulation.naive_simulator import DatasetDimensions, AdditiveSimulator, BacktestSimulator
 
 
@@ -16,8 +16,8 @@ def data_folder():
     return Path(__file__).parent / "data"
 
 
-class BacktestOW(OldBackTestRead):
-    forecasts: list[BackTestForecast]
+class BacktestOW(OldBacktestRead):
+    forecasts: list[BacktestForecast]
 
 
 @pytest.fixture(autouse=True)
@@ -126,7 +126,7 @@ def dataset_weeks_large():
 @pytest.fixture
 def forecasts():
     return [
-        BackTestForecast(
+        BacktestForecast(
             id=t * 2 * 2 + loc * 2 + ls,
             backtest_id=1,
             period=f"2022-0{t + 1}",
@@ -144,7 +144,7 @@ def forecasts():
 @pytest.fixture
 def forecasts_weeks():
     return [
-        BackTestForecast(
+        BacktestForecast(
             id=t * 2 * 2 + loc * 2 + ls,
             backtest_id=1,
             period=f"2022W0{t + 1}",
@@ -167,7 +167,7 @@ def forecasts_weeks_large():
     with 100 samples per forecast for stress testing.
     """
     return [
-        BackTestForecast(
+        BacktestForecast(
             id=t * 20 + loc,
             backtest_id=1,
             period=periods_weeks_large[t],
@@ -183,13 +183,13 @@ def forecasts_weeks_large():
 
 @pytest.fixture
 def backtest(dataset, forecasts):
-    return BackTest(
+    return Backtest(
         id=1,
         dataset_id=dataset.id,
         dataset=dataset,
         model_id="Test Model",
         model_db_id=1,
-        name="Test BackTest",
+        name="Test Backtest",
         created=None,
         aggregate_metrics={},
         forecasts=forecasts,
@@ -199,13 +199,13 @@ def backtest(dataset, forecasts):
 
 @pytest.fixture
 def backtest_weeks(dataset_weeks, forecasts_weeks):
-    return BackTest(
+    return Backtest(
         id=1,
         dataset_id=dataset_weeks.id,
         dataset=dataset_weeks,
         model_id="Test Model",
         model_db_id=1,
-        name="Test BackTest",
+        name="Test Backtest",
         created=None,
         aggregate_metrics={},
         forecasts=forecasts_weeks,
@@ -216,13 +216,13 @@ def backtest_weeks(dataset_weeks, forecasts_weeks):
 @pytest.fixture
 def backtest_weeks_large(dataset_weeks_large, forecasts_weeks_large):
     """Large backtest with 5 years of weekly forecasts for 20 org units."""
-    return BackTest(
+    return Backtest(
         id=1,
         dataset_id=dataset_weeks_large.id,
         dataset=dataset_weeks_large,
         model_id="Test Model Large",
         model_db_id=1,
-        name="Large Test BackTest",
+        name="Large Test Backtest",
         created=None,
         aggregate_metrics={},
         forecasts=forecasts_weeks_large,
@@ -232,14 +232,14 @@ def backtest_weeks_large(dataset_weeks_large, forecasts_weeks_large):
 
 @pytest.fixture
 def backtest_empty(dataset):
-    """BackTest with no forecasts for edge case testing."""
-    return BackTest(
+    """Backtest with no forecasts for edge case testing."""
+    return Backtest(
         id=1,
         dataset_id=dataset.id,
         dataset=dataset,
         model_id="Test Model",
         model_db_id=1,
-        name="Empty Test BackTest",
+        name="Empty Test Backtest",
         created=None,
         aggregate_metrics={},
         forecasts=[],
@@ -252,7 +252,7 @@ def backtest_empty(dataset):
 @pytest.fixture
 def backtest_metrics(forecasts):
     return [
-        BackTestMetric(
+        BacktestMetric(
             id=forecast.id,
             backtest_id=forecast.backtest_id,
             metric_id="MAE",

--- a/tests/evaluation/test_backtest_plot.py
+++ b/tests/evaluation/test_backtest_plot.py
@@ -22,7 +22,7 @@ from chap_core.assessment.backtest_plots.predicted_vs_actual_plot import Predict
 from chap_core.assessment.backtest_plots.sample_bias_plot import SampleBiasPlot
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.cli_endpoints.utils import plot_backtest
-from chap_core.database.tables import BackTest
+from chap_core.database.tables import Backtest
 
 
 @pytest.fixture(scope="module")
@@ -175,8 +175,8 @@ def test_evaluation_plot_monthly_data(default_transformer):
     "plot_id, _backtest",
     list(itertools.product(list(get_backtest_plots_registry().keys()), ["simulated_backtest", "old_backtest"])),
 )
-def test_all_registered_plots_from_backtest(plot_id: str, _backtest: BackTest, default_transformer, request):
-    """Test that all registered plots can be successfully generated from a BackTest."""
+def test_all_registered_plots_from_backtest(plot_id: str, _backtest: Backtest, default_transformer, request):
+    """Test that all registered plots can be successfully generated from a Backtest."""
     chart = create_plot_from_backtest(plot_id, request.getfixturevalue(_backtest))
     assert chart is not None
 
@@ -185,14 +185,14 @@ def test_all_registered_plots_from_backtest(plot_id: str, _backtest: BackTest, d
     "plot_id, _backtest",
     list(itertools.product(list(get_backtest_plots_registry().keys()), ["simulated_backtest", "old_backtest"])),
 )
-def test_all_registered_plots_from_evaluation(plot_id: str, _backtest: BackTest, default_transformer, request):
+def test_all_registered_plots_from_evaluation(plot_id: str, _backtest: Backtest, default_transformer, request):
     """Test that all registered plots can be successfully generated from an Evaluation."""
     evaluation = Evaluation.from_backtest(request.getfixturevalue(_backtest))
     chart = create_plot_from_evaluation(plot_id, evaluation)
     assert chart is not None
 
 
-def test_plot_backtest_cli(backtest: BackTest, tmp_path: Path, default_transformer):
+def test_plot_backtest_cli(backtest: Backtest, tmp_path: Path, default_transformer):
     """Test the CLI plot_backtest function."""
     evaluation = Evaluation.from_backtest(backtest)
     input_file = tmp_path / "evaluation.nc"
@@ -205,7 +205,7 @@ def test_plot_backtest_cli(backtest: BackTest, tmp_path: Path, default_transform
     assert output_file.stat().st_size > 0
 
 
-def test_eval_cmd_plot_flag(backtest: BackTest, tmp_path: Path, default_transformer):
+def test_eval_cmd_plot_flag(backtest: Backtest, tmp_path: Path, default_transformer):
     """Test that eval_cmd's plot flag generates an HTML plot file."""
     from chap_core.assessment.backtest_plots import create_plot_from_evaluation
 
@@ -221,7 +221,7 @@ def test_eval_cmd_plot_flag(backtest: BackTest, tmp_path: Path, default_transfor
     assert plot_path.stat().st_size > 0
 
 
-def test_generate_pdf_report(backtest: BackTest, tmp_path: Path):
+def test_generate_pdf_report(backtest: Backtest, tmp_path: Path):
     from chap_core.cli_endpoints.utils import generate_pdf_report
 
     evaluation = Evaluation.from_backtest(backtest)

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -59,7 +59,7 @@ class TestEvaluation:
         assert isinstance(evaluation, EvaluationBase)
 
     def test_to_backtest_returns_wrapped_object(self, backtest):
-        """Test that to_backtest returns the original BackTest object."""
+        """Test that to_backtest returns the original Backtest object."""
         evaluation = Evaluation.from_backtest(backtest)
 
         result = evaluation.to_backtest()
@@ -67,7 +67,7 @@ class TestEvaluation:
         assert result is backtest
 
     def test_get_org_units_returns_correct_data(self, backtest):
-        """Test that get_org_units returns the org_units from BackTest."""
+        """Test that get_org_units returns the org_units from Backtest."""
         evaluation = Evaluation.from_backtest(backtest)
 
         org_units = evaluation.get_org_units()
@@ -75,7 +75,7 @@ class TestEvaluation:
         assert org_units == backtest.org_units
 
     def test_get_split_periods_returns_correct_data(self, backtest):
-        """Test that get_split_periods returns the split_periods from BackTest."""
+        """Test that get_split_periods returns the split_periods from Backtest."""
         evaluation = Evaluation.from_backtest(backtest)
 
         split_periods = evaluation.get_split_periods()

--- a/tests/evaluation/test_evaluation_plot.py
+++ b/tests/evaluation/test_evaluation_plot.py
@@ -6,7 +6,7 @@ import pytest
 
 from chap_core.assessment.metrics import CRPSMetric, RMSEMetric
 from chap_core.assessment.evaluation import Evaluation
-from chap_core.database.tables import BackTestMetric
+from chap_core.database.tables import BacktestMetric
 from chap_core.plotting.evaluation_plot import (
     MetricByHorizonV2Mean,
     MetricMapV2,
@@ -39,7 +39,7 @@ def rwanda_orgunits(rwanda_geojson) -> list[str]:
 
 
 @pytest.fixture
-def rwanda_metrics(rwanda_orgunits) -> list[BackTestMetric]:
+def rwanda_metrics(rwanda_orgunits) -> list[BacktestMetric]:
     time_periods = ["2022-02", "2022-03"]
     rows = [
         {"location": ou, "time_period": tp, "horizon_distance": 1, "metric": float((i * o + o) % 5)}

--- a/tests/evaluation/test_flat_representations.py
+++ b/tests/evaluation/test_flat_representations.py
@@ -7,7 +7,7 @@ from chap_core.assessment.flat_representations import (
 
 def test_convert_backtest_to_flat_forecast(backtest_weeks_large):
     """
-    Test converting BackTestForecast objects to ForecastFlatDataSchema format.
+    Test converting BacktestForecast objects to ForecastFlatDataSchema format.
 
     This test uses the same backtest fixture as test_external_evaluation
     and prints the resulting flat DataFrame.

--- a/tests/evaluation/test_metric_tables.py
+++ b/tests/evaluation/test_metric_tables.py
@@ -1,12 +1,12 @@
 import pytest
 import pandas as pd
 from chap_core.assessment.flat_representations import FlatMetric
-from chap_core.database.tables import BackTest, BackTestMetric
+from chap_core.database.tables import Backtest, BacktestMetric
 from chap_core.assessment.metric_table import create_metric_table
 from chap_core.plotting.evaluation_plot import MetricByHorizonV2Mean
 
 
-def test_create_metric_table(backtest_metrics: list[BackTestMetric]):
+def test_create_metric_table(backtest_metrics: list[BacktestMetric]):
     table = create_metric_table(backtest_metrics)
 
     assert len(table["last_seen_period"]) > 0
@@ -14,7 +14,7 @@ def test_create_metric_table(backtest_metrics: list[BackTestMetric]):
 
 
 # @pytest.fixture
-# def metric_table(backtest_metrics: list[BackTestMetric]):
+# def metric_table(backtest_metrics: list[BacktestMetric]):
 #   return create_metric_table(backtest_metrics)
 
 

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -29,7 +29,7 @@ import pytest
 import pandas as pd
 
 from chap_core.database.database import SessionWrapper
-from chap_core.database.tables import BackTest
+from chap_core.database.tables import Backtest
 from chap_core.datatypes import SamplesWithTruth
 
 

--- a/tests/integration/rest_api/conftest.py
+++ b/tests/integration/rest_api/conftest.py
@@ -8,10 +8,10 @@ from sqlmodel import select, Session
 
 from chap_core.api_types import FeatureCollectionModel, FeatureModel
 from chap_core.database.dataset_tables import DataSet, Observation, DataSource
-from chap_core.database.tables import Prediction, BackTest, BackTestForecast, BackTestMetric, PredictionSamplesEntry
+from chap_core.database.tables import Prediction, Backtest, BacktestForecast, BacktestMetric, PredictionSamplesEntry
 from chap_core.rest_api.app import app
 from chap_core.rest_api.v1.debug import router as debug_router
-from chap_core.rest_api.v1.routers.analytics import BackTestParams
+from chap_core.rest_api.v1.routers.analytics import BacktestParams
 from chap_core.rest_api.v1.routers.dependencies import get_session
 
 app.include_router(debug_router, prefix="/v1")
@@ -39,7 +39,7 @@ def org_units():
 
 @pytest.fixture
 def backtest_params():
-    return BackTestParams(n_periods=3, n_splits=2, stride=1)
+    return BacktestParams(n_periods=3, n_splits=2, stride=1)
 
 
 @pytest.fixture
@@ -220,14 +220,14 @@ def forecasts_2(seen_periods, org_units, backtest_params):
 
 
 def _generate_forecasts(
-    backtest_params: BackTestParams, org_units: list[str], seen_periods: list[str], backtest_id: int = 1
+    backtest_params: BacktestParams, org_units: list[str], seen_periods: list[str], backtest_id: int = 1
 ) -> list[typing.Any]:
     start_split = len(seen_periods) - backtest_params.n_splits - backtest_params.n_periods
     forecasts = []
     for start in range(start_split, start_split + backtest_params.n_splits):
         forecasts.extend(
             [
-                BackTestForecast(
+                BacktestForecast(
                     org_unit=ou,
                     last_train_period=seen_periods[start],
                     last_seen_period=seen_periods[start],
@@ -246,7 +246,7 @@ def _generate_forecasts(
 
 @pytest.fixture
 def backtest(dataset, forecasts):
-    return BackTest(
+    return Backtest(
         name="test backtest",
         dataset_id=1,
         dataset=dataset,
@@ -259,7 +259,7 @@ def backtest(dataset, forecasts):
 
 @pytest.fixture
 def backtest_with_nans(dataset_with_nans, forecasts_2):
-    return BackTest(
+    return Backtest(
         name="test_backtest_with_nans",
         dataset_id=1,
         dataset=dataset_with_nans,
@@ -322,10 +322,10 @@ def p_seeded_engine(
         d_observations = list(session.exec(select(DataSet).where(DataSet.name == "testing dataset")).one().observations)
         assert d_observations, d_observations
         observations = list(
-            session.exec(select(BackTest).where(BackTest.name == "test backtest")).one().dataset.observations
+            session.exec(select(Backtest).where(Backtest.name == "test backtest")).one().dataset.observations
         )
         obs_with_nan = list(
-            session.exec(select(BackTest).where(BackTest.name == "test_backtest_with_nans")).one().dataset.observations
+            session.exec(select(Backtest).where(Backtest.name == "test_backtest_with_nans")).one().dataset.observations
         )
         assert any(obs.value is None for obs in obs_with_nan), "No NaN observations found in dataset_with_nans"
         assert observations, observations

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -15,15 +15,15 @@ from chap_core.database.dataset_tables import DataSet, DataSetWithObservations, 
 from chap_core.database.debug import DebugEntry
 from chap_core.database.model_spec_tables import ModelSpecRead
 from chap_core.database.tables import (
-    BackTest,
-    BackTestRead,
+    Backtest,
+    BacktestRead,
     ConfiguredModelWithDataSource,
     Prediction,
     PredictionInfo,
     PredictionRead,
 )
 from chap_core.rest_api.data_models import (
-    BackTestFull,
+    BacktestFull,
     ConfiguredModelInfoRead,
     DatasetCreate,
     DatasetMakeRequest,
@@ -114,7 +114,7 @@ def test_backtest_flow(celery_session_worker, clean_engine, dependency_overrides
     dataset_response = client.get("/v1/crud/datasets")
 
     assert response.status_code == 200, response.json()
-    BackTestFull.model_validate(response.json())
+    BacktestFull.model_validate(response.json())
     split_period, org_units = None, []
     if do_filter:
         split_period = "2022W30"
@@ -337,7 +337,7 @@ def test_compatible_backtests(clean_engine, dependency_overrides):
         session.commit()
 
         ds_id = dataset.id
-        backtest = BackTest(
+        backtest = Backtest(
             dataset_id=ds_id,
             name="testing",
             model_id="naive_model",
@@ -345,7 +345,7 @@ def test_compatible_backtests(clean_engine, dependency_overrides):
             org_units=["Oslo", "Bergen"],
             split_periods=["202201", "202202"],
         )
-        matching = BackTest(
+        matching = Backtest(
             dataset_id=ds_id,
             name="testing2",
             model_id="chap_auto_ewars",
@@ -353,7 +353,7 @@ def test_compatible_backtests(clean_engine, dependency_overrides):
             org_units=["Bergen", "Trondheim"],
             split_periods=["202202", "202203"],
         )
-        non_matching = BackTest(
+        non_matching = Backtest(
             dataset_id=ds_id,
             name="testing3",
             model_id="auto_regressive_monthly",
@@ -387,7 +387,7 @@ def test_list_configured_models_with_data_source_empty(clean_engine, dependency_
 
 
 def test_create_configured_model_with_data_source_from_backtest(override_session, seeded_session):
-    backtest = seeded_session.exec(select(BackTest)).first()
+    backtest = seeded_session.exec(select(Backtest)).first()
     assert backtest is not None, "seeded_session should contain a backtest"
     seeded_dataset = backtest.dataset
 
@@ -411,7 +411,7 @@ def test_create_configured_model_with_data_source_from_nonexistent_backtest(clea
 
 
 def test_get_configured_model_with_data_source_by_id_includes_predictions(override_session, seeded_session):
-    backtest = seeded_session.exec(select(BackTest)).first()
+    backtest = seeded_session.exec(select(Backtest)).first()
     assert backtest is not None, "seeded_session should contain a backtest"
 
     response = client.post(f"/v1/crud/configured-models-with-data-source/from-backtest/{backtest.id}")
@@ -637,7 +637,7 @@ def _check_backtest_with_data(request_payload, expected_rejections=None, dry_run
     db_id = await_result_id(job_id, timeout=180)
     response = client.get(f"/v1/crud/backtests/{db_id}/info")
     assert response.status_code == 200, response.json()
-    backtest_info = BackTestRead.model_validate(response.json())
+    backtest_info = BacktestRead.model_validate(response.json())
     assert len(backtest_info.dataset.data_sources) > 0, backtest_info.dataset
     assert len(backtest_info.dataset.org_units) > 0, backtest_info.dataset
     assert backtest_info.dataset.last_period is not None, backtest_info.dataset
@@ -710,10 +710,10 @@ def test_all_backtest_plots_via_api(override_session, seeded_session):
     assert len(plot_types) > 0, "No backtest plot types registered"
 
     # Get a backtest ID from the seeded database
-    from chap_core.database.tables import BackTest
+    from chap_core.database.tables import Backtest
     from sqlmodel import select
 
-    backtests = seeded_session.exec(select(BackTest)).all()
+    backtests = seeded_session.exec(select(Backtest)).all()
     assert len(backtests) > 0, "No backtests in seeded database"
     backtest_id = backtests[0].id
 

--- a/tests/integration/rest_api/test_from_seeded_engine.py
+++ b/tests/integration/rest_api/test_from_seeded_engine.py
@@ -7,7 +7,7 @@ from sqlmodel import Session, select
 from starlette.testclient import TestClient
 
 from chap_core.database.dataset_tables import DataSet
-from chap_core.database.tables import BackTestRead
+from chap_core.database.tables import BacktestRead
 from chap_core.rest_api.app import app
 from chap_core.rest_api.v1.routers.dependencies import get_session
 
@@ -60,7 +60,7 @@ def test_get_prediction_entries(override_session):
 
 
 def test_get_backtest(override_session):
-    backtest: BackTestRead = client.get_obj("/v1/crud/backtests/1/info", __model__=BackTestRead)
+    backtest: BacktestRead = client.get_obj("/v1/crud/backtests/1/info", __model__=BacktestRead)
     dataset = backtest.dataset
     assert dataset.data_sources is not None
     assert dataset.data_sources[0].covariate == "mean_temperature"

--- a/tests/integration/rest_api/test_python_endpoints.py
+++ b/tests/integration/rest_api/test_python_endpoints.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import pytest
 from sqlmodel import select, Session
 
-from chap_core.database.tables import BackTest
-from chap_core.rest_api.data_models import BackTestFull
+from chap_core.database.tables import Backtest
+from chap_core.rest_api.data_models import BacktestFull
 from chap_core.rest_api.v1.routers.visualization import (
     get_available_metrics,
     generate_visualization,
@@ -33,7 +33,7 @@ def load_backtest():
         pytest.skip("Weird backtest data not available")
     json_data = json.load(open(path))
     print(json_data.keys())
-    return BackTestFull.model_validate(json_data)
+    return BacktestFull.model_validate(json_data)
 
 
 @pytest.fixture
@@ -74,7 +74,7 @@ def test_generate_backtest_plot(seeded_session, visualization_name="metrics_dash
 
 @pytest.fixture
 def backtest_ids(seeded_session):
-    backtests = seeded_session.exec(select(BackTest)).all()
+    backtests = seeded_session.exec(select(Backtest)).all()
     return [bt.id for bt in backtests]
 
 

--- a/tests/integration/rest_api/test_validation.py
+++ b/tests/integration/rest_api/test_validation.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 
 from chap_core.datatypes import create_tsdataclass
 from chap_core.rest_api.app import app
-from chap_core.api_types import BackTestParams
+from chap_core.api_types import BacktestParams
 from chap_core.assessment.dataset_splitting import train_test_generator
 from chap_core.rest_api.v1.routers.analytics import (
     _filter_dataset_by_locations,
@@ -62,7 +62,7 @@ def test_validate_target_in_first_train_split_rejects_all_nan_location():
     # n_periods=3, n_splits=2, stride=1 -> first train split ends at index -(3 + 1*1 + 1) = -5
     # i.e. first train split = periods 2020-01 to 2020-06 (inclusive)
     # loc2 has NaN for 2020-01 to 2020-04 but has 5.0 at 2020-05, so it should pass
-    params = BackTestParams(n_periods=3, n_splits=2, stride=1)
+    params = BacktestParams(n_periods=3, n_splits=2, stride=1)
     train_set, _ = train_test_generator(dataset, params.n_periods, params.n_splits, stride=params.stride)
     locations_to_keep, rejected = _find_locations_with_target_data(train_set)
     filtered = _filter_dataset_by_locations(dataset, locations_to_keep)
@@ -89,7 +89,7 @@ def test_validate_target_in_first_train_split_rejects_when_no_data():
     dataset = DataSet({"loc1": data_good, "loc2": data_bad})
 
     # first train split = periods 2020-01 to 2020-06 -> loc2 is all NaN there
-    params = BackTestParams(n_periods=3, n_splits=2, stride=1)
+    params = BacktestParams(n_periods=3, n_splits=2, stride=1)
     train_set, _ = train_test_generator(dataset, params.n_periods, params.n_splits, stride=params.stride)
     locations_to_keep, rejected = _find_locations_with_target_data(train_set)
     filtered = _filter_dataset_by_locations(dataset, locations_to_keep)

--- a/tests/integration/test_chapkit_e2e.py
+++ b/tests/integration/test_chapkit_e2e.py
@@ -20,9 +20,9 @@ from sqlmodel import SQLModel
 import chap_core.database.tables  # noqa: F401 - register all table models
 from chap_core.database.database import SessionWrapper
 from chap_core.database.model_templates_and_config_tables import ModelConfiguration
-from chap_core.database.tables import BackTest
+from chap_core.database.tables import Backtest
 from chap_core.models.external_chapkit_model import ml_service_info_to_model_template_config
-from chap_core.rest_api.data_models import BackTestCreate
+from chap_core.rest_api.data_models import BacktestCreate
 from chap_core.rest_api.db_worker_functions import run_backtest
 from chap_core.rest_api.services.schemas import MLServiceInfo
 
@@ -173,7 +173,7 @@ def test_chapkit_backtest_via_worker_function(chapkit_service):
 
         # Run backtest directly (bypasses Celery)
         backtest_id = run_backtest(
-            BackTestCreate(dataset_id=dataset_id, model_id="chapkit-test-model"),
+            BacktestCreate(dataset_id=dataset_id, model_id="chapkit-test-model"),
             n_splits=2,
             session=session,
         )
@@ -185,7 +185,7 @@ def test_chapkit_backtest_via_worker_function(chapkit_service):
         # backtest row so the `GET /v1/crud/backtests/{id}/full` response
         # includes global CRPS/MAPE/RMSE/etc without needing a round-trip
         # through the Vega visualization endpoints.
-        fetched = session.session.get(BackTest, backtest_id)
+        fetched = session.session.get(Backtest, backtest_id)
         assert fetched is not None
         assert fetched.aggregate_metrics, (
             f"expected non-empty aggregate_metrics on backtest {backtest_id}, got {fetched.aggregate_metrics!r}"

--- a/tests/preference_learning/test_preference_learn_cli.py
+++ b/tests/preference_learning/test_preference_learn_cli.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from chap_core.api_types import BackTestParams, RunConfig
+from chap_core.api_types import BacktestParams, RunConfig
 from chap_core.cli_endpoints.preference_learn import (
     PreferenceLearningParams,
     preference_learn,
@@ -95,7 +95,7 @@ learning_rate:
             dataset_csv=dataset_csv,
             search_space_yaml=search_space_yaml,
             state_file=state_file,
-            backtest_params=BackTestParams(n_periods=2, n_splits=2, stride=1),
+            backtest_params=BacktestParams(n_periods=2, n_splits=2, stride=1),
             run_config=RunConfig(),
             learning_params=learning_params,
         )
@@ -159,7 +159,7 @@ learning_rate:
             model_name="test_model",
             dataset_csv=dataset_csv,
             state_file=state_file,
-            backtest_params=BackTestParams(n_periods=2, n_splits=2, stride=1),
+            backtest_params=BacktestParams(n_periods=2, n_splits=2, stride=1),
             run_config=RunConfig(),
             learning_params=learning_params,
         )

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -25,9 +25,9 @@ from chap_core.database.model_templates_and_config_tables import (  # noqa: F401
     ModelTemplateDB,
 )
 from chap_core.database.tables import (  # noqa: F401
-    BackTest,
-    BackTestForecast,
-    BackTestMetric,
+    Backtest,
+    BacktestForecast,
+    BacktestMetric,
     Prediction,
     PredictionSamplesEntry,
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ def test_forecast_github_model():
 
 def test_eval_cmd(tmp_path):
     from chap_core.file_io.example_data_set import datasets
-    from chap_core.api_types import BackTestParams, RunConfig
+    from chap_core.api_types import BacktestParams, RunConfig
 
     # Export hydromet dataset to CSV for testing
     dataset = datasets["hydromet_5_filtered"].load()
@@ -22,7 +22,7 @@ def test_eval_cmd(tmp_path):
     dataset.to_csv(csv_path)
 
     # Prepare parameters
-    backtest_params = BackTestParams(n_periods=3, n_splits=2, stride=1)
+    backtest_params = BacktestParams(n_periods=3, n_splits=2, stride=1)
     run_config = RunConfig()
 
     # Run eval_cmd with CSV
@@ -44,7 +44,7 @@ def test_eval_cmd_with_data_source_mapping(tmp_path):
 
     import pandas as pd
 
-    from chap_core.api_types import BackTestParams, RunConfig
+    from chap_core.api_types import BacktestParams, RunConfig
     from chap_core.file_io.example_data_set import datasets
 
     # Export hydromet dataset to CSV for testing
@@ -65,7 +65,7 @@ def test_eval_cmd_with_data_source_mapping(tmp_path):
         json.dump(mapping, f)
 
     # Prepare parameters
-    backtest_params = BackTestParams(n_periods=3, n_splits=2, stride=1)
+    backtest_params = BacktestParams(n_periods=3, n_splits=2, stride=1)
     run_config = RunConfig()
 
     # Run eval_cmd with the mapping

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -18,7 +18,7 @@ from chap_core.database.model_templates_and_config_tables import (
     ModelTemplateDB,
     ModelTemplateMetaData,
 )
-from chap_core.database.tables import BackTest
+from chap_core.database.tables import Backtest
 from chap_core.datatypes import HealthPopulationData
 from chap_core.external.model_configuration import (
     CommandConfig,
@@ -27,7 +27,7 @@ from chap_core.external.model_configuration import (
     ModelTemplateConfigV2,
 )
 from chap_core.models.external_model import ExternalModel
-from chap_core.rest_api.data_models import BackTestCreate
+from chap_core.rest_api.data_models import BacktestCreate
 from chap_core.rest_api.db_worker_functions import run_backtest, run_prediction
 from chap_core.testing.testing import assert_dataset_equal
 
@@ -69,9 +69,9 @@ def test_backtest(engine_with_dataset):
     with Session(engine_with_dataset) as session:
         dataset_id = session.exec(select(DataSet.id)).first()
     with SessionWrapper(engine_with_dataset) as session:
-        res = run_backtest(BackTestCreate(model_id="naive_model", dataset_id=dataset_id), 12, 2, 1, session=session)
+        res = run_backtest(BacktestCreate(model_id="naive_model", dataset_id=dataset_id), 12, 2, 1, session=session)
     with Session(engine_with_dataset) as session:
-        backtests = session.exec(select(BackTest)).all()
+        backtests = session.exec(select(Backtest)).all()
         assert len(backtests) == 1
         backtest = backtests[0]
         assert backtest.dataset_id == dataset_id


### PR DESCRIPTION
## Summary
- Rename 13 PascalCase `BackTest*` classes to `Backtest*` (one word) so the type names match the lowercase form already used everywhere else (function names, DB table, API paths, FK strings, module dirs).
- Touches 49 files; every change is a symmetric rename (342 insertions / 342 deletions).
- No DB migration: SQLModel derives table names via `cls.__name__.lower()`, so both spellings yield the same tables. FK and `back_populates` strings were already lowercase and are untouched.

## Renames
`BackTestBase` -> `BacktestBase`, `_BackTestRead` -> `_BacktestRead`, `BackTest` -> `Backtest`, `BackTestRead` -> `BacktestRead`, `OldBackTestRead` -> `OldBacktestRead`, `BackTestForecast` -> `BacktestForecast`, `BackTestMetric` -> `BacktestMetric`, `BackTestParams` -> `BacktestParams`, `BackTestCreate` -> `BacktestCreate`, `BackTestFull` -> `BacktestFull`, `BackTestUpdate` -> `BacktestUpdate`, `BackTestPlotType` -> `BacktestPlotType`, `BackTestStub` -> `BacktestStub`.

Already-correct classes (`BacktestDomain`, `MakeBacktestRequest`, `MakeBacktestWithDataRequest`, `BacktestSimulator`, `BacktestPlotBase`) were not changed.

## API impact
OpenAPI schema component names change accordingly (`BackTestRead` -> `BacktestRead`, etc.). URL paths (`/backtests`, `/create-backtest`), JSON field names, DB table/column names, and FK relationships are all unchanged. Frontend SDKs regenerated from the OpenAPI spec will pick up the new component names.

## Frontend (chap-frontend) impact
The consuming app at `chap-sdk/chap-frontend` does have a generated OpenAPI client and will need a follow-up PR. Impact is contained and mechanical:

**Generated client** (`packages/ui/src/httpfunctions/`) — 5 files get renamed on regeneration:
- `BackTest.ts` -> `Backtest.ts`
- `BackTestCreate.ts` -> `BacktestCreate.ts`
- `BackTestPlotType.ts` -> `BacktestPlotType.ts`
- `BackTestRead.ts` -> `BacktestRead.ts`
- `BackTestUpdate.ts` -> `BacktestUpdate.ts`

Already-correct files (no change): `BacktestDomain.ts`, `MakeBacktestRequest.ts`, `MakeBacktestWithDataRequest.ts`, `BacktestsService.ts`.

**App code**: 14 files import the renamed types (mostly `BackTestRead`, plus a few `BackTestPlotType`/`BackTestCreate`/`BackTestUpdate` references). Same project-wide search-and-replace pattern as the backend refactor.

**Unchanged**: URL paths, HTTP methods, operation IDs, service class names (`BacktestsService`), JSON field names, runtime behavior. Pure compile-time TypeScript rename.

**Follow-up steps** (after this PR merges + a new chap-core release ships):
1. Regenerate the OpenAPI client in chap-frontend.
2. Project-wide rename in app code, longest-first to avoid prefix collisions:
   - `BackTestRead` -> `BacktestRead`
   - `BackTestCreate` -> `BacktestCreate`
   - `BackTestUpdate` -> `BacktestUpdate`
   - `BackTestPlotType` -> `BacktestPlotType`
   - `BackTest` -> `Backtest`
3. `pnpm tsc --noEmit` to verify clean compile.

## Test plan
- [x] `make lint` clean
- [x] `make test` (735 passed, 110 skipped, 0 failed)
- [x] `uv run chap --help` starts cleanly
- [x] `tests/test_alembic_migrations.py` passes (covers the `alembic/env.py` import rename and confirms no schema drift)
- [x] `grep -rn "BackTest"` across tracked files returns zero hits