### PR TITLE
fix: honour prediction-length bounds even when only one is declared

### DIFF
--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -195,18 +195,23 @@ def eval_cmd(
             raise NotImplementedError("Ensemble mode is not yet implemented")
 
         model_info = estimator.model_information
-        if model_info.min_prediction_length is None or model_info.max_prediction_length is None:
+        if model_info.min_prediction_length is None and model_info.max_prediction_length is None:
             logger.warning("Model has not specified minimum and maximum predicted length")
-        else:
-            if model_info.min_prediction_length > backtest_params.n_periods:
-                raise ValueError(
-                    f"The desired prediction length of {backtest_params.n_periods} is less than the model's minimum prediction length of {model_info.min_prediction_length}"
-                )
-            elif model_info.max_prediction_length < backtest_params.n_periods:
-                logger.warning(
-                    f"Wrapping model to extend prediction length from {model_info.max_prediction_length} to {backtest_params.n_periods}. This is done iteratively, and may worsen model performance"
-                )
-                estimator = ExtendedPredictor(estimator, backtest_params.n_periods)
+        if (
+            model_info.min_prediction_length is not None
+            and model_info.min_prediction_length > backtest_params.n_periods
+        ):
+            raise ValueError(
+                f"The desired prediction length of {backtest_params.n_periods} is less than the model's minimum prediction length of {model_info.min_prediction_length}"
+            )
+        if (
+            model_info.max_prediction_length is not None
+            and model_info.max_prediction_length < backtest_params.n_periods
+        ):
+            logger.warning(
+                f"Wrapping model to extend prediction length from {model_info.max_prediction_length} to {backtest_params.n_periods}. This is done iteratively, and may worsen model performance"
+            )
+            estimator = ExtendedPredictor(estimator, backtest_params.n_periods)
 
         model_template_db = ModelTemplateDB(
             id=template.model_template_config.name,

--- a/tests/external/test_model_specification.py
+++ b/tests/external/test_model_specification.py
@@ -79,3 +79,36 @@ entry_points:
 
     assert template.model_template_config.min_prediction_length == 2
     assert template.model_template_config.max_prediction_length == 6
+
+
+def test_mlproject_max_prediction_length_only_parses_with_min_none(tmp_path):
+    """Real models in the wild (e.g. chap-models/Vietnam-dengue-superensemble) declare
+    only max_prediction_length and leave min_prediction_length unset. Both halves of
+    the contract must be visible on the parsed config: max as the declared int, min as None."""
+    from chap_core.models.utils import get_model_template_from_mlproject_file
+
+    mlproject_yaml = """name: vietnam_style_model
+max_prediction_length: 1
+docker_env:
+  image: ghcr.io/dhis2-chap/docker_r_inla:master
+entry_points:
+  train:
+    parameters:
+      train_data: path
+      model: str
+    command: "Rscript train.R {train_data} {model}"
+  predict:
+    parameters:
+      model: str
+      historic_data: path
+      future_data: path
+      out_file: path
+    command: "Rscript predict.R {model} {historic_data} {future_data} {out_file}"
+"""
+    mlproject_file = tmp_path / "MLproject"
+    mlproject_file.write_text(mlproject_yaml)
+
+    template = get_model_template_from_mlproject_file(mlproject_file)
+
+    assert template.model_template_config.max_prediction_length == 1
+    assert template.model_template_config.min_prediction_length is None

--- a/tests/external/test_model_specification.py
+++ b/tests/external/test_model_specification.py
@@ -45,3 +45,37 @@ def test_parse_deepar_model_as_model_template(example_config):
     # parse yaml
     example_config = yaml.load(example_config, Loader=yaml.FullLoader)
     parsed = ModelTemplateConfigV2.model_validate(example_config)
+
+
+def test_mlproject_min_max_prediction_length_parsed_into_model_template(tmp_path):
+    """End-to-end: MLproject file declares min/max_prediction_length at the root,
+    and those values must reach ModelTemplate.model_template_config so that
+    eval_cmd's dispatch logic (and any other consumer of model_information)
+    can read them."""
+    from chap_core.models.utils import get_model_template_from_mlproject_file
+
+    mlproject_yaml = """name: bounded_horizon_model
+min_prediction_length: 2
+max_prediction_length: 6
+uv_env: pyproject.toml
+entry_points:
+  train:
+    parameters:
+      train_data: str
+      model: str
+    command: "python main.py train {train_data} {model}"
+  predict:
+    parameters:
+      model: str
+      historic_data: str
+      future_data: str
+      out_file: str
+    command: "python main.py predict {model} {historic_data} {future_data} {out_file}"
+"""
+    mlproject_file = tmp_path / "MLproject"
+    mlproject_file.write_text(mlproject_yaml)
+
+    template = get_model_template_from_mlproject_file(mlproject_file)
+
+    assert template.model_template_config.min_prediction_length == 2
+    assert template.model_template_config.max_prediction_length == 6

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,6 +130,46 @@ def test_eval_cmd_wraps_in_extended_predictor_when_n_periods_above_max(tmp_path)
     assert isinstance(forwarded, ExtendedPredictor)
 
 
+def test_eval_cmd_wraps_when_only_max_set_and_below_n_periods(tmp_path):
+    """Real models often declare max_prediction_length but leave min unset
+    (e.g. chap-models/Vietnam-dengue-superensemble declares max=1, no min).
+    The dispatch must still honour the declared max even when min is None."""
+    from chap_core.api_types import BacktestParams, RunConfig
+    from chap_core.external.ExtendedPredictor import ExtendedPredictor
+
+    fake_estimator = _make_fake_estimator(min_prediction_length=None, max_prediction_length=2)
+    stack, eval_mock = _patched_eval_chain(fake_estimator)
+    with stack:
+        eval_cmd(
+            model_name="dummy",
+            dataset_csv="dummy.csv",
+            output_file=tmp_path / "out.nc",
+            backtest_params=BacktestParams(n_periods=5, n_splits=2, stride=1),
+            run_config=RunConfig(),
+        )
+
+    assert eval_mock.create.call_count == 1
+    forwarded = eval_mock.create.call_args.kwargs["estimator"]
+    assert isinstance(forwarded, ExtendedPredictor)
+
+
+def test_eval_cmd_raises_when_only_min_set_and_above_n_periods(tmp_path):
+    """The min-bound check must also fire when only min is declared and max is None."""
+    from chap_core.api_types import BacktestParams, RunConfig
+
+    fake_estimator = _make_fake_estimator(min_prediction_length=5, max_prediction_length=None)
+    stack, _ = _patched_eval_chain(fake_estimator)
+    with stack:
+        with pytest.raises(ValueError, match="minimum prediction length"):
+            eval_cmd(
+                model_name="dummy",
+                dataset_csv="dummy.csv",
+                output_file=tmp_path / "out.nc",
+                backtest_params=BacktestParams(n_periods=3, n_splits=2, stride=1),
+                run_config=RunConfig(),
+            )
+
+
 def test_eval_cmd_does_not_wrap_when_bounds_unspecified(tmp_path):
     """When the model declares neither min nor max, dispatch logs a warning and forwards
     the original estimator unchanged."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,6 @@
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
 from chap_core.api import forecast
 import pytest
 from chap_core.util import docker_available
@@ -37,6 +40,115 @@ def test_eval_cmd(tmp_path):
 
     # Verify output file was created
     assert output_file.exists()
+
+
+def _make_fake_estimator(min_prediction_length, max_prediction_length):
+    from chap_core.database.model_templates_and_config_tables import ModelTemplateInformation
+
+    info = ModelTemplateInformation(
+        min_prediction_length=min_prediction_length,
+        max_prediction_length=max_prediction_length,
+    )
+    estimator = MagicMock(name="FakeEstimator")
+    estimator.model_information = info
+    return estimator
+
+
+def _patched_eval_chain(fake_estimator):
+    """Stack mocks for the parts of eval_cmd that aren't under test, returning
+    the Evaluation mock so the caller can inspect ``Evaluation.create`` calls."""
+    template_cm = MagicMock(name="ModelTemplate")
+    template_cm.__enter__.return_value = template_cm
+    template_cm.__exit__.return_value = False
+    template_cm.model_template_config.name = "test_model"
+    template_cm.model_template_config.version = "1"
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "chap_core.cli_endpoints.evaluate.resolve_csv_path",
+            return_value=("dummy.csv", None),
+        )
+    )
+    stack.enter_context(patch("chap_core.cli_endpoints.evaluate.discover_geojson", return_value=None))
+    stack.enter_context(
+        patch(
+            "chap_core.cli_endpoints.evaluate.load_dataset_from_csv",
+            return_value=MagicMock(name="DataSet"),
+        )
+    )
+    stack.enter_context(patch("chap_core.log_config.initialize_logging"))
+    mt_mock = stack.enter_context(patch("chap_core.models.model_template.ModelTemplate"))
+    mt_mock.from_directory_or_github_url.return_value = template_cm
+    stack.enter_context(
+        patch(
+            "chap_core.cli_endpoints.evaluate.get_estimator",
+            return_value=(fake_estimator, None),
+        )
+    )
+    eval_mock = stack.enter_context(patch("chap_core.assessment.evaluation.Evaluation"))
+    eval_mock.create.return_value = MagicMock(name="EvaluationInstance")
+    return stack, eval_mock
+
+
+def test_eval_cmd_raises_when_n_periods_below_min_prediction_length(tmp_path):
+    """Dispatch in evaluate.py guards against horizons shorter than the model's declared min."""
+    from chap_core.api_types import BacktestParams, RunConfig
+
+    fake_estimator = _make_fake_estimator(min_prediction_length=5, max_prediction_length=10)
+    stack, _ = _patched_eval_chain(fake_estimator)
+    with stack:
+        with pytest.raises(ValueError, match="minimum prediction length"):
+            eval_cmd(
+                model_name="dummy",
+                dataset_csv="dummy.csv",
+                output_file=tmp_path / "out.nc",
+                backtest_params=BacktestParams(n_periods=3, n_splits=2, stride=1),
+                run_config=RunConfig(),
+            )
+
+
+def test_eval_cmd_wraps_in_extended_predictor_when_n_periods_above_max(tmp_path):
+    """When the requested horizon exceeds the model's declared max, the dispatch wraps
+    the estimator in ExtendedPredictor and forwards the wrapped estimator to evaluation."""
+    from chap_core.api_types import BacktestParams, RunConfig
+    from chap_core.external.ExtendedPredictor import ExtendedPredictor
+
+    fake_estimator = _make_fake_estimator(min_prediction_length=1, max_prediction_length=2)
+    stack, eval_mock = _patched_eval_chain(fake_estimator)
+    with stack:
+        eval_cmd(
+            model_name="dummy",
+            dataset_csv="dummy.csv",
+            output_file=tmp_path / "out.nc",
+            backtest_params=BacktestParams(n_periods=5, n_splits=2, stride=1),
+            run_config=RunConfig(),
+        )
+
+    assert eval_mock.create.call_count == 1
+    forwarded = eval_mock.create.call_args.kwargs["estimator"]
+    assert isinstance(forwarded, ExtendedPredictor)
+
+
+def test_eval_cmd_does_not_wrap_when_bounds_unspecified(tmp_path):
+    """When the model declares neither min nor max, dispatch logs a warning and forwards
+    the original estimator unchanged."""
+    from chap_core.api_types import BacktestParams, RunConfig
+
+    fake_estimator = _make_fake_estimator(min_prediction_length=None, max_prediction_length=None)
+    stack, eval_mock = _patched_eval_chain(fake_estimator)
+    with stack:
+        eval_cmd(
+            model_name="dummy",
+            dataset_csv="dummy.csv",
+            output_file=tmp_path / "out.nc",
+            backtest_params=BacktestParams(n_periods=3, n_splits=2, stride=1),
+            run_config=RunConfig(),
+        )
+
+    assert eval_mock.create.call_count == 1
+    forwarded = eval_mock.create.call_args.kwargs["estimator"]
+    assert forwarded is fake_estimator
 
 
 def test_eval_cmd_with_data_source_mapping(tmp_path):


### PR DESCRIPTION
## Summary

- `eval_cmd`'s dispatch logic gated the entire `min/max_prediction_length` check on both bounds being non-None. Real models in the wild declare only one bound — e.g. [chap-models/Vietnam-dengue-superensemble](https://github.com/chap-models/Vietnam-dengue-superensemble/blob/main/MLproject) declares `max_prediction_length: 1` with no min — and the asymmetric case fell into the "Model has not specified minimum and maximum predicted length" warning, silently ignoring the declared bound and skipping the `ExtendedPredictor` wrap.
- Each bound is now checked independently. The fall-through warning still fires, but only when both are unset.

## What was broken

`evaluate.py` (before):

```python
if min is None or max is None:
    logger.warning("Model has not specified minimum and maximum predicted length")
else:
    if min > n_periods: raise ValueError(...)
    elif max < n_periods: estimator = ExtendedPredictor(...)
```

For Vietnam (`min=None, max=1`), running `chap eval ... --backtest-params.n-periods 3` would just log the warning and ask the model directly for a 3-step forecast.

## What changes

- `min` and `max` checks each gated by their own `is not None`. Existing behaviour preserved when both are set or both are unset.
- Two new dispatch tests for the asymmetric cases (min-only raises; max-only wraps).
- Three earlier commits add coverage that was missing before this fix:
  - dispatch tests for the original (both-set / both-unset) cases
  - MLproject parse test confirming both bounds reach `ModelTemplate.model_template_config`
  - MLproject parse test for the Vietnam-style `max_prediction_length`-only declaration

## Test plan

- [x] `make lint` clean
- [x] `make test` — 754 passed (the single failure is on an untracked local design doc unrelated to this branch)
- New tests live in `tests/test_cli.py` and `tests/external/test_model_specification.py`