### PR TITLE
fix: round disease_cases to int when updating historic data in Extend…

### DIFF
--- a/chap_core/external/ExtendedPredictor.py
+++ b/chap_core/external/ExtendedPredictor.py
@@ -98,7 +98,7 @@ class ExtendedPredictor(ConfiguredModel):
         sample_cols = [col for col in new_rows.columns if col.startswith("sample_")]
 
         # Replace them with a single column "disease_cases" as the average
-        new_rows["disease_cases"] = new_rows[sample_cols].mean(axis=1).round().astype(int)
+        new_rows["disease_cases"] = new_rows[sample_cols].median(axis=1).round().astype(int)
 
         # Drop the original sample columns
         new_rows = new_rows.drop(columns=sample_cols)

--- a/chap_core/external/ExtendedPredictor.py
+++ b/chap_core/external/ExtendedPredictor.py
@@ -98,7 +98,7 @@ class ExtendedPredictor(ConfiguredModel):
         sample_cols = [col for col in new_rows.columns if col.startswith("sample_")]
 
         # Replace them with a single column "disease_cases" as the average
-        new_rows["disease_cases"] = new_rows[sample_cols].mean(axis=1)
+        new_rows["disease_cases"] = new_rows[sample_cols].mean(axis=1).round().astype(int)
 
         # Drop the original sample columns
         new_rows = new_rows.drop(columns=sample_cols)


### PR DESCRIPTION
When ExtendedPredictor chains predictions iteratively, the mean of the sample columns (used as disease_cases for the next iteration) produces floats. Some models expect integer case counts, so this rounds the value before feeding it back as history.    