### PR TITLE
fix: REST API bugfix bundle (chap-scheduler CHAP_ISSUES.md)

### DIFF
--- a/chap_core/api_types.py
+++ b/chap_core/api_types.py
@@ -81,9 +81,9 @@ class EvaluationEntry(PredictionEntry):
 
 
 class BacktestParams(DBModel):
-    n_periods: int = 3
-    n_splits: int = 7
-    stride: int = 1
+    n_periods: int = Field(default=3, gt=0)
+    n_splits: int = Field(default=7, gt=0)
+    stride: int = Field(default=1, gt=0)
 
 
 class RunConfig(BaseModel):

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -149,7 +149,8 @@ class SessionWrapper:
         model_template = self.session.exec(
             select(ModelTemplateDB).where(ModelTemplateDB.id == model_template_id)
         ).first()
-        assert model_template is not None, f"Model template with id {model_template_id} not found"
+        if model_template is None:
+            raise ValueError(f"Model template with id {model_template_id} not found")
         template_name = model_template.name
 
         # set configured name

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -46,7 +46,7 @@ class JobResponse(BaseModel):
 
 class PredictionParams(DBModel):
     model_id: str
-    n_periods: int = 3
+    n_periods: int = Field(default=3, gt=0)
 
 
 class ValidationError(DBModel):

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from chap_core.api_types import BacktestParams, FeatureCollectionModel
 from chap_core.database.base_tables import DBModel
@@ -153,7 +153,7 @@ class ConfiguredModelInfoRead(DBModel):
 class ModelConfigurationCreate(DBModel):
     name: str
     model_template_id: int
-    user_option_values: dict | None = None
+    user_option_values: dict = Field(default_factory=dict)
     additional_continuous_covariates: list[str] = []
 
 

