### PR TITLE
fix(CLIM-694): forbid extra fields on ModelConfiguration

### DIFF
--- a/chap_core/database/model_templates_and_config_tables.py
+++ b/chap_core/database/model_templates_and_config_tables.py
@@ -2,6 +2,7 @@ import logging
 from enum import Enum
 
 import jsonschema
+from pydantic import ConfigDict
 from sqlalchemy import JSON, Column
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -59,6 +60,8 @@ class ModelTemplateDB(DBModel, ModelTemplateMetaData, ModelTemplateInformation, 
 
 
 class ModelConfiguration(SQLModel):
+    model_config = ConfigDict(extra="forbid")  # type: ignore[assignment]
+
     user_option_values: dict | None = Field(sa_column=Column(JSON), default_factory=dict)
     additional_continuous_covariates: list[str] = Field(default_factory=list, sa_column=Column(JSON))
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -618,7 +618,10 @@ def add_configured_model(
     uses_chapkit = template.uses_chapkit if template else False
     db_id = session_wrapper.add_configured_model(
         model_template_id,
-        ModelConfiguration(**model_configuration.model_dump()),
+        ModelConfiguration(
+            user_option_values=model_configuration.user_option_values,
+            additional_continuous_covariates=model_configuration.additional_continuous_covariates,
+        ),
         configuration_name,
         uses_chapkit=uses_chapkit,
     )

--- a/docs/external_models/additional_configuration.md
+++ b/docs/external_models/additional_configuration.md
@@ -60,17 +60,25 @@ Configuration values can be provided via the `--model-configuration-yaml` CLI fl
 chap eval my_model data.csv results.nc --model-configuration-yaml config.yaml
 ```
 
-The configuration YAML file should contain the parameter values:
+The configuration YAML is a `ModelConfiguration` document with two top-level keys:
+
+- `user_option_values` — a mapping whose keys must match the parameter names declared in your MLproject `user_options`
+- `additional_continuous_covariates` — an optional list of extra continuous covariates (only meaningful when the template sets `allow_free_additional_continuous_covariates: true`)
 
 ```yaml
-n_lag_periods: 5
-learning_rate: 0.01
+user_option_values:
+  n_lag_periods: 5
+  learning_rate: 0.01
+additional_continuous_covariates:
+  - rainfall
+  - mean_temperature
 ```
 
 ### Validation rules
 
-- Options without a `default` value are required and must be provided
-- Only options defined in `user_options` are allowed in the configuration file
+- The top-level YAML must contain only `user_option_values` and `additional_continuous_covariates`. Any other top-level key raises a validation error — flat YAMLs like `n_lag_periods: 5` at the root are rejected.
+- Options without a `default` value are required and must be provided under `user_option_values`
+- Only options defined in `user_options` are allowed under `user_option_values`
 - Values must match the specified type (e.g., integers for `integer` type)
 
 ### Examples in the codebase

--- a/example_data/debug_model/model_configuration.yaml
+++ b/example_data/debug_model/model_configuration.yaml
@@ -1,1 +1,2 @@
-n_lag_periods: 3
+user_option_values:
+  n_lag_periods: 3

--- a/external_models/naive_python_model_with_mlproject_file_and_docker/example_model_configuration.yaml
+++ b/external_models/naive_python_model_with_mlproject_file_and_docker/example_model_configuration.yaml
@@ -1,2 +1,2 @@
-
-some_option: 123
+user_option_values:
+  some_option: 123

--- a/tests/test_command_line_interface_adaptor.py
+++ b/tests/test_command_line_interface_adaptor.py
@@ -26,11 +26,12 @@ class DummyModel(ConfiguredModel):
         return None
 
     def __init__(self, config: ModelConfiguration):
+        self._model_configuration = config
         self._config = DummyConfig.model_validate(config.user_option_values)
 
     def save(self, filepath: str) -> None:
         with open(filepath, "w") as f:
-            f.write(self._config.model_dump_json())
+            f.write(self._model_configuration.model_dump_json())
 
     @classmethod
     def load_predictor(cls, filepath: str) -> "DummyModel":
@@ -64,7 +65,7 @@ class DummyModelTemplate(ModelTemplateInterface):
 
 @pytest.fixture()
 def model_config():
-    return DummyConfig(n_iterations=10)
+    return ModelConfiguration(user_option_values={"n_iterations": 10})
 
 
 @pytest.fixture

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -236,3 +236,24 @@ def test_resolve_configured_model_by_nonexistent_name_raises(configured_model_fi
     with SessionWrapper(engine) as session:
         with pytest.raises(ValueError, match="not found"):
             session.get_configured_model_by_id_or_name("no_such_model")
+
+
+def test_model_configuration_rejects_flat_yaml_keys():
+    """Flat YAMLs like ``n_lag_periods: 5`` at the top level used to be silently dropped
+    because pydantic ignored unknown fields. They must now raise a validation error so
+    users learn to wrap parameters under ``user_option_values``."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ModelConfiguration.model_validate({"n_lag_periods": 5})
+
+
+def test_model_configuration_accepts_nested_format():
+    config = ModelConfiguration.model_validate(
+        {
+            "user_option_values": {"n_lag_periods": 5},
+            "additional_continuous_covariates": ["rainfall"],
+        }
+    )
+    assert config.user_option_values == {"n_lag_periods": 5}
+    assert config.additional_continuous_covariates == ["rainfall"]


### PR DESCRIPTION
## Summary

The CLI `--model-configuration-yaml` loader (`chap_core/cli_endpoints/_common.py:242`) does:

```python
configuration = ModelConfiguration.model_validate(yaml.safe_load(open(...)))
```

With pydantic's default `extra="ignore"`, a flat YAML like

```yaml
n_lag_periods: 5
```

silently parsed to `ModelConfiguration(user_option_values={}, additional_continuous_covariates=[])` — the user's values were dropped without warning, and the model trained with all defaults. The shipped docs and the two example yamls (`example_data/debug_model/model_configuration.yaml`, `external_models/.../example_model_configuration.yaml`) used exactly this broken flat shape, so any user following the docs hit the silent-drop.

## What changed

- `ModelConfiguration` now sets `model_config = ConfigDict(extra="forbid")`. Flat YAMLs raise a clear `ValidationError` instead of silently producing an empty config.
- `docs/external_models/additional_configuration.md`: example YAML and validation rules updated to the nested `user_option_values:` / `additional_continuous_covariates:` shape that the loader actually expects.
- `example_data/debug_model/model_configuration.yaml` and `external_models/naive_python_model_with_mlproject_file_and_docker/example_model_configuration.yaml`: rewritten to the nested format.
- `chap_core/rest_api/v1/routers/crud.py`: fixed `add_configured_model` which was splatting `ModelConfigurationCreate.model_dump()` (carries extra `name`, `model_template_id`) into `ModelConfiguration` — now picks the two relevant fields explicitly.
- `tests/test_command_line_interface_adaptor.py`: `DummyModel` save/load round-trip and the `model_config` fixture both relied on the silent-drop. Updated to use the proper `ModelConfiguration` shape.
- `tests/test_database.py`: lock-in tests for both flat-rejection and nested-acceptance.

## Out of scope

Auto-wrapping flat dicts into `user_option_values` (the magic option) — rejected because it would hide the structural concept of `additional_continuous_covariates`.

## Test plan

- [x] `make lint` clean
- [x] `uv run pytest --ignore=tests/test_documentation.py` — 666 passed
- [x] New lock-in tests in `tests/test_database.py` pass
- [x] Doc test for `additional_configuration.md` passes