### PR TITLE
feat: write prediction_length to run config YAML for MLproject models (CLIM-685)

### DIFF
--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -373,7 +373,9 @@ class SessionWrapper:
             self.session.commit()
         return cast("str", live_url)
 
-    def get_configured_model_with_code(self, configured_model_id: int) -> ConfiguredModel:
+    def get_configured_model_with_code(
+        self, configured_model_id: int, prediction_length: int | None = None
+    ) -> ConfiguredModel:
         logger.info(f"Getting configured model with id {configured_model_id}")
         configured_model = self.session.get(ConfiguredModelDB, configured_model_id)
         if configured_model is None:
@@ -397,7 +399,7 @@ class SessionWrapper:
             template = ExternalChapkitModelTemplate(source_url)
             logger.info(f"template: {template}")
             logger.info(f"configured_model: {configured_model}")
-            return template.get_model(configured_model)  # type: ignore[arg-type, return-value]
+            return template.get_model(configured_model, prediction_length=prediction_length)  # type: ignore[arg-type, return-value]
         else:
             logger.info(f"Assuming github model at {configured_model.model_template.source_url}")
             return cast(
@@ -405,7 +407,7 @@ class SessionWrapper:
                 ModelTemplate.from_directory_or_github_url(
                     configured_model.model_template.source_url,
                     ignore_env=ignore_env,
-                ).get_model(configured_model),  # type: ignore[arg-type]
+                ).get_model(configured_model, prediction_length=prediction_length),  # type: ignore[arg-type]
             )
 
     def get_model_template(self, model_template_id: int) -> ModelTemplateDB:

--- a/chap_core/models/external_chapkit_model.py
+++ b/chap_core/models/external_chapkit_model.py
@@ -205,10 +205,18 @@ class ExternalChapkitModelTemplate:
             )
             return False
 
-    def get_model(self, model_configuration: dict) -> "ExternalChapkitModel":
+    def get_model(
+        self,
+        model_configuration: dict,
+        prediction_length: int | None = None,
+    ) -> "ExternalChapkitModel":
         """
         Sends the model configuration for storing in the model (by sending to the model rest api).
         This returns a configuration id back that we can use to identify the model.
+
+        ``prediction_length`` is accepted for interface compatibility with
+        ``ModelTemplate.get_model``; chapkit models receive the horizon at
+        train/predict time via :class:`RunInfo` instead of via this method.
         """
         self._ensure_initialized()
         assert self.client is not None

--- a/chap_core/models/model_template.py
+++ b/chap_core/models/model_template.py
@@ -99,7 +99,11 @@ class ModelTemplate:
     def get_default_model(self) -> ExternalModel:
         return self.get_model()
 