--- a/chap_core/rest_api/v1/jobs.py
+++ b/chap_core/rest_api/v1/jobs.py
@@ -99,9 +99,6 @@ def cancel_job(job_id: str) -> dict:
     """
     _ensure_job_exists(job_id)
     job = worker.get_job(job_id)
-    if job is None:
-        raise HTTPException(status_code=404, detail="Job not found")
-
     job_status = job.status.lower()
 
     if job_status in ["success", "failure", "revoked"]:

--- a/chap_core/rest_api/v1/jobs.py
+++ b/chap_core/rest_api/v1/jobs.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from chap_core.api_types import EvaluationResponse
 from chap_core.log_config import initialize_logging
-from chap_core.rest_api.celery_tasks import CeleryPool, JobDescription
+from chap_core.rest_api.celery_tasks import CeleryPool, JobDescription, get_job_meta
 from chap_core.rest_api.celery_tasks import r as redis
 from chap_core.rest_api.data_models import FullPredictionResponse
 
@@ -45,7 +45,17 @@ def list_jobs(
     return cast("list[JobDescription]", jobs_to_return)
 
 
+def _ensure_job_exists(job_id: str) -> None:
+    """Celery's AsyncResult fabricates a PENDING state and a TaskRevokedError
+    result for unknown task ids, which used to leak as 200/500 responses.
+    Gate every job_id-scoped route on the Redis metadata that the worker
+    records when a job is queued."""
+    if not get_job_meta(job_id):
+        raise HTTPException(status_code=404, detail=f"Job '{job_id}' not found")
+
+
 def _get_successful_job(job_id):
+    _ensure_job_exists(job_id)
     job = worker.get_job(job_id)
     if job.status.lower() == "failed":
         raise HTTPException(status_code=400, detail="Job failed. Check the exception endpoint for more information")
@@ -58,6 +68,7 @@ def _get_successful_job(job_id):
 
 @router.get("/{job_id}")
 def get_job_status(job_id: str) -> str:
+    _ensure_job_exists(job_id)
     status: str = worker.get_job(job_id).status
     logger.info(f"status of job {job_id}: {status}")
     return status
@@ -86,6 +97,7 @@ def cancel_job(job_id: str) -> dict:
     """
     Cancel a running job
     """
+    _ensure_job_exists(job_id)
     job = worker.get_job(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -105,6 +117,7 @@ def cancel_job(job_id: str) -> dict:
 
 @router.get("/{job_id}/logs")
 def get_logs(job_id: str) -> str:
+    _ensure_job_exists(job_id)
     job = worker.get_job(job_id)
     logs: str = job.get_logs()
     if logs is None:

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -326,7 +326,13 @@ async def get_evaluation_entries(
 
 
 @router.post("/create-backtest", response_model=JobResponse, tags=["Backtests"])
-async def create_backtest(request: MakeBacktestRequest, database_url: str = Depends(get_database_url)):
+async def create_backtest(
+    request: MakeBacktestRequest,
+    database_url: str = Depends(get_database_url),
+    session: Session = Depends(get_session),
+):
+    if session.get(DataSetTable, request.dataset_id) is None:
+        raise HTTPException(status_code=404, detail=f"Dataset {request.dataset_id} not found")
     job = worker.queue_db(
         wf.run_backtest,
         BacktestCreate(name=request.name, dataset_id=request.dataset_id, model_id=request.model_id),

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -219,9 +219,9 @@ def get_backtest_overlap(
     backtest1 = session.get(Backtest, backtest_id1)
     backtest2 = session.get(Backtest, backtest_id2)
     if backtest1 is None:
-        raise HTTPException(status_code=404, detail="Backtest 1 not found")
+        raise HTTPException(status_code=404, detail=f"Backtest {backtest_id1} not found")
     if backtest2 is None:
-        raise HTTPException(status_code=404, detail="Backtest 2 not found")
+        raise HTTPException(status_code=404, detail=f"Backtest {backtest_id2} not found")
     org_units1 = list(set(backtest1.org_units) & set(backtest2.org_units))
     split_periods1 = list(set(backtest1.split_periods) & set(backtest2.split_periods))
     return BacktestDomain(org_units=org_units1, split_periods=split_periods1)

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -273,6 +273,7 @@ async def get_backtest(backtest_id: Annotated[int, Path(alias="backtestId")], se
 
 
 @router_get("/backtests/{backtestId}/info", response_model=BacktestRead, tags=["Backtests"])
+@router_get("/backtests/{backtestId}", response_model=BacktestRead, tags=["Backtests"])
 def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
     backtest = session.exec(
         select(Backtest)

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -754,25 +754,6 @@ async def create_configured_model_with_data_source_from_backtest(
     return result
 
 
-###########
-# models (alias for configured models)
-
-
-@router.get("/models", response_model=list[ModelSpecRead], tags=["Models"])
-def list_models(session: Session = Depends(get_session)):
-    """List all models from the db (alias for configured models)"""
-    return list_configured_models(session)
-
-
-@router.post("/models", response_model=ConfiguredModelDB, tags=["Models"])
-def add_model(
-    model_configuration: ModelConfigurationCreate,
-    session: Session = Depends(get_session),
-):
-    """Add a model to the database (alias for configured models)"""
-    return add_configured_model(model_configuration, session)
-
-
 #############
 # other misc
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -510,6 +510,8 @@ async def create_dataset_csv(
 
 @router.get("/datasets/{datasetId}/df", tags=["Datasets"])
 async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
+    if session.get(DataSet, dataset_id) is None:
+        raise HTTPException(status_code=404, detail="Dataset not found")
     sw = SessionWrapper(session=session)
     in_memory_dataset = sw.get_dataset(dataset_id)
     df = in_memory_dataset.to_pandas()
@@ -527,6 +529,8 @@ async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], se
 
 @router.get("/datasets/{datasetId}/csv", tags=["Datasets"])
 async def get_dataset_csv(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
+    if session.get(DataSet, dataset_id) is None:
+        raise HTTPException(status_code=404, detail="Dataset not found")
     sw = SessionWrapper(session=session)
     in_memory_dataset = sw.get_dataset(dataset_id)
     df = in_memory_dataset.to_pandas()

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -319,7 +319,11 @@ async def get_metrics_csv(
 
 
 @router.post("/backtests", response_model=JobResponse, tags=["Backtests"])
-async def create_backtest(backtest: BacktestCreate, database_url: str = Depends(get_database_url)):
+async def create_backtest(
+    backtest: BacktestCreate,
+    database_url: str = Depends(get_database_url),
+    session: Session = Depends(get_session),
+):
     # `BacktestCreate.model_id` accepts either the configured-model name
     # (what the DB column actually stores) or the integer primary key (what
     # most API clients reach for because that's what GET /v1/crud/configured-models
@@ -327,6 +331,8 @@ async def create_backtest(backtest: BacktestCreate, database_url: str = Depends(
     # `SessionWrapper.get_configured_model_by_id_or_name` before touching
     # anything else, so the endpoint itself stays dumb and there's exactly
     # one resolution point.
+    if session.get(DataSet, backtest.dataset_id) is None:
+        raise HTTPException(status_code=404, detail=f"Dataset {backtest.dataset_id} not found")
     job = worker.queue_db(
         wf.run_backtest,
         backtest,

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -510,15 +510,19 @@ async def create_dataset_csv(
 
 @router.get("/datasets/{datasetId}/df", tags=["Datasets"])
 async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
-    # dataset = session.get(DataSet, dataset_id)
-    # if dataset is None:
-    #    raise HTTPException(status_code=404, detail="Dataset not found")
     sw = SessionWrapper(session=session)
     in_memory_dataset = sw.get_dataset(dataset_id)
     df = in_memory_dataset.to_pandas()
     # Convert time_period column to strings for proper serialization
     df["time_period"] = df["time_period"].astype(str)
-    return df.to_dict(orient="records")
+    records = df.to_dict(orient="records")
+    # NaN floats are not JSON-serialisable; surface them as JSON null instead.
+    # Done after to_dict because reassigning None into a float column re-casts it to NaN.
+    for record in records:
+        for key, value in record.items():
+            if isinstance(value, float) and not np.isfinite(value):
+                record[key] = None
+    return records
 
 
 @router.get("/datasets/{datasetId}/csv", tags=["Datasets"])

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -623,7 +623,9 @@ def add_configured_model(
     configuration_name = model_configuration.name
     # Inherit uses_chapkit from parent template so the model loads correctly at runtime
     template = session.exec(select(ModelTemplateDB).where(ModelTemplateDB.id == model_template_id)).first()
-    uses_chapkit = template.uses_chapkit if template else False
+    if template is None:
+        raise HTTPException(status_code=404, detail="Model template not found")
+    uses_chapkit = template.uses_chapkit
     db_id = session_wrapper.add_configured_model(
         model_template_id,
         ModelConfiguration(

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -2,7 +2,7 @@ import json
 import logging
 from functools import partial
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session
 from starlette.responses import JSONResponse
 
@@ -76,14 +76,14 @@ def generate_visualization(
 ):
     backtest = session.get(Backtest, backtest_id)
     if not backtest:
-        return {"error": "Backtest not found"}
+        raise HTTPException(status_code=404, detail="Backtest not found")
 
     if metric_id not in available_metrics:
-        return {"error": f"Metric {metric_id} not found"}
+        raise HTTPException(status_code=400, detail=f"Metric {metric_id} not found")
 
     registry = get_metric_plots_registry()
     if visualization_name not in registry:
-        return {"error": f"Visualization {visualization_name} not found"}
+        raise HTTPException(status_code=404, detail=f"Visualization {visualization_name} not found")
 
     geojson_str = backtest.dataset.geojson
     geojson = json.loads(geojson_str) if geojson_str else None
@@ -112,11 +112,13 @@ def generate_data_plots(visualization_name: str, dataset_id: int, session: Sessi
     registry = get_dataset_plots_registry()
     if visualization_name not in registry:
         available = ", ".join(registry.keys())
-        return {"error": f"Visualization {visualization_name} not found. Available: {available}"}
+        raise HTTPException(
+            status_code=404, detail=f"Visualization {visualization_name} not found. Available: {available}"
+        )
 
     dataset = session.get(DataSet, dataset_id)
     if not dataset:
-        return {"error": "Dataset not found"}
+        raise HTTPException(status_code=404, detail="Dataset not found")
 
     chart = create_plot_from_dataset(visualization_name, dataset)
     return JSONResponse(chart)
@@ -141,11 +143,13 @@ def generate_backtest_plots(visualization_name: str, backtest_id: int, session: 
     registry = get_backtest_plots_registry()
     if visualization_name not in registry:
         available = ", ".join(registry.keys())
-        return {"error": f"Visualization {visualization_name} not found. Available: {available}"}
+        raise HTTPException(
+            status_code=404, detail=f"Visualization {visualization_name} not found. Available: {available}"
+        )
 
     backtest = session.get(Backtest, backtest_id)
     if not backtest:
-        return {"error": "Backtest not found"}
+        raise HTTPException(status_code=404, detail="Backtest not found")
 
     chart = create_plot_from_backtest(visualization_name, backtest)
     return JSONResponse(chart.to_dict(format="vega"))

--- a/docs/modeling-app/enabling-optional-model-services.md
+++ b/docs/modeling-app/enabling-optional-model-services.md
@@ -60,7 +60,7 @@ Check that the service is running and the model appears in the API:
 
 ```console
 docker compose ps
-curl http://localhost:8000/v1/crud/models
+curl http://localhost:8000/v1/crud/configured-models
 ```
 
 The model (e.g. `ewars_plus`) should appear in the list of configured models.

--- a/tests/docker_db_flow.py
+++ b/tests/docker_db_flow.py
@@ -105,7 +105,7 @@ class IntegrationTest:
         return response.json()
 
     def get_models(self):
-        model_url = self._chap_url + "/v1/crud/models"
+        model_url = self._chap_url + "/v1/crud/configured-models"
         models = self._get(model_url)
         # hacky remove autoreg weekly
         # TODO: delete after new version is published

--- a/tests/docker_db_flow_configured_models.py
+++ b/tests/docker_db_flow_configured_models.py
@@ -187,7 +187,7 @@ class ConfiguredModelsIntegrationTest:
     def get_configured_models(self):
         """Fetch all configured models from the API."""
         logger.info("Fetching configured models from API")
-        models = self._get(self._chap_url + "/v1/crud/models")
+        models = self._get(self._chap_url + "/v1/crud/configured-models")
         logger.info(f"Found {len(models)} configured models")
         return models
 

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -678,6 +678,18 @@ def test_add_configured_model_flow(celery_session_worker, dependency_overrides):
     assert response.status_code == 200, response.json()
 
 
+def test_add_configured_model_without_user_option_values(dependency_overrides):
+    """Omitting userOptionValues should not 500; a template with no required user
+    options should accept an empty configuration."""
+    content = get_content("/v1/crud/model-templates")
+    model = next(m for m in content if m["name"] == "naive_model")
+    payload = {"name": "naive_without_options", "modelTemplateId": model["id"]}
+
+    response = client.post("/v1/crud/configured-models", json=payload)
+    assert response.status_code == 200, response.json()
+    assert response.json()["userOptionValues"] == {}
+
+
 def test_get_configured_model_info(celery_session_worker, dependency_overrides):
     configured = get_content("/v1/crud/configured-models")
     default = next(m for m in configured if m["name"] == "chap_ewars_monthly")

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -757,3 +757,19 @@ def test_get_dataset_csv(override_session, seeded_session):
     assert len(lines) > 1, "CSV should have header and data rows"
     header = lines[0]
     assert "time_period" in header, f"Expected time_period in header, got: {header}"
+
+
+def test_get_dataset_df_with_nans(override_session, seeded_session):
+    """Datasets containing NaN observations must round-trip through /df as JSON.
+    Previously pandas NaN floats leaked into the response and triggered a 500
+    because they are not JSON-serialisable."""
+    dataset = seeded_session.exec(select(DataSet).where(DataSet.name == "dataset_with_nans")).one()
+
+    response = client.get(f"/v1/crud/datasets/{dataset.id}/df")
+    assert response.status_code == 200, response.text
+
+    records = response.json()
+    assert len(records) > 0
+    assert any(record.get("disease_cases") is None for record in records), (
+        "Expected at least one None disease_cases value in the response"
+    )

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -405,6 +405,22 @@ def test_compatible_backtests(clean_engine, dependency_overrides):
     assert response.json() == {"orgUnits": ["Bergen"], "splitPeriods": ["202202"]}, response.json()
 
 
+def test_get_backtest_bare_route_returns_info(override_session, seeded_session):
+    """GET /v1/crud/backtests/{id} (bare, no /info or /full suffix) should return
+    the BacktestRead view rather than 405."""
+    backtest = seeded_session.exec(select(Backtest)).first()
+    assert backtest is not None
+
+    response = client.get(f"/v1/crud/backtests/{backtest.id}")
+    assert response.status_code == 200, response.text
+    BacktestRead.model_validate(response.json())
+
+
+def test_get_backtest_bare_route_unknown_id_returns_404(clean_engine, dependency_overrides):
+    response = client.get("/v1/crud/backtests/999999")
+    assert response.status_code == 404, response.text
+
+
 def test_backtest_overlap_error_message_includes_id(clean_engine, dependency_overrides):
     """The error detail must surface the actual id, not its path position."""
     missing_id1 = 888888

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -405,6 +405,15 @@ def test_compatible_backtests(clean_engine, dependency_overrides):
     assert response.json() == {"orgUnits": ["Bergen"], "splitPeriods": ["202202"]}, response.json()
 
 
+def test_backtest_overlap_error_message_includes_id(clean_engine, dependency_overrides):
+    """The error detail must surface the actual id, not its path position."""
+    missing_id1 = 888888
+    missing_id2 = 999999
+    response = client.get(f"/v1/analytics/backtest-overlap/{missing_id1}/{missing_id2}")
+    assert response.status_code == 404, response.text
+    assert str(missing_id1) in response.json()["detail"], response.json()
+
+
 def test_list_configured_models_with_data_source_empty(clean_engine, dependency_overrides):
     response = client.get("/v1/crud/configured-models-with-data-source")
     assert response.status_code == 200

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -759,6 +759,16 @@ def test_get_dataset_csv(override_session, seeded_session):
     assert "time_period" in header, f"Expected time_period in header, got: {header}"
 
 
+def test_get_dataset_df_unknown_id_returns_404(clean_engine, dependency_overrides):
+    response = client.get("/v1/crud/datasets/999999/df")
+    assert response.status_code == 404, response.text
+
+
+def test_get_dataset_csv_unknown_id_returns_404(clean_engine, dependency_overrides):
+    response = client.get("/v1/crud/datasets/999999/csv")
+    assert response.status_code == 404, response.text
+
+
 def test_get_dataset_df_with_nans(override_session, seeded_session):
     """Datasets containing NaN observations must round-trip through /df as JSON.
     Previously pandas NaN floats leaked into the response and triggered a 500

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -97,6 +97,31 @@ def test_get_visualizations(celery_session_worker, clean_engine, dependency_over
     assert any(plot["id"] == "metric_by_horizon" for plot in response.json())
 
 
+def test_visualization_endpoints_404_on_missing_ids(clean_engine, dependency_overrides):
+    """Visualization endpoints used to return 200 with `{"error": ...}` bodies for
+    unknown backtest/dataset ids and unknown plot names. Each should now produce a
+    proper 4xx response."""
+    # unknown backtest
+    response = client.get("/v1/visualization/metric-plots/metric_by_horizon/999999/crps")
+    assert response.status_code == 404, response.text
+    # unknown metric on existing backtest path (the missing-metric case is bad input → 400)
+    response = client.get("/v1/visualization/metric-plots/metric_by_horizon/999999/no_such_metric")
+    # Backtest is checked first → 404. With a real backtest this would be 400; the
+    # other 404 assertion already covers the rewrite, so just assert it is not 200.
+    assert response.status_code != 200, response.text
+    # unknown plot name on dataset-plots / backtest-plots
+    response = client.get("/v1/visualization/dataset-plots/no_such_plot/1")
+    assert response.status_code == 404, response.text
+    response = client.get("/v1/visualization/backtest-plots/no_such_plot/1")
+    assert response.status_code == 404, response.text
+    # unknown dataset on a real plot name
+    plot_types = client.get("/v1/visualization/dataset-plots/").json()
+    if plot_types:
+        plot_id = plot_types[0]["id"]
+        response = client.get(f"/v1/visualization/dataset-plots/{plot_id}/999999")
+        assert response.status_code == 404, response.text
+
+
 # @pytest.mark.slow
 @pytest.mark.parametrize("do_filter", [True, False])
 @pytest.mark.slow

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -193,24 +193,10 @@ def test_add_dataset_flow(celery_session_worker, dependency_overrides, dataset_c
     assert "orgUnit" in response.json()["observations"][0], response.json()["observations"][0].keys()
 
 
-def test_list_models_alias(celery_session_worker, dependency_overrides):
-    # alias for list configured models
+def test_list_models_alias_is_gone(clean_engine, dependency_overrides):
+    """The /v1/crud/models alias was removed; /configured-models is the only path."""
     response = client.get("/v1/crud/models")
-    assert response.status_code == 200, response.json()
-    assert isinstance(response.json(), list)
-    for m in response.json():
-        logger.info(m)
-    assert len(response.json()) > 0
-    assert "id" in response.json()[0]
-    for attr_name in ("displayName", "id", "description"):
-        """Check these here to make sure camelCase in response"""
-        assert attr_name in response.json()[0], response.json()[0].keys()
-    models = [ModelSpecRead.model_validate(m) for m in response.json()]
-    assert "chap_ewars_monthly" in (m.name for m in models)
-    ewars_model = next(m for m in models if m.name == "chap_ewars_monthly")
-    assert "population" in (f.name for f in ewars_model.covariates)
-    assert ewars_model.source_url is not None
-    assert ewars_model.source_url.startswith("https:/")
+    assert response.status_code == 404, response.text
 
 
 def test_list_configured_models(celery_session_worker, dependency_overrides):
@@ -546,7 +532,7 @@ def test_make_prediction_with_data_source_nonexistent_id(clean_engine, dependenc
 def test_full_prediction_with_data_source_flow(
     celery_session_worker, clean_engine, dependency_overrides, example_polygons
 ):
-    model_list = client.get("/v1/crud/models").json()
+    model_list = client.get("/v1/crud/configured-models").json()
     models = [ModelSpecRead.model_validate(m) for m in model_list]
     model = next(m for m in models if m.name == "naive_model")
     assert model.id is not None
@@ -633,7 +619,7 @@ def test_add_csv_dataset(celery_session_worker, dependency_overrides, data_path)
 
 
 def test_full_prediction_flow(celery_session_worker, dependency_overrides, example_polygons):
-    model_list = client.get("/v1/crud/models").json()
+    model_list = client.get("/v1/crud/configured-models").json()
     models = [ModelSpecRead.model_validate(m) for m in model_list]
     model = next(m for m in models if m.name == "naive_model")
     features = [f.name for f in model.covariates]

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -421,6 +421,25 @@ def test_get_backtest_bare_route_unknown_id_returns_404(clean_engine, dependency
     assert response.status_code == 404, response.text
 
 
+def test_create_backtest_unknown_dataset_returns_404(clean_engine, dependency_overrides):
+    """Both /v1/crud/backtests and /v1/analytics/create-backtest should reject
+    bogus dataset ids synchronously rather than queueing a job that fails later."""
+    crud_payload = {"name": "bogus", "datasetId": 999999, "modelId": "naive_model"}
+    response = client.post("/v1/crud/backtests", json=crud_payload)
+    assert response.status_code == 404, response.text
+
+    analytics_payload = {
+        "name": "bogus",
+        "datasetId": 999999,
+        "modelId": "naive_model",
+        "nPeriods": 3,
+        "nSplits": 2,
+        "stride": 1,
+    }
+    response = client.post("/v1/analytics/create-backtest", json=analytics_payload)
+    assert response.status_code == 404, response.text
+
+
 def test_backtest_overlap_error_message_includes_id(clean_engine, dependency_overrides):
     """The error detail must surface the actual id, not its path position."""
     missing_id1 = 888888

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -421,6 +421,33 @@ def test_get_backtest_bare_route_unknown_id_returns_404(clean_engine, dependency
     assert response.status_code == 404, response.text
 
 
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("nPeriods", 0),
+        ("nPeriods", -1),
+        ("nSplits", 0),
+        ("nSplits", -2),
+        ("stride", 0),
+        ("stride", -1),
+    ],
+)
+def test_create_backtest_rejects_non_positive_params(field, value, clean_engine, dependency_overrides):
+    """n_periods, n_splits and stride must be >= 1; Pydantic validation should
+    reject anything <= 0 with 422 before the handler runs."""
+    payload = {
+        "name": "x",
+        "datasetId": 1,
+        "modelId": "naive_model",
+        "nPeriods": 3,
+        "nSplits": 2,
+        "stride": 1,
+    }
+    payload[field] = value
+    response = client.post("/v1/analytics/create-backtest", json=payload)
+    assert response.status_code == 422, response.text
+
+
 def test_create_backtest_unknown_dataset_returns_404(clean_engine, dependency_overrides):
     """Both /v1/crud/backtests and /v1/analytics/create-backtest should reject
     bogus dataset ids synchronously rather than queueing a job that fails later."""

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -678,6 +678,12 @@ def test_add_configured_model_flow(celery_session_worker, dependency_overrides):
     assert response.status_code == 200, response.json()
 
 
+def test_add_configured_model_unknown_template_returns_404(dependency_overrides):
+    payload = {"name": "orphan", "modelTemplateId": 999999, "userOptionValues": {}}
+    response = client.post("/v1/crud/configured-models", json=payload)
+    assert response.status_code == 404, response.text
+
+
 def test_add_configured_model_without_user_option_values(dependency_overrides):
     """Omitting userOptionValues should not 500; a template with no required user
     options should accept an empty configuration."""

--- a/tests/integration/rest_api/test_from_seeded_engine.py
+++ b/tests/integration/rest_api/test_from_seeded_engine.py
@@ -69,7 +69,7 @@ def test_get_backtest(override_session):
     assert dataset.last_period
 
 
-@pytest.mark.parametrize("plot_name", ["standardized-feature", "seasonal-correlation-plot"])
+@pytest.mark.parametrize("plot_name", ["standardized-feature-plot", "seasonal-correlation-plot"])
 def test_data_plot(override_session, tmp_path, plot_name):
     response = client.get("/v1/visualization/dataset-plots/%s/2" % plot_name)
     assert response.status_code == 200, response.json()

--- a/tests/integration/rest_api/test_jobs_routes.py
+++ b/tests/integration/rest_api/test_jobs_routes.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+import uuid
 
 import pytest
 from fastapi.testclient import TestClient
@@ -42,3 +43,40 @@ def test_predict(big_request_json, celery_session_worker, dependency_overrides):
     result = client.get(f"{base_path}/{task_id}/evaluation_result")
     assert result.status_code == 200, result.json()
     print(result.json())
+
+
+# Job-id membership: routes that took a job_id used to either silently accept a
+# bogus id (returning "PENDING" / empty logs / 200 cancel) or 500 with a leaked
+# TaskRevokedError. Every such route should now 404 on unknown ids. A fresh uuid
+# per test avoids picking up Redis state from any prior run that buggy code may
+# have written.
+
+
+@pytest.fixture
+def unknown_job_id():
+    return f"nonexistent-{uuid.uuid4()}"
+
+
+@pytest.mark.skipif(not redis_available(), reason="Redis not available")
+def test_get_job_status_unknown_id_returns_404(unknown_job_id):
+    response = client.get(f"{base_path}/{unknown_job_id}")
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.skipif(not redis_available(), reason="Redis not available")
+def test_cancel_job_unknown_id_returns_404(unknown_job_id):
+    response = client.post(f"{base_path}/{unknown_job_id}/cancel")
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.skipif(not redis_available(), reason="Redis not available")
+def test_get_logs_unknown_id_returns_404(unknown_job_id):
+    response = client.get(f"{base_path}/{unknown_job_id}/logs")
+    assert response.status_code == 404, response.text
+
+
+@pytest.mark.skipif(not redis_available(), reason="Redis not available")
+@pytest.mark.parametrize("suffix", ["database_result", "evaluation_result", "prediction_result"])
+def test_result_endpoints_unknown_id_return_404(unknown_job_id, suffix):
+    response = client.get(f"{base_path}/{unknown_job_id}/{suffix}")
+    assert response.status_code == 404, response.text

--- a/tests/integration/rest_api/test_python_endpoints.py
+++ b/tests/integration/rest_api/test_python_endpoints.py
@@ -51,7 +51,7 @@ def seeded_session_with_weird_backtest(seeded_session: Session):
     all_metric_ids()[:1],
 )
 def test_generate_metric_visualization_weird_backtest(
-    seeded_session_with_weird_backtest, metric_id, visualization_name="MetricByHorizonV2Mean"
+    seeded_session_with_weird_backtest, metric_id, visualization_name="metric_by_horizon_mean"
 ):
     session, backtest_id = seeded_session_with_weird_backtest
     assert generate_visualization(
@@ -60,7 +60,7 @@ def test_generate_metric_visualization_weird_backtest(
 
 
 @pytest.mark.parametrize("metric_id", all_metric_ids())
-def test_generate_metric_visualization(seeded_session, metric_id, visualization_name="MetricByHorizonV2Mean"):
+def test_generate_metric_visualization(seeded_session, metric_id, visualization_name="metric_by_horizon_mean"):
     assert generate_visualization(
         visualization_name=visualization_name, backtest_id=1, metric_id=metric_id, session=seeded_session
     )


### PR DESCRIPTION
Bundles bugfixes for issues catalogued in
[chap-scheduler/chap_client/CHAP_ISSUES.md](https://github.com/dhis2-chap/chap-scheduler/blob/main/chap_client/CHAP_ISSUES.md).

Each commit on this branch addresses one numbered issue (or a tightly-related group) from that document and ships its own regression test, so each fix can be reviewed in isolation.

## Issues addressed

| # | Issue | Commit |
|---|---|---|
| #10 | `POST /v1/crud/configured-models` 500s when `userOptionValues` is omitted | `1e985ef6` |
| #26 | `GET /v1/crud/datasets/{id}/df` 500s on datasets containing NaN | `76b9bbf4` |
| #27 | `/datasets/{id}/df` and `/csv` return 500 (not 404) for unknown ids | `0b565547` |
| #3 | `POST /v1/crud/configured-models` 500s on bogus `modelTemplateId` | `94c56a98` |
| #13 | Visualization endpoints return 200 with `{\"error\": ...}` body | `65fcb75e` |
| #24 | `/v1/analytics/backtest-overlap` error message uses path position, not id | `bb8377f5` |
| #8 | `GET /v1/crud/backtests/{id}` returns 405 | `fe70deba` |
| #7, #19, #21, #22 | `/v1/jobs/{id}*` accept bogus ids (200 \"PENDING\" / 200 cancel / empty logs / 500 with `TaskRevokedError`) | `ae681702` |
| #6 | `datasetId` unvalidated on `create-backtest` (sync 404 instead of async job failure) | `fa9f7f6a` |
| #15 | `n_periods` / `n_splits` / `stride` accepted `<= 0` | `84ff03d2` |
| #2 | Remove `/v1/crud/models` alias routes | `bd2bfbcd` |

## Out of scope

Items in CHAP_ISSUES.md that are observations rather than bugs were intentionally **not** addressed in this PR and should be discussed separately:

`#1` (FeatureType OpenAPI schema), `#4` (configured-model name namespacing is documented behaviour), `#5` (modelId validation is a free-form string by design), `#9` (missing DELETE on configured-models-with-data-source is a missing feature), `#11` (silently-idempotent POST), `#12` (unknown query params on list endpoints), `#14` (empty `name` validation — judgement call), `#16` (`extra=\"forbid\"` on POST request models — broader API contract change), `#17` (CORS reflection — security rewrite, separate PR), `#18` (35 endpoints with no `description=` — docs-only sweep), `#20` (result-endpoint response_model mismatch — needs worker-side change), `#23` (`/info` vs `/full` shape overlap — design decision).

Issues `#28-#33` are in `chap-frontend`, not chap-core.

## Removal notice

`#2` (commit `bd2bfbcd`) **removes** `/v1/crud/models` (both GET and POST). External clients must use `/v1/crud/configured-models` instead. The two internal docker-flow scripts and the modeling-app docs were updated in the same commit. Worth a quick grep on chap-frontend before merging.

## Test plan

- [x] Each fix ships at least one regression test in `tests/integration/rest_api/`
- [x] All bugs verified pre-fix by stashing the fix and running the new test (each failed for the expected reason)
- [x] Bug `#7/#19/#21/#22` verified against a real Redis container (ephemeral, torn down after)
- [x] `make lint` clean (0 errors; 5 pre-existing pyright warnings in `chap_core/explainability/`)
- [x] `make test` green (793 passed, 115 skipped, 4 xfailed, 1 xpassed)
- [x] Two pre-existing tests (`test_generate_metric_visualization*`, `test_data_plot[standardized-feature]`) were updated in commit `0f9a7ed9`. They had been passing for the wrong reason — the assertions were accepting the `{\"error\": ...}` dicts as truthy without ever exercising plot generation. Updated to use real registry names.