### PR TITLE
chore: bump ewars_template default to v6

### DIFF
--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -44,6 +44,7 @@
     v2: 'main'
     v3: 'e4520a2123a3228c10947f2b25029c3f7190e320'
     v4: 'cb4edc53ce3ed1353ae5b60a501b23095d8430fc'
+    v5: '5b2affb989f4900251f75ba95c3bd814e255357d'
   configurations:
     default:
       user_option_values:

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -45,10 +45,11 @@
     v3: 'e4520a2123a3228c10947f2b25029c3f7190e320'
     v4: 'cb4edc53ce3ed1353ae5b60a501b23095d8430fc'
     v5: '5b2affb989f4900251f75ba95c3bd814e255357d'
+    v6: 'cdd06ed61ee0f6eccab1fc9b9d74eb52cb122539'
   configurations:
     default:
       user_option_values:
-        n_lags: [3]
+        n_lags: 3
         precision: 1
       additional_continuous_covariates:
         - rainfall

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -48,7 +48,7 @@
   configurations:
     default:
       user_option_values:
-        n_lags: 3
+        n_lags: [3]
         precision: 1
       additional_continuous_covariates:
         - rainfall


### PR DESCRIPTION
## Summary

Adds `v5` and `v6` version lines to the `ewars_template` entry in `config/configured_models/default.yaml`. Per the comment at the top of that file, only the last version listed is seeded into the database, so this makes **v6** the active version.

- **v5** (`5b2affb`) — merged form of [chap-models/ewars_template#3](https://github.com/chap-models/ewars_template/pull/3): per-covariate `n_lags` (array of integers, paired by position with `additional_continuous_covariates`) and a `region_seasonal` boolean user option.
- **v6** (`cdd06ed`) — merged form of [chap-models/ewars_template#4](https://github.com/chap-models/ewars_template/pull/4): widens the `n_lags` schema to accept either an integer or an array of integers, so the existing scalar form keeps validating.

## Default configuration

Unchanged from before: `n_lags: 3`, `precision: 1`, two continuous covariates. v6's relaxed schema accepts the scalar; the R model broadcasts a length-1 lag list across all covariates.

## Test plan

- [x] `tests/test_database.py::test_seed_configured_models` passes locally with the bumped config.
- [ ] Start chap-core with a fresh DB and confirm the `ewars_template` entry seeds with `v6` selected.