-    def get_model(self, model_configuration: ModelConfiguration | None = None) -> ExternalModel:
+    def get_model(
+        self,
+        model_configuration: ModelConfiguration | None = None,
+        prediction_length: int | None = None,
+    ) -> ExternalModel:
         """
         Returns a model based on the model configuration. The model configuration is an object of the class
         returned by get_model_class (i.e. specified by the user). If no model configuration is passed, the default
@@ -109,6 +113,10 @@ class ModelTemplate:
         ----------
         model_configuration : ModelConfiguration, optional
             The configuration for the model, by default None
+        prediction_length : int, optional
+            Forecast horizon (number of periods) the model will be asked to predict.
+            When supplied, written into ``model_configuration_for_run.yaml`` so
+            MLproject-based models can read it at both train and predict time.
 
         Returns
         -------
@@ -145,6 +153,7 @@ class ModelTemplate:
             self._ignore_env,
             model_configuration,
             dry_run=self._dry_run,
+            prediction_length=prediction_length,
         )
 
         config = self._model_template_config

--- a/chap_core/models/model_template_interface.py
+++ b/chap_core/models/model_template_interface.py
@@ -29,7 +29,11 @@ class ModelTemplateInterface(abc.ABC):
     def get_schema(self) -> ModelTemplateInformation: ...
 
     @abc.abstractmethod
-    def get_model(self, model_configuration: ModelConfiguration | None = None) -> "ConfiguredModel":
+    def get_model(
+        self,
+        model_configuration: ModelConfiguration | None = None,
+        prediction_length: int | None = None,
+    ) -> "ConfiguredModel":
         pass
 
     def get_default_model(self) -> "ConfiguredModel":

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -114,7 +114,7 @@ def run_backtest(
 
     status_logger.info(f"Running {n_splits} evaluation splits with prediction length {n_periods}")
     assert configured_model.id is not None, "configured_model.id is required"
-    estimator = session.get_configured_model_with_code(configured_model.id)
+    estimator = session.get_configured_model_with_code(configured_model.id, prediction_length=n_periods)
     predictions_list = _backtest(
         estimator,
         dataset,
@@ -165,7 +165,7 @@ def run_prediction(
     status_logger.info(f"Training model and generating {n_periods} period forecast")
     configured_model = session.get_configured_model_by_name(model_id)
     assert configured_model.id is not None, "configured_model.id is required"
-    estimator = session.get_configured_model_with_code(configured_model.id)
+    estimator = session.get_configured_model_with_code(configured_model.id, prediction_length=n_periods)
     predictions = forecast_ahead(estimator, dataset, n_periods)
     db_id = session.add_predictions(
         predictions,

--- a/chap_core/runners/helper_functions.py
+++ b/chap_core/runners/helper_functions.py
@@ -25,12 +25,18 @@ def get_train_predict_runner_from_model_template_config(
     skip_environment=False,
     model_configuration: Optional["ModelConfiguration"] = None,
     dry_run=False,
+    prediction_length: int | None = None,
 ) -> TrainPredictRunner:
     """
     Utility function that returns a suitbale runner for a model given a ModelTemplateConfig (which contains information
     about what runner the Template says that its models shold use)
     Returns a TrainPredictRunner (e.g. a MlFlowTrainPredictRunner or a DockerTrainPredictRunner) by parsing
     the config for the template.
