### PR TITLE
fix: return 200 with rejection summary on fully-rejected dry-run backtest (CLIM-582)

### DIFF
--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -583,8 +583,18 @@ async def create_backtest_with_data(
     database_url: str = Depends(get_database_url),
     worker_settings=Depends(get_settings),
 ):
-    feature_names, provided_data_processed = _read_dataset(request)
-    provided_data_processed, rejections = _validate_full_dataset(feature_names, provided_data_processed)
+    try:
+        feature_names, provided_data_processed = _read_dataset(request)
+        provided_data_processed, rejections = _validate_full_dataset(feature_names, provided_data_processed)
+    except HTTPException as exc:
+        if not dry_run or exc.status_code != 400:
+            raise
+        # Rejections, when present, were serialised by `_validate_full_dataset` into
+        # `exc.detail["rejected"]`. The empty-`provided_data` case in `_read_dataset`
+        # raises with a plain-string detail and has no rejections to recover. If
+        # either helper changes its detail shape, this branch must be updated.
+        rejected: list = exc.detail.get("rejected", []) if isinstance(exc.detail, dict) else []
+        return ImportSummaryResponse.model_validate({"id": None, "imported_count": 0, "rejected": rejected})
     backtest_params = BacktestParams(**request.model_dump())
     train_set, _ = train_test_generator(
         provided_data_processed, backtest_params.n_periods, backtest_params.n_splits, stride=backtest_params.stride

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -595,6 +595,39 @@ def test_backtest_with_empty_provided_data(dependency_overrides, create_backtest
     assert "No observation data provided" in response.json()["detail"]
 
 
+def test_backtest_with_empty_provided_data_dry_run(dependency_overrides, create_backtest_with_data_request):
+    request_payload = create_backtest_with_data_request.model_dump()
+    request_payload["provided_data"] = []
+    response = client.post("/v1/analytics/create-backtest-with-data?dryRun=true", json=request_payload)
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["id"] is None
+    assert body["importedCount"] == 0
+    assert body["rejected"] == []
+
+
+def test_backtest_with_all_regions_rejected_dry_run(dependency_overrides, create_backtest_with_data_request):
+    request_payload = create_backtest_with_data_request.model_dump()
+    obs = request_payload["provided_data"]
+    target_feature = next(e["feature_name"] for e in obs if e["feature_name"] != "disease_cases")
+    seen_locations = set()
+    pruned = []
+    for entry in obs:
+        if entry["feature_name"] == target_feature and entry["org_unit"] not in seen_locations:
+            seen_locations.add(entry["org_unit"])
+            continue
+        pruned.append(entry)
+    request_payload["provided_data"] = pruned
+
+    response = client.post("/v1/analytics/create-backtest-with-data?dryRun=true", json=request_payload)
+    assert response.status_code == 200, response.json()
+    body = response.json()
+    assert body["id"] is None
+    assert body["importedCount"] == 0
+    assert len(body["rejected"]) > 0
+    assert all(r["featureName"] == target_feature for r in body["rejected"])
+
+
 @pytest.mark.parametrize("dry_run", [False, True])
 def test_backtest_with_weekly_data_flow(
     celery_session_worker, dependency_overrides, example_polygons, create_backtest_with_weekly_data_request, dry_run


### PR DESCRIPTION
## Summary

- `POST /v1/analytics/create-backtest-with-data/?dryRun=true` returned HTTP 400 when `provided_data` was empty or every region was rejected for missing covariate values. The modeling app expects dry-run to surface validation errors as HTTP 200 with an `ImportSummaryResponse` so the UI can render rejected regions uniformly.
- In dry-run mode, catch the 400 raised by `_read_dataset` / `_validate_full_dataset` and convert it to `ImportSummaryResponse(id=None, imported_count=0, rejected=...)`. Rejections are recovered from `exc.detail["rejected"]` (already serialised by `_validate_full_dataset`); the empty-data case yields `rejected=[]`.
- Non-dry-run behaviour is unchanged.

## Notes

- The recovery path couples to the dict shape produced by `_validate_full_dataset` (`detail["rejected"]`). A comment marks this. If that helper changes its detail format, this branch must be updated.
- Only 400 status codes are converted; any other error still propagates.
- `make_dataset` and the prediction endpoints are intentionally unchanged.

## Test plan

- [x] `uv run pytest tests/integration/rest_api/test_db_endpoints.py::test_backtest_with_empty_provided_data tests/integration/rest_api/test_db_endpoints.py::test_backtest_with_empty_provided_data_dry_run tests/integration/rest_api/test_db_endpoints.py::test_backtest_with_all_regions_rejected_dry_run`
- [x] `make lint`
- [x] `make test` (746 passed)