### PR TITLE
fix: clearer error when Docker daemon is unreachable

### DIFF
--- a/chap_core/docker_helper_functions.py
+++ b/chap_core/docker_helper_functions.py
@@ -4,7 +4,37 @@ from pathlib import Path
 
 import docker
 
+from chap_core.exceptions import DockerUnavailableError
+
 logger = logging.getLogger(__name__)
+
+
+def _docker_client_or_raise(image_name: str | None = None):
+    """Return a docker client, raising DockerUnavailableError with actionable
+    guidance when the daemon is not reachable.
+
+    The message differs depending on whether chap-core is running inside the
+    server container (IS_IN_DOCKER=1) or locally (CLI / dev).
+    """
+    try:
+        return docker.from_env()
+    except docker.errors.DockerException as e:
+        ref = f" '{image_name}'" if image_name else ""
+        if os.environ.get("IS_IN_DOCKER"):
+            msg = (
+                f"Cannot reach the Docker daemon from the chap-core worker. "
+                f"Models with docker_env (image{ref}) cannot run on the server "
+                f"because the worker has no Docker socket access. "
+                f"Re-register the model without docker_env (use uv_env / renv_env / "
+                f"conda_env / python_env), or run it as a chapkit sidecar."
+            )
+        else:
+            msg = (
+                f"Cannot reach the Docker daemon. The model{ref} requires Docker "
+                f"to run. Start the daemon and retry: open Docker Desktop on macOS/Windows, "
+                f"or run `sudo systemctl start docker` on Linux."
+            )
+        raise DockerUnavailableError(msg) from e
 
 
 def create_docker_image(dockerfile_directory: Path | str):
@@ -21,7 +51,7 @@ def create_docker_image(dockerfile_directory: Path | str):
 
 
 def docker_image_from_fo(fileobject, name):
-    client = docker.from_env()
+    client = _docker_client_or_raise(name)
     response = client.api.build(fileobj=fileobject, tag=name, decode=True)
     for _ in response:
         pass
@@ -31,7 +61,7 @@ def docker_image_from_fo(fileobject, name):
 def run_command_through_docker_container(
     docker_image_name: str, working_directory: str, command: str, remove_after_run: bool = False
 ):
-    client = docker.from_env()
+    client = _docker_client_or_raise(docker_image_name)
     try:
         working_dir_full_path = os.path.abspath(working_directory)
     except FileNotFoundError:

--- a/chap_core/exceptions.py
+++ b/chap_core/exceptions.py
@@ -23,3 +23,7 @@ class InvalidDateError(Exception): ...
 
 class ChapkitServiceStartupError(Exception):
     """Raised when a chapkit model service fails to start."""
+
+
+class DockerUnavailableError(Exception):
+    """Raised when the Docker daemon cannot be reached."""

--- a/tests/external/test_docker.py
+++ b/tests/external/test_docker.py
@@ -4,6 +4,7 @@ from chap_core.docker_helper_functions import (
     create_docker_image,
     run_command_through_docker_container,
 )
+from chap_core.exceptions import DockerUnavailableError
 from chap_core.util import docker_available
 
 
@@ -34,3 +35,30 @@ def test_run_docker_basic(models_path):
 def test_run_docker_basic_r_inla(models_path):
     result = run_command_through_docker_container("ivargr/r_inla:latest", "./", "echo 'hi'")
     print(result)
+
+
+def _raise_docker_unavailable(*_args, **_kwargs):
+    raise docker.errors.DockerException(
+        "Error while fetching server API version: ('Connection aborted.', "
+        "FileNotFoundError(2, 'No such file or directory'))"
+    )
+
+
+def test_docker_unavailable_in_server(monkeypatch):
+    monkeypatch.setenv("IS_IN_DOCKER", "1")
+    monkeypatch.setattr("chap_core.docker_helper_functions.docker.from_env", _raise_docker_unavailable)
+    with pytest.raises(DockerUnavailableError) as excinfo:
+        run_command_through_docker_container("rwanda_malaria_bym", "./", "echo hi")
+    msg = str(excinfo.value)
+    assert "rwanda_malaria_bym" in msg
+    assert "chapkit" in msg
+    assert "docker_env" in msg
+
+
+def test_docker_unavailable_locally(monkeypatch):
+    monkeypatch.delenv("IS_IN_DOCKER", raising=False)
+    monkeypatch.setattr("chap_core.docker_helper_functions.docker.from_env", _raise_docker_unavailable)
+    with pytest.raises(DockerUnavailableError) as excinfo:
+        run_command_through_docker_container("some_model", "./", "echo hi")
+    msg = str(excinfo.value)
+    assert "Docker Desktop" in msg or "systemctl start docker" in msg


### PR DESCRIPTION
## Summary

When a model with a \`docker_env\` runs and \`docker.from_env()\` can't reach the Docker daemon, the user previously got a raw urllib3 \`ProtocolError\` / \`DockerException\` stack trace surfaced through Celery — unhelpful both on the server (where docker-in-docker is not supported) and locally (where the daemon may simply not be running).

This PR wraps \`docker.from_env()\` in a single helper that raises a new \`DockerUnavailableError\` with actionable guidance, branching on the \`IS_IN_DOCKER\` env var:

- **Server (\`IS_IN_DOCKER=1\`, e.g. the celery worker):** explains that \`docker_env\` models can't run on the server because the worker has no docker socket access, and points the user at re-registering the model without \`docker_env\` (uv / renv / conda / python_env) or running it as a chapkit sidecar.
- **Local (CLI / dev):** tells the user to start the daemon (Docker Desktop on macOS/Windows, \`sudo systemctl start docker\` on Linux).

Both \`docker_image_from_fo\` and \`run_command_through_docker_container\` route through the new helper. The clean message is what surfaces in the celery job's \`error\` field (via \`on_failure\`); the original \`DockerException\` is preserved as \`__cause__\` for the worker traceback.

## Test plan

- [x] \`uv run pytest tests/external/test_docker.py\` — added two unit tests that patch \`docker.from_env\` to raise and assert the right message branch is produced (with and without \`IS_IN_DOCKER\`).
- [x] \`uv run pytest tests/external/\` — full external suite still green (79 passed, 9 skipped).
- [x] \`make lint\` — clean.