+
+    When ``prediction_length`` is provided it is written as a root-level
+    ``prediction_length`` key in ``model_configuration_for_run.yaml`` so that
+    MLproject-based external models (mlflow / uv / conda / docker / renv) can
+    read it from the same config file at both train and predict time.
     """
     if model_template_config.docker_env is not None:
         runner_type = "docker"
@@ -52,6 +58,14 @@ def get_train_predict_runner_from_model_template_config(
     model_configuration_file = working_dir / yaml_filename
     with open(model_configuration_file, "w") as file:
         config_dict = model_configuration.model_dump() if model_configuration is not None else {}
+        if prediction_length is not None:
+            if "prediction_length" in config_dict:
+                logger.warning(
+                    "Overriding prediction_length=%r from ModelConfiguration with chap-provided value %r",
+                    config_dict["prediction_length"],
+                    prediction_length,
+                )
+            config_dict["prediction_length"] = int(prediction_length)
         yaml.dump(config_dict, file)
 
     if skip_environment or runner_type in ("docker", "uv", "renv", "conda"):

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import patch, MagicMock, ANY
 
+import yaml
+
 from chap_core.exceptions import CommandLineException, ModelFailedException
 from chap_core.runners.command_line_runner import CommandLineRunner
 from chap_core.runners.docker_runner import DockerRunner
@@ -89,6 +91,63 @@ def test_runner_selection_with_uv_env(tmp_path):
     )
     runner = get_train_predict_runner_from_model_template_config(config, tmp_path)
     assert isinstance(runner, UvTrainPredictRunner)
+
+
+def test_runner_writes_prediction_length_to_run_config_yaml(tmp_path):
+    """prediction_length is written at the root of model_configuration_for_run.yaml so that
+    MLproject-based external models can read the horizon at both train and predict time."""
+    config = ModelTemplateConfigV2(
+        name="test_model",
+        uv_env="pyproject.toml",
+        entry_points=EntryPointConfig(
+            train=CommandConfig(
+                command="python main.py train {train_data} {model}",
+                parameters={"train_data": "str", "model": "str"},
+            ),
+            predict=CommandConfig(
+                command="python main.py predict {model} {historic_data} {future_data} {out_file}",
+                parameters={
+                    "model": "str",
+                    "historic_data": "str",
+                    "future_data": "str",
+                    "out_file": "str",
+                },
+            ),
+        ),
+    )
+
+    get_train_predict_runner_from_model_template_config(config, tmp_path, prediction_length=5)
+
+    written = yaml.safe_load((tmp_path / "model_configuration_for_run.yaml").read_text())
+    assert written["prediction_length"] == 5
+
+
+def test_runner_omits_prediction_length_when_not_provided(tmp_path):
+    """When prediction_length is not supplied, the YAML must not gain a stray key."""
+    config = ModelTemplateConfigV2(
+        name="test_model",
+        uv_env="pyproject.toml",
+        entry_points=EntryPointConfig(
+            train=CommandConfig(
+                command="python main.py train {train_data} {model}",
+                parameters={"train_data": "str", "model": "str"},
+            ),
+            predict=CommandConfig(
+                command="python main.py predict {model} {historic_data} {future_data} {out_file}",
+                parameters={
+                    "model": "str",
+                    "historic_data": "str",
+                    "future_data": "str",
+                    "out_file": "str",
+                },
+            ),
+        ),
+    )
+
+    get_train_predict_runner_from_model_template_config(config, tmp_path)
+
+    written = yaml.safe_load((tmp_path / "model_configuration_for_run.yaml").read_text()) or {}
+    assert "prediction_length" not in written
 
 
 def test_renv_runner_restores_and_runs_command(tmp_path):


### PR DESCRIPTION
## Summary

- MLproject-based external models (mlflow / uv / conda / docker / renv) had no way to receive the forecast horizon. The runner only forwarded `historic_data`, `future_data`, `model`, `out_file`. ChapKit/REST API models get it via `RunInfo`, but that path is not exercised in production.
- Plumb an optional `prediction_length` kwarg from the worker / DB session helper through `ModelTemplate.get_model` and `get_train_predict_runner_from_model_template_config`, then write it as a root-level `prediction_length` key in `model_configuration_for_run.yaml`. External train and predict commands read it from the same config file they already receive.
- `prediction_length` is constant for the lifetime of an `ExternalModel` (same value at train and every predict call), so the YAML is written once at runner construction; no per-predict rewriting.

## Plumbing

- `ModelTemplateInterface.get_model` and `ModelTemplate.get_model` now accept `prediction_length: int | None = None`.
- `ExternalChapkitModelTemplate.get_model` accepts the kwarg for interface compatibility but ignores it (chapkit gets the horizon via `RunInfo`).
- `SessionWrapper.get_configured_model_with_code` accepts and forwards `prediction_length`.
- `db_worker_functions.run_evaluation` and `run_prediction` pass `n_periods` through.
- `get_train_predict_runner_from_model_template_config` writes `prediction_length` into the dumped config dict (root-level) before `yaml.dump`. If the user's `ModelConfiguration` already contains a `prediction_length`, chap's value wins and a warning is logged.
- Default `None` means existing call sites without the horizon in scope behave identically to today (key omitted).

## Test plan

- [x] `make lint` (clean)
- [x] `make test` (749 passed; the single failure is on an untracked local design doc `docs/contributor/rest_api_cleanup_plan.md` and unrelated to this change)
- New focused tests in `tests/runners/test_runners.py`:
  - `test_runner_writes_prediction_length_to_run_config_yaml`: pass `prediction_length=5`, assert YAML root contains `prediction_length: 5`
  - `test_runner_omits_prediction_length_when_not_provided`: confirms back-compat (key absent when not supplied)