### PR TITLE
fix: preserve covariate columns when ExtendedPredictor appends to historic data

### DIFF
--- a/chap_core/external/ExtendedPredictor.py
+++ b/chap_core/external/ExtendedPredictor.py
@@ -64,6 +64,23 @@ class ExtendedPredictor(ConfiguredModel):
                 DataSet.from_pandas(historic_df), DataSet.from_pandas(future_slice)
             )
             new_prediction_pandas = new_prediction.to_pandas()
+
+            # Carry covariate columns from future_slice into predictions so that
+            # the rows appended to historic_df are not missing covariate values.
+            covariate_cols = [
+                col
+                for col in future_slice.columns
+                if col not in ("time_period", "location")
+                and not col.startswith("sample_")
+                and col not in new_prediction_pandas.columns
+            ]
+            if covariate_cols:
+                new_prediction_pandas = new_prediction_pandas.merge(
+                    future_slice[["time_period", "location", *covariate_cols]],
+                    on=["time_period", "location"],
+                    how="left",
+                )
+
             predictions = pd.concat([predictions, new_prediction_pandas])
             if remaining_time_periods > max_pred_length:
                 if remaining_time_periods <= 2 * max_pred_length:

--- a/tests/external/test_extended_predictor.py
+++ b/tests/external/test_extended_predictor.py
@@ -472,6 +472,54 @@ def test_single_location_prediction():
     assert len(result_df["time_period"].unique()) == 5
 
 
+def test_covariates_preserved_in_historic_data_between_iterations():
+    """Covariates from future_data must not become NaN in historic data passed to later iterations."""
+    recorded_historic: list[pd.DataFrame] = []
+
+    class SamplesOnlyModel(ConfiguredModel):
+        _model_information = ModelTemplateConfigV2(name="m", min_prediction_length=1, max_prediction_length=2)
+
+        @property
+        def model_information(self):
+            return self._model_information
+
+        def train(self, train_data, extra_args=None):
+            return self
+
+        def predict(self, historic_data: DataSet, future_data: DataSet) -> DataSet:
+            recorded_historic.append(historic_data.to_pandas().copy())
+            rows = [
+                {"time_period": r["time_period"], "location": r["location"], "sample_0": 50.0}
+                for _, r in future_data.to_pandas().iterrows()
+            ]
+            return DataSet.from_pandas(pd.DataFrame(rows))  # type: ignore[reportArgumentType]
+
+    historic_data = DataSet.from_pandas(
+        pd.DataFrame(
+            {
+                "time_period": ["2020-01", "2020-02"],
+                "location": ["A", "A"],
+                "disease_cases": [10, 15],
+                "rainfall": [50.0, 60.0],
+            }
+        )
+    )  # type: ignore[reportArgumentType]
+    future_data = DataSet.from_pandas(
+        pd.DataFrame(
+            {
+                "time_period": ["2020-03", "2020-04", "2020-05", "2020-06"],
+                "location": ["A"] * 4,
+                "rainfall": [70.0, 80.0, 90.0, 100.0],
+            }
+        )
+    )  # type: ignore[reportArgumentType]
+
+    ExtendedPredictor(SamplesOnlyModel(), desired_scope=4).predict(historic_data, future_data)
+
+    assert len(recorded_historic) >= 2
+    assert not recorded_historic[1]["rainfall"].isna().any(), "Rainfall must not be NaN in extended historic data"
+
+
 def test_update_historic_data_averages_samples():
     """Verify disease_cases is computed as the mean of sample columns."""
     mock_model = MockModel()


### PR DESCRIPTION
## Summary

- When `ExtendedPredictor` runs iteratively, the inner model's output contains only `sample_*` columns (no covariates). The new rows appended to `historic_df` were therefore missing all covariate values (rainfall, temperature, etc.), causing `NaN` features in every subsequent iteration.
- Fix: after each inner model call, merge any missing covariate columns from `future_slice` into `new_prediction_pandas` before it is appended to the historic data.
- Added `test_covariates_preserved_in_historic_data_between_iterations` to catch this regression.

## Test plan

- [ ] `uv run pytest tests/external/test_extended_predictor.py` — all 20 tests pass
- [ ] `make lint` — no issues