### PR TITLE
fix: add report() to all CommandLine-based runners (CLIM-179)

### DIFF
--- a/chap_core/runners/command_line_runner.py
+++ b/chap_core/runners/command_line_runner.py
@@ -79,11 +79,13 @@ class CommandLineTrainPredictRunner(TrainPredictRunner):
         train_command: str,
         predict_command: str,
         model_configuration_filename: str | None = None,
+        report_command: str | None = None,
     ):
         self._runner = runner
         self._train_command = train_command
         self._predict_command = predict_command
         self._model_configuration_filename = model_configuration_filename
+        self._report_command = report_command
 
     def _format_command(self, command, keys):
         try:
@@ -128,4 +130,18 @@ class CommandLineTrainPredictRunner(TrainPredictRunner):
         keys = self._handle_polygons(self._predict_command, keys, polygons_file_name)
         keys = self._handle_config(self._predict_command, keys)
         command = self._format_command(self._predict_command, keys)
+        return self._runner.run_command(command)
+
+    def report(self, model_file_name, historic_data, output_file, polygons_file_name=None):
+        if self._report_command is None:
+            raise NotImplementedError("This runner does not support report generation")
+        keys = {
+            "model": model_file_name,
+            "historic_data": historic_data,
+            "out_file": output_file,
+        }
+        keys = self._handle_polygons(self._report_command, keys, polygons_file_name)
+        keys = self._handle_config(self._report_command, keys)
+        command = self._format_command(self._report_command, keys)
+        logger.debug(f"Running command {command}")
         return self._runner.run_command(command)

--- a/chap_core/runners/conda_runner.py
+++ b/chap_core/runners/conda_runner.py
@@ -58,8 +58,9 @@ class CondaTrainPredictRunner(CommandLineTrainPredictRunner):
         train_command: str,
         predict_command: str,
         model_configuration_filename: str | None = None,
+        report_command: str | None = None,
     ):
-        super().__init__(runner, train_command, predict_command, model_configuration_filename)
+        super().__init__(runner, train_command, predict_command, model_configuration_filename, report_command)
 
     def teardown(self):
         self._runner.teardown()

--- a/chap_core/runners/docker_runner.py
+++ b/chap_core/runners/docker_runner.py
@@ -49,10 +49,9 @@ class DockerTrainPredictRunner(CommandLineTrainPredictRunner):
         train_command: str,
         predict_command: str,
         model_configuration_filename: str | None = None,
+        report_command: str | None = None,
     ):
-        # assert False, (predict_command, model_configuration_filename)
-
-        super().__init__(runner, train_command, predict_command, model_configuration_filename)
+        super().__init__(runner, train_command, predict_command, model_configuration_filename, report_command)
 
     def teardown(self):
         self._runner.teardown()

