### PR TITLE
fix: default matplotlib backend to Agg to avoid Tk crash on Linux (CLIM-688)

### DIFF
--- a/chap_core/__init__.py
+++ b/chap_core/__init__.py
@@ -1,8 +1,18 @@
 """Top-level package for chap-core."""
 
+import os
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+# Force matplotlib to a non-interactive backend by default. Some Linux
+# environments (notably Fedora) auto-select the Tk backend, which aborts
+# with "bit out of range 0 - FD_SETSIZE on fd_set" when stdlib tkinter
+# is loaded under high file-descriptor counts. Agg has no GUI dependency
+# and works on every platform we ship to. setdefault lets a user override
+# (e.g. for interactive notebooks) by exporting MPLBACKEND themselves.
+# Must run before matplotlib is imported anywhere.
+os.environ.setdefault("MPLBACKEND", "Agg")
 
 # gluonts.json emits a UserWarning at import when neither orjson nor ujson
 # is installed; chap_core does not exercise gluonts JSON I/O paths, so the

--- a/tests/test_mpl_backend.py
+++ b/tests/test_mpl_backend.py
@@ -1,0 +1,30 @@
+"""Lock in that chap_core forces a non-interactive matplotlib backend.
+
+Some Linux environments (e.g. Fedora) auto-select the Tk backend, which
+crashes with "bit out of range 0 - FD_SETSIZE on fd_set" under high
+file-descriptor counts. chap_core/__init__.py uses os.environ.setdefault
+so users can still override MPLBACKEND for interactive use.
+"""
+
+import os
+import subprocess
+import sys
+
+import chap_core  # noqa: F401  -- import for side effect
+
+
+def test_mplbackend_default_after_import():
+    assert os.environ.get("MPLBACKEND") == "Agg"
+
+
+def test_mplbackend_override_is_respected():
+    env = {k: v for k, v in os.environ.items() if k != "MPLBACKEND"}
+    env["MPLBACKEND"] = "Qt5Agg"
+    result = subprocess.run(
+        [sys.executable, "-c", "import os; import chap_core; print(os.environ['MPLBACKEND'])"],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    assert result.stdout.strip() == "Qt5Agg"


### PR DESCRIPTION
## Summary

- On some Linux environments (notably Fedora) matplotlib auto-selects the Tk backend, which aborts with `bit out of range 0 - FD_SETSIZE on fd_set` when stdlib `tkinter` is loaded under high file-descriptor counts.
- Set `MPLBACKEND=Agg` once in `chap_core/__init__.py` via `os.environ.setdefault`, before any matplotlib import. Every entry point (tests, CLI, library) inherits the non-interactive backend.
- `setdefault` semantics let users override (e.g. for interactive notebooks) by exporting `MPLBACKEND` themselves before importing chap_core.

## Test plan

- [x] `tests/test_mpl_backend.py` — verifies default is `Agg` after import and that a pre-set `MPLBACKEND` is preserved (subprocess test).
- [x] `make lint` — clean.
- [x] `make test` — 746 passed.