### PR TITLE
ci: run mypy and pyright in lint workflow (CLIM-653)

### DIFF
--- a/.github/workflows/ci-lint-code-style.yml
+++ b/.github/workflows/ci-lint-code-style.yml
@@ -2,9 +2,19 @@ name: Code Formatting & Linting
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
-  ruff:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: Set up Python
+        run: uv python install 3.13
+      - name: Install the project
+        run: uv sync --dev
+      - name: Run make check
+        run: make check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean coverage dist docs help install lint lint/flake8 regen-plot-help test-chapkit-compose force-restart restart chap-version
+.PHONY: clean coverage dist docs help install lint lint/flake8 check regen-plot-help test-chapkit-compose force-restart restart chap-version
 .DEFAULT_GOAL := help
 
 define PRINT_HELP_PYSCRIPT
@@ -32,6 +32,16 @@ lint: ## check and fix code style with ruff, run type checking
 	uv run ruff check --fix
 	@echo "Formatting code..."
 	uv run ruff format
+	@echo "Type checking (mypy)..."
+	uv run mypy
+	@echo "Type checking (pyright)..."
+	uv run pyright
+
+check: ## non-mutating lint + type checks (used in CI)
+	@echo "Ruff check..."
+	uv run ruff check
+	@echo "Ruff format check..."
+	uv run ruff format --check
 	@echo "Type checking (mypy)..."
 	uv run mypy
 	@echo "Type checking (pyright)..."


### PR DESCRIPTION
## Summary
- The `Code Formatting & Linting` workflow only ran ruff via `astral-sh/ruff-action@v1`. The project moved to ruff + mypy + pyright a while back (see `make lint`), but the CI workflow was never updated, so type-check regressions could land on master unnoticed.
- Add a non-mutating `make check` target that runs `ruff check`, `ruff format --check`, `mypy`, and `pyright`. The new lint workflow installs the project with `uv sync --dev` and calls `make check`.
- `make lint` is unchanged (still autofixes locally).

## Test plan
- [x] `make check` runs locally and reports the same output as `make lint`, minus the autofix steps
- [ ] CI run on this PR shows the new mypy and pyright steps execute

Tracking: CLIM-653