--- a/chap_core/runners/helper_functions.py
+++ b/chap_core/runners/helper_functions.py
@@ -108,7 +108,9 @@ def get_train_predict_runner_from_model_template_config(
             assert model_template_config.docker_env is not None
             logging.debug(f"Docker image is {model_template_config.docker_env.image}")
             command_runner = DockerRunner(model_template_config.docker_env.image, working_dir, dry_run=dry_run)
-            return DockerTrainPredictRunner(command_runner, train_command, predict_command, yaml_filename, report_command)
+            return DockerTrainPredictRunner(
+                command_runner, train_command, predict_command, yaml_filename, report_command
+            )
     else:
         # assert model_configuration is None or model_configuration == {}, "ModelConfiguration (for templates) not supported when runner is mlflow for now"
         assert runner_type == "mlflow"

--- a/chap_core/runners/helper_functions.py
+++ b/chap_core/runners/helper_functions.py
@@ -57,10 +57,13 @@ def get_train_predict_runner_from_model_template_config(
     if skip_environment or runner_type in ("docker", "uv", "renv", "conda"):
         # read yaml file into a dict
         assert model_template_config.entry_points is not None
-        train_command = model_template_config.entry_points.train.command  # data["entry_points"]["train"]["command"]
-        predict_command = (
-            model_template_config.entry_points.predict.command
-        )  # data["entry_points"]["predict"]["command"]
+        train_command = model_template_config.entry_points.train.command
+        predict_command = model_template_config.entry_points.predict.command
+        report_command = (
+            model_template_config.entry_points.report.command
+            if model_template_config.entry_points.report is not None
+            else None
+        )
 
         # dump model configuration to a tmp file in working_dir, pass this file to the train and predict command
         # pydantic write to yaml
@@ -74,6 +77,7 @@ def get_train_predict_runner_from_model_template_config(
                 train_command,
                 predict_command,
                 model_configuration_filename=yaml_filename,
+                report_command=report_command,
             )
         elif runner_type == "uv":
             return UvTrainPredictRunner(
@@ -81,6 +85,7 @@ def get_train_predict_runner_from_model_template_config(
                 train_command,
                 predict_command,
                 model_configuration_filename=yaml_filename,
+                report_command=report_command,
             )
         elif runner_type == "renv":
             return RenvTrainPredictRunner(
@@ -88,6 +93,7 @@ def get_train_predict_runner_from_model_template_config(
                 train_command,
                 predict_command,
                 model_configuration_filename=yaml_filename,
+                report_command=report_command,
             )
         elif runner_type == "conda":
             assert model_template_config.conda_env is not None
@@ -96,12 +102,13 @@ def get_train_predict_runner_from_model_template_config(
                 train_command,
                 predict_command,
                 model_configuration_filename=yaml_filename,
+                report_command=report_command,
             )
         else:
             assert model_template_config.docker_env is not None
             logging.debug(f"Docker image is {model_template_config.docker_env.image}")
             command_runner = DockerRunner(model_template_config.docker_env.image, working_dir, dry_run=dry_run)
-            return DockerTrainPredictRunner(command_runner, train_command, predict_command, yaml_filename)
+            return DockerTrainPredictRunner(command_runner, train_command, predict_command, yaml_filename, report_command)
     else:
         # assert model_configuration is None or model_configuration == {}, "ModelConfiguration (for templates) not supported when runner is mlflow for now"
         assert runner_type == "mlflow"

--- a/chap_core/runners/renv_runner.py
+++ b/chap_core/runners/renv_runner.py
@@ -60,8 +60,9 @@ class RenvTrainPredictRunner(CommandLineTrainPredictRunner):
         train_command: str,
         predict_command: str,
         model_configuration_filename: str | None = None,
+        report_command: str | None = None,
     ):
-        super().__init__(runner, train_command, predict_command, model_configuration_filename)
+        super().__init__(runner, train_command, predict_command, model_configuration_filename, report_command)
 
     def teardown(self):
         self._runner.teardown()

--- a/chap_core/runners/uv_runner.py
+++ b/chap_core/runners/uv_runner.py
@@ -41,8 +41,9 @@ class UvTrainPredictRunner(CommandLineTrainPredictRunner):
         train_command: str,
         predict_command: str,
         model_configuration_filename: str | None = None,
+        report_command: str | None = None,
     ):
-        super().__init__(runner, train_command, predict_command, model_configuration_filename)
+        super().__init__(runner, train_command, predict_command, model_configuration_filename, report_command)
 
     def teardown(self):
         self._runner.teardown()

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -238,6 +238,35 @@ def test_conda_runner_fails_without_env_file(tmp_path):
         runner.run_command("python main.py train data.csv model.pkl")
 
 
+def test_command_line_runner_report_formats_command():
+    """Test that CommandLineTrainPredictRunner.report() formats and runs the report command."""
+    with patch.object(CommandLineRunner, "run_command") as mock_run:
+        mock_run.return_value = "done"
+        from chap_core.runners.command_line_runner import CommandLineTrainPredictRunner
+
+        runner = CommandLineTrainPredictRunner(
+            CommandLineRunner(Path(".")),
+            train_command="python train.py {train_data} {model}",
+            predict_command="python predict.py {model} {historic_data} {future_data} {out_file}",
+            report_command="python report.py {model} {historic_data} {out_file}",
+        )
+        runner.report("model.pkl", "historic.csv", "report.pdf")
+        mock_run.assert_called_once_with("python report.py model.pkl historic.csv report.pdf")
+
+
+def test_command_line_runner_report_raises_when_no_command():
+    """Test that CommandLineTrainPredictRunner.report() raises NotImplementedError when no report command is set."""
+    from chap_core.runners.command_line_runner import CommandLineTrainPredictRunner
+
+    runner = CommandLineTrainPredictRunner(
+        CommandLineRunner(Path(".")),
+        train_command="python train.py {train_data} {model}",
+        predict_command="python predict.py {model} {historic_data} {future_data} {out_file}",
+    )
+    with pytest.raises(NotImplementedError):
+        runner.report("model.pkl", "historic.csv", "report.pdf")
+
+
 def test_mlflow_runner_report_invokes_report_entry_point(tmp_path):
     runner = MlFlowTrainPredictRunner(model_path=tmp_path)
     with patch("mlflow.projects.run") as mock_run:


### PR DESCRIPTION
Extends the report() entry point from CLIM-179 to all CommandLine-based runners (CommandLineTrainPredictRunner, UvTrainPredictRunner, RenvTrainPredictRunner, DockerTrainPredictRunner, CondaTrainPredictRunner). Tests added.