### PR TITLE
fix: update example model URL in eval command

### DIFF
--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -115,7 +115,7 @@ def eval_cmd(
 
     Examples:
         # Evaluate a GitHub-hosted model
-        chap eval --model-name https://github.com/dhis2-chap/minimalist_example_r \\
+        chap eval --model-name https://github.com/dhis2-chap/minimalist_example_uv \\
             --dataset-csv ./data/vietnam.csv --output-file ./results/eval.nc
 
         # Evaluate a chapkit model (REST API)


### PR DESCRIPTION
The R example model requires R to be installed. Otherwise it fails ungracefully. Switching the documentation to the python uv model instead (which probably requires uv installed, but @knutdrand  told me to commit this change).