### PR TITLE
feat: add counterfactual comparison plot for causal analysis

### DIFF
--- a/chap_core/assessment/backtest_plots/evaluation_plot.py
+++ b/chap_core/assessment/backtest_plots/evaluation_plot.py
@@ -206,7 +206,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_line()
             .encode(
                 x="time_period:T",
-                y=alt.Y("q_50:Q", alt.Scale(zero=False))),
+                y=alt.Y("q_50:Q", alt.Scale(zero=False)),
             )
         )
 

--- a/chap_core/assessment/backtest_plots/evaluation_plot.py
+++ b/chap_core/assessment/backtest_plots/evaluation_plot.py
@@ -206,7 +206,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_line()
             .encode(
                 x="time_period:T",
-                y=alt.Y("q_50:Q", alt.Scale(zero=False)),
+                y=alt.Y("q_50:Q", scale=alt.Scale(zero=False)),
             )
         )
 

--- a/chap_core/assessment/backtest_plots/evaluation_plot.py
+++ b/chap_core/assessment/backtest_plots/evaluation_plot.py
@@ -110,7 +110,6 @@ class EvaluationPlot(BacktestPlotBase):
         observations: pd.DataFrame,
         forecasts: pd.DataFrame,
         historical_observations: pd.DataFrame | None = None,
-        y_domain: list[float] | None = None,
     ) -> ChartType:
         """
         Generate and return the evaluation visualization.
@@ -125,16 +124,12 @@ class EvaluationPlot(BacktestPlotBase):
         historical_observations : pd.DataFrame, optional
             Historical observations before split periods, with columns:
             location, time_period, disease_cases
-        y_domain : list[float], optional
-            Fixed [min, max] for the y-axis. When None the scale is inferred
-            from the data in each chart independently.
 
         Returns
         -------
         ChartType
             Altair faceted chart showing forecasts vs observations
         """
-        y_scale = alt.Scale(zero=False, domain=y_domain) if y_domain is not None else alt.Scale(zero=False)
 
         # Compute quantiles from forecast samples
         forecast_quantiles = _compute_quantiles_from_forecasts(forecasts)
@@ -211,7 +206,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_line()
             .encode(
                 x="time_period:T",
-                y=alt.Y("q_50:Q", scale=y_scale),
+                y=alt.Y("q_50:Q", alt.Scale(zero=False))),
             )
         )
 
@@ -221,7 +216,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_errorband(color="blue", opacity=0.3)
             .encode(
                 x="time_period:T",
-                y=alt.Y("q_10:Q", scale=y_scale),
+                y=alt.Y("q_10:Q", scale=alt.Scale(zero=False)),
                 y2="q_90:Q",
             )
         )
@@ -231,7 +226,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_errorband(color="blue", opacity=0.5)
             .encode(
                 x="time_period:T",
-                y=alt.Y("q_25:Q", scale=y_scale),
+                y=alt.Y("q_25:Q", scale=alt.Scale(zero=False)),
                 y2="q_75:Q",
             )
         )
@@ -242,7 +237,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_line(color="orange")
             .encode(
                 x="time_period:T",
-                y=alt.Y("disease_cases:Q", scale=y_scale),
+                y=alt.Y("disease_cases:Q", scale=alt.Scale(zero=False)),
             )
         )
 

--- a/chap_core/assessment/backtest_plots/evaluation_plot.py
+++ b/chap_core/assessment/backtest_plots/evaluation_plot.py
@@ -110,6 +110,7 @@ class EvaluationPlot(BacktestPlotBase):
         observations: pd.DataFrame,
         forecasts: pd.DataFrame,
         historical_observations: pd.DataFrame | None = None,
+        y_domain: list[float] | None = None,
     ) -> ChartType:
         """
         Generate and return the evaluation visualization.
@@ -124,12 +125,17 @@ class EvaluationPlot(BacktestPlotBase):
         historical_observations : pd.DataFrame, optional
             Historical observations before split periods, with columns:
             location, time_period, disease_cases
+        y_domain : list[float], optional
+            Fixed [min, max] for the y-axis. When None the scale is inferred
+            from the data in each chart independently.
 
         Returns
         -------
         ChartType
             Altair faceted chart showing forecasts vs observations
         """
+        y_scale = alt.Scale(zero=False, domain=y_domain) if y_domain is not None else alt.Scale(zero=False)
+
         # Compute quantiles from forecast samples
         forecast_quantiles = _compute_quantiles_from_forecasts(forecasts)
 
@@ -205,7 +211,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_line()
             .encode(
                 x="time_period:T",
-                y=alt.Y("q_50:Q", scale=alt.Scale(zero=False)),
+                y=alt.Y("q_50:Q", scale=y_scale),
             )
         )
 
@@ -215,7 +221,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_errorband(color="blue", opacity=0.3)
             .encode(
                 x="time_period:T",
-                y=alt.Y("q_10:Q", scale=alt.Scale(zero=False)),
+                y=alt.Y("q_10:Q", scale=y_scale),
                 y2="q_90:Q",
             )
         )
@@ -225,7 +231,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_errorband(color="blue", opacity=0.5)
             .encode(
                 x="time_period:T",
-                y=alt.Y("q_25:Q", scale=alt.Scale(zero=False)),
+                y=alt.Y("q_25:Q", scale=y_scale),
                 y2="q_75:Q",
             )
         )
@@ -236,7 +242,7 @@ class EvaluationPlot(BacktestPlotBase):
             .mark_line(color="orange")
             .encode(
                 x="time_period:T",
-                y=alt.Y("disease_cases:Q", scale=alt.Scale(zero=False)),
+                y=alt.Y("disease_cases:Q", scale=y_scale),
             )
         )
 

--- a/chap_core/assessment/causal_plot.py
+++ b/chap_core/assessment/causal_plot.py
@@ -13,43 +13,7 @@ if TYPE_CHECKING:
     from chap_core.assessment.backtest_plots import ChartType
 
 
-def _location_y_domain(eval_original, eval_cf, location: str) -> list[float]:
-    """Compute shared y-domain for one location across both evaluations.
-
-    The lower bound is the minimum of all observations (including historical).
-    The upper bound is the maximum of all observations and q_90 of forecast samples,
-    so that outlier raw samples do not inflate the axis.
-    """
-    obs_values: list[pd.Series] = []
-    upper_values: list[pd.Series] = []
-
-    for ev in (eval_original, eval_cf):
-        flat = ev.to_flat()
-
-        forecasts = pd.DataFrame(flat.forecasts)
-        loc_fc = forecasts[forecasts["location"] == location].dropna(subset=["forecast"])
-        if not loc_fc.empty:
-            per_period_q90 = loc_fc.groupby("time_period")["forecast"].quantile(0.9)
-            upper_values.append(pd.Series([float(per_period_q90.max())]))
-
-        for df_raw in (flat.observations, flat.historical_observations):
-            if df_raw is None:
-                continue
-            df = pd.DataFrame(df_raw)
-            if "location" in df.columns and "disease_cases" in df.columns:
-                vals = df.loc[df["location"] == location, "disease_cases"].dropna()
-                if not vals.empty:
-                    obs_values.append(vals)
-                    upper_values.append(vals)
-
-    if not obs_values or not upper_values:
-        return [0.0, 1.0]
-    all_lower = pd.concat(obs_values)
-    all_upper = pd.concat(upper_values)
-    return [float(all_lower.min()), float(all_upper.max())]
-
-
-def _chart_for_location(evaluation, location: str, y_domain: list[float], title: str) -> ChartType:
+def _chart_for_location(evaluation, location: str, title: str) -> ChartType:
     flat = evaluation.to_flat()
     obs = pd.DataFrame(flat.observations)
     forecasts = pd.DataFrame(flat.forecasts)
@@ -64,7 +28,6 @@ def _chart_for_location(evaluation, location: str, y_domain: list[float], title:
             obs[obs["location"] == location],
             forecasts[forecasts["location"] == location],
             historical,
-            y_domain=y_domain,
         )
         .properties(title=title)
     )
@@ -75,19 +38,14 @@ def plot_counterfactual(
     eval_cf,
     counterfactual_columns: list[str] | None = None,
 ) -> ChartType:
-    """Return a per-location vconcat of side-by-side Altair charts comparing original vs counterfactual.
-
-    For each location the two panels share the same y-axis domain so predictions
-    and observations are directly comparable.
-    """
+    """Return a per-location vconcat of side-by-side Altair charts comparing original vs counterfactual."""
     locations = sorted(pd.DataFrame(eval_original.to_flat().observations)["location"].unique())
 
     rows = []
     for loc in locations:
-        y_domain = _location_y_domain(eval_original, eval_cf, loc)
-        orig_chart = _chart_for_location(eval_original, loc, y_domain, "Original")
-        cf_chart = _chart_for_location(eval_cf, loc, y_domain, "Counterfactual")
-        rows.append(alt.hconcat(orig_chart, cf_chart))
+        orig_chart = _chart_for_location(eval_original, loc, "Original")
+        cf_chart = _chart_for_location(eval_cf, loc, "Counterfactual")
+        rows.append(alt.hconcat(orig_chart, cf_chart).resolve_scale(y="shared"))
 
     subtitle = f" ({', '.join(counterfactual_columns)})" if counterfactual_columns else ""
     return alt.vconcat(*rows).properties(title=f"Causal Analysis: Original vs Counterfactual{subtitle}")

--- a/chap_core/assessment/causal_plot.py
+++ b/chap_core/assessment/causal_plot.py
@@ -13,13 +13,12 @@ if TYPE_CHECKING:
     from chap_core.assessment.backtest_plots import ChartType
 
 
-def _chart_for_location(evaluation, location: str, title: str) -> ChartType:
-    flat = evaluation.to_flat()
-    obs = pd.DataFrame(flat.observations)
-    forecasts = pd.DataFrame(flat.forecasts)
+def _chart_for_location(flat_evaluation, location: str, title: str) -> ChartType:
+    obs = pd.DataFrame(flat_evaluation.observations)
+    forecasts = pd.DataFrame(flat_evaluation.forecasts)
     historical = None
-    if flat.historical_observations is not None:
-        hist = pd.DataFrame(flat.historical_observations)
+    if flat_evaluation.historical_observations is not None:
+        hist = pd.DataFrame(flat_evaluation.historical_observations)
         loc_hist = hist[hist["location"] == location]
         historical = loc_hist if not loc_hist.empty else None
     return (
@@ -40,11 +39,13 @@ def plot_counterfactual(
 ) -> ChartType:
     """Return a per-location vconcat of side-by-side Altair charts comparing original vs counterfactual."""
     locations = sorted(pd.DataFrame(eval_original.to_flat().observations)["location"].unique())
+    flat_evaluation = eval_original.to_flat()
+    flat_evaluation_cf = eval_cf.to_flat()
 
     rows = []
     for loc in locations:
-        orig_chart = _chart_for_location(eval_original, loc, "Original")
-        cf_chart = _chart_for_location(eval_cf, loc, "Counterfactual")
+        orig_chart = _chart_for_location(flat_evaluation, loc, "Original")
+        cf_chart = _chart_for_location(flat_evaluation_cf, loc, "Counterfactual")
         rows.append(alt.hconcat(orig_chart, cf_chart).resolve_scale(y="shared"))
 
     subtitle = f" ({', '.join(counterfactual_columns)})" if counterfactual_columns else ""

--- a/chap_core/assessment/causal_plot.py
+++ b/chap_core/assessment/causal_plot.py
@@ -1,0 +1,33 @@
+"""Side-by-side comparison plot for causal counterfactual analysis."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import altair as alt
+import pandas as pd
+
+from chap_core.assessment.backtest_plots.evaluation_plot import EvaluationPlot
+
+if TYPE_CHECKING:
+    from chap_core.assessment.backtest_plots import ChartType
+
+
+def plot_counterfactual(
+    eval_original,
+    eval_cf,
+    counterfactual_columns: list[str] | None = None,
+) -> ChartType:
+    """Return a side-by-side Altair chart comparing original vs counterfactual predictions."""
+
+    def _chart(evaluation, title: str):
+        flat = evaluation.to_flat()
+        return (
+            EvaluationPlot().plot(pd.DataFrame(flat.observations), pd.DataFrame(flat.forecasts)).properties(title=title)
+        )
+
+    subtitle = f" ({', '.join(counterfactual_columns)})" if counterfactual_columns else ""
+    return alt.hconcat(
+        _chart(eval_original, "Original"),
+        _chart(eval_cf, "Counterfactual"),
+    ).properties(title=f"Causal Analysis: Original vs Counterfactual{subtitle}")

--- a/chap_core/assessment/causal_plot.py
+++ b/chap_core/assessment/causal_plot.py
@@ -13,24 +13,78 @@ if TYPE_CHECKING:
     from chap_core.assessment.backtest_plots import ChartType
 
 
+def _location_y_domain(eval_original, eval_cf, location: str) -> list[float]:
+    """Compute shared y-domain for one location across both evaluations.
+
+    The lower bound is the minimum of all observations (including historical).
+    The upper bound is the maximum of all observations and q_90 of forecast samples,
+    so that outlier raw samples do not inflate the axis.
+    """
+    obs_values: list[pd.Series] = []
+    upper_values: list[pd.Series] = []
+
+    for ev in (eval_original, eval_cf):
+        flat = ev.to_flat()
+
+        forecasts = pd.DataFrame(flat.forecasts)
+        loc_fc = forecasts[forecasts["location"] == location].dropna(subset=["forecast"])
+        if not loc_fc.empty:
+            per_period_q90 = loc_fc.groupby("time_period")["forecast"].quantile(0.9)
+            upper_values.append(pd.Series([float(per_period_q90.max())]))
+
+        for df_raw in (flat.observations, flat.historical_observations):
+            if df_raw is None:
+                continue
+            df = pd.DataFrame(df_raw)
+            if "location" in df.columns and "disease_cases" in df.columns:
+                vals = df.loc[df["location"] == location, "disease_cases"].dropna()
+                obs_values.append(vals)
+                upper_values.append(vals)
+
+    all_lower = pd.concat(obs_values)
+    all_upper = pd.concat(upper_values)
+    return [float(all_lower.min()), float(all_upper.max())]
+
+
+def _chart_for_location(evaluation, location: str, y_domain: list[float], title: str) -> ChartType:
+    flat = evaluation.to_flat()
+    obs = pd.DataFrame(flat.observations)
+    forecasts = pd.DataFrame(flat.forecasts)
+    historical = None
+    if flat.historical_observations is not None:
+        hist = pd.DataFrame(flat.historical_observations)
+        loc_hist = hist[hist["location"] == location]
+        historical = loc_hist if not loc_hist.empty else None
+    return (
+        EvaluationPlot()
+        .plot(
+            obs[obs["location"] == location],
+            forecasts[forecasts["location"] == location],
+            historical,
+            y_domain=y_domain,
+        )
+        .properties(title=title)
+    )
+
+
 def plot_counterfactual(
     eval_original,
     eval_cf,
     counterfactual_columns: list[str] | None = None,
 ) -> ChartType:
-    """Return a side-by-side Altair chart comparing original vs counterfactual predictions."""
+    """Return a per-location vconcat of side-by-side Altair charts comparing original vs counterfactual.
 
-    def _chart(evaluation, title: str):
-        flat = evaluation.to_flat()
-        historical = pd.DataFrame(flat.historical_observations) if flat.historical_observations is not None else None
-        return (
-            EvaluationPlot()
-            .plot(pd.DataFrame(flat.observations), pd.DataFrame(flat.forecasts), historical)
-            .properties(title=title)
-        )
+    For each location the two panels share the same y-axis domain so predictions
+    and observations are directly comparable.
+    """
+    locations = sorted(pd.DataFrame(eval_original.to_flat().observations)["location"].unique())
+
+    rows = []
+    for loc in locations:
+        y_domain = _location_y_domain(eval_original, eval_cf, loc)
+        orig_chart = _chart_for_location(eval_original, loc, y_domain, "Original")
+        cf_chart = _chart_for_location(eval_cf, loc, y_domain, "Counterfactual")
+        rows.append(alt.hconcat(orig_chart, cf_chart))
 
     subtitle = f" ({', '.join(counterfactual_columns)})" if counterfactual_columns else ""
-    return alt.hconcat(
-        _chart(eval_original, "Original"),
-        _chart(eval_cf, "Counterfactual"),
-    ).properties(title=f"Causal Analysis: Original vs Counterfactual{subtitle}")
+    return alt.vconcat(*rows).properties(title=f"Causal Analysis: Original vs Counterfactual{subtitle}")

--- a/chap_core/assessment/causal_plot.py
+++ b/chap_core/assessment/causal_plot.py
@@ -22,8 +22,11 @@ def plot_counterfactual(
 
     def _chart(evaluation, title: str):
         flat = evaluation.to_flat()
+        historical = pd.DataFrame(flat.historical_observations) if flat.historical_observations is not None else None
         return (
-            EvaluationPlot().plot(pd.DataFrame(flat.observations), pd.DataFrame(flat.forecasts)).properties(title=title)
+            EvaluationPlot()
+            .plot(pd.DataFrame(flat.observations), pd.DataFrame(flat.forecasts), historical)
+            .properties(title=title)
         )
 
     subtitle = f" ({', '.join(counterfactual_columns)})" if counterfactual_columns else ""

--- a/chap_core/assessment/causal_plot.py
+++ b/chap_core/assessment/causal_plot.py
@@ -38,9 +38,12 @@ def _location_y_domain(eval_original, eval_cf, location: str) -> list[float]:
             df = pd.DataFrame(df_raw)
             if "location" in df.columns and "disease_cases" in df.columns:
                 vals = df.loc[df["location"] == location, "disease_cases"].dropna()
-                obs_values.append(vals)
-                upper_values.append(vals)
+                if not vals.empty:
+                    obs_values.append(vals)
+                    upper_values.append(vals)
 
+    if not obs_values or not upper_values:
+        return [0.0, 1.0]
     all_lower = pd.concat(obs_values)
     all_upper = pd.concat(upper_values)
     return [float(all_lower.min()), float(all_upper.max())]

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -413,13 +413,13 @@ class Evaluation(EvaluationBase):
         )
 
         # Calculate number of periods based on dataset period type
-        historical_context_periods = cls._calculate_periods_from_years(
+        historical_context_periods = cls.calculate_periods_from_years(
             dataset=dataset,
             years=historical_context_years,
         )
 
         # Extract historical observations from the dataset for plotting context
-        historical_observations = cls._extract_historical_observations(
+        historical_observations = cls.extract_historical_observations(
             dataset=dataset,
             up_to_period=last_train_period,
             n_periods=historical_context_periods,
@@ -436,7 +436,7 @@ class Evaluation(EvaluationBase):
         )
 
     @classmethod
-    def _calculate_periods_from_years(cls, dataset: _DataSet, years: int) -> int:
+    def calculate_periods_from_years(cls, dataset: _DataSet, years: int) -> int:
         """
         Calculate number of periods from years based on dataset period type.
 
@@ -473,7 +473,7 @@ class Evaluation(EvaluationBase):
         return years * periods_per_year
 
     @classmethod
-    def _extract_historical_observations(
+    def extract_historical_observations(
         cls,
         dataset: _DataSet,
         up_to_period: TimePeriod,

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -239,6 +239,8 @@ class EvaluationBase(ABC):
         last_train_period: TimePeriod,
         configured_model: ConfiguredModelDB,
         info: "BacktestCreate",
+        historical_observations: list[Observation] | None = None,
+        historical_context_periods: int = 0,
     ) -> "EvaluationBase": ...
 
 

--- a/chap_core/cli_endpoints/causal.py
+++ b/chap_core/cli_endpoints/causal.py
@@ -171,10 +171,27 @@ def causal_cmd(
         )
         last_train_period = train_data.period_range[-1]
 
-        eval_original = Evaluation.from_samples_with_truth(
-            [original_swt], last_train_period, configured_model_db, backtest_info
+        historical_context_periods = Evaluation.calculate_periods_from_years(train_data, years=6)
+        historical_observations = Evaluation.extract_historical_observations(
+            train_data, last_train_period, historical_context_periods
         )
-        eval_cf = Evaluation.from_samples_with_truth([cf_swt], last_train_period, configured_model_db, backtest_info)
+
+        eval_original = Evaluation.from_samples_with_truth(
+            [original_swt],
+            last_train_period,
+            configured_model_db,
+            backtest_info,
+            historical_observations=historical_observations,
+            historical_context_periods=historical_context_periods,
+        )
+        eval_cf = Evaluation.from_samples_with_truth(
+            [cf_swt],
+            last_train_period,
+            configured_model_db,
+            backtest_info,
+            historical_observations=historical_observations,
+            historical_context_periods=historical_context_periods,
+        )
 
         cf_output_file = output_file.with_stem(output_file.stem + "_cf")
         shared_kwargs = {

--- a/chap_core/cli_endpoints/causal.py
+++ b/chap_core/cli_endpoints/causal.py
@@ -57,7 +57,13 @@ def causal_cmd(
     model_name: ModelNameArg,
     dataset_csv: DatasetCsvArg,
     counterfactual_csv: Annotated[str, Parameter(help="Path or URL to the counterfactual dataset CSV")],
-    counterfactual_columns: Annotated[list[str], Parameter(help="Column names that hold counterfactual values")],
+    counterfactual_columns: Annotated[
+        list[str], 
+        Parameter(
+            help="Column names that hold counterfactual values",
+            consume_multiple=True,
+        ),
+    ],
     split_period: Annotated[
         str,
         Parameter(help="Period string where training ends and prediction begins (e.g. '2023-01' or '2023W01')"),

--- a/chap_core/cli_endpoints/causal.py
+++ b/chap_core/cli_endpoints/causal.py
@@ -58,7 +58,7 @@ def causal_cmd(
     dataset_csv: DatasetCsvArg,
     counterfactual_csv: Annotated[str, Parameter(help="Path or URL to the counterfactual dataset CSV")],
     counterfactual_columns: Annotated[
-        list[str], 
+        list[str],
         Parameter(
             help="Column names that hold counterfactual values",
             consume_multiple=True,
@@ -72,6 +72,16 @@ def causal_cmd(
         Path,
         Parameter(help="Path for original predictions NetCDF file; counterfactual saved to {stem}_cf.nc"),
     ],
+    cf_start_period: Annotated[
+        str | None,
+        Parameter(
+            help=(
+                "Period where counterfactual values begin as historic context during prediction "
+                "(must be before split_period). When set, periods from here up to split_period "
+                "use counterfactual covariates instead of original values. Defaults to split_period."
+            )
+        ),
+    ] = None,
     run_config: Annotated[
         RunConfig,
         Parameter(help="Model execution configuration"),
@@ -92,6 +102,10 @@ def causal_cmd(
     model once on the original data up to (but not including) split_period and generates
     predictions from split_period to the end of the dataset for both the original and
     counterfactual inputs.
+
+    When cf_start_period is given, the counterfactual prediction uses original historic data
+    up to cf_start_period and counterfactual historic data from cf_start_period to split_period,
+    rather than using only original data as historical context.
 
     Results are written to two NetCDF files: output_file (original) and
     output_file with a _cf suffix (counterfactual).
@@ -118,6 +132,15 @@ def causal_cmd(
 
     initialize_logging(run_config.debug, run_config.log_file)
 
+    split_period_obj = TimePeriod.parse(split_period)
+    cf_start_period_obj = None
+    if cf_start_period is not None:
+        cf_start_period_obj = TimePeriod.parse(cf_start_period)
+        if cf_start_period_obj >= split_period_obj:
+            raise ValueError(
+                f"cf_start_period ({cf_start_period}) must be strictly before split_period ({split_period})."
+            )
+
     original_csv_path, url_geojson_path = resolve_csv_path(dataset_csv)
     cf_csv_path, _ = resolve_csv_path(counterfactual_csv)
     geojson_path = url_geojson_path or discover_geojson(original_csv_path)
@@ -142,8 +165,6 @@ def causal_cmd(
         estimator, configuration = get_estimator(template, model_configuration_yaml)
         model_info = estimator.model_information
 
-        split_period_obj = TimePeriod.parse(split_period)
-
         train_data, original_test_data = train_test_split(original_dataset, split_period_obj)
         _, cf_test_data = train_test_split(cf_dataset, split_period_obj)
 
@@ -154,7 +175,18 @@ def causal_cmd(
         original_predictions = predictor.predict(train_data, original_test_data.remove_field("disease_cases"))
 
         logger.info("Predicting on counterfactual dataset")
-        cf_predictions = predictor.predict(train_data, cf_test_data.remove_field("disease_cases"))
+        if cf_start_period_obj is not None:
+            cf_historical_full, _ = train_test_split(cf_dataset, split_period_obj)
+            cf_hist_from_start = cf_historical_full.restrict_time_period(slice(cf_start_period_obj, None))
+            if cf_start_period_obj == train_data.period_range[0]:
+                cf_historic_data = cf_hist_from_start
+            else:
+                original_pre_cf, _ = train_test_split(original_dataset, cf_start_period_obj)
+                cf_historic_data = original_pre_cf.join_on_time(cf_hist_from_start)
+        else:
+            cf_historic_data = train_data
+
+        cf_predictions = predictor.predict(cf_historic_data, cf_test_data.remove_field("disease_cases"))
 
         original_swt = original_test_data.merge(original_predictions, result_dataclass=SamplesWithTruth)
         cf_swt = cf_test_data.merge(cf_predictions, result_dataclass=SamplesWithTruth)

--- a/chap_core/cli_endpoints/causal.py
+++ b/chap_core/cli_endpoints/causal.py
@@ -12,9 +12,7 @@ from cyclopts import Parameter
 from chap_core.api_types import RunConfig
 from chap_core.cli_endpoints._args import (  # noqa: TC001 — used at runtime via cyclopts get_type_hints()
     DatasetCsvArg,
-    ModelConfigYamlArg,
     ModelNameArg,
-    RunConfigArg,
 )
 from chap_core.cli_endpoints._common import (
     discover_geojson,

--- a/chap_core/cli_endpoints/causal.py
+++ b/chap_core/cli_endpoints/causal.py
@@ -66,8 +66,18 @@ def causal_cmd(
         Path,
         Parameter(help="Path for original predictions NetCDF file; counterfactual saved to {stem}_cf.nc"),
     ],
-    run_config: RunConfigArg = RunConfig(),
-    model_configuration_yaml: ModelConfigYamlArg = None,
+    run_config: Annotated[
+        RunConfig,
+        Parameter(help="Model execution configuration"),
+    ] = RunConfig(),
+    model_configuration_yaml: Annotated[
+        Path | None,
+        Parameter(help="Path to YAML file with model-specific configuration parameters"),
+    ] = None,
+    plot: Annotated[
+        bool,
+        Parameter(help="Generate a side-by-side comparison plot (HTML) alongside the NetCDF output"),
+    ] = False,
 ):
     """Train a model on the original dataset up to split_period and predict on both datasets.
 
@@ -179,6 +189,15 @@ def causal_cmd(
 
         logger.info(f"Saving counterfactual predictions to {cf_output_file}")
         eval_cf.to_file(cf_output_file, **shared_kwargs)
+
+        if plot:
+            from chap_core.assessment.causal_plot import plot_counterfactual
+
+            plot_path = output_file.with_suffix(".html")
+            logger.info(f"Generating counterfactual plot to {plot_path}")
+            chart = plot_counterfactual(eval_original, eval_cf, counterfactual_columns)
+            chart.save(str(plot_path))
+            logger.info(f"Plot saved to {plot_path}")
 
 
 def register_commands(app):

--- a/tests/evaluation/conftest.py
+++ b/tests/evaluation/conftest.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import altair
 import pandas as pd
 import pytest
 
@@ -9,6 +10,12 @@ from chap_core.assessment.evaluation import Evaluation
 from chap_core.database.dataset_tables import DataSetWithObservations, Observation, DataSet
 from chap_core.database.tables import BacktestRead, OldBacktestRead, BacktestForecast, Backtest, BacktestMetric
 from chap_core.simulation.naive_simulator import DatasetDimensions, AdditiveSimulator, BacktestSimulator
+
+
+@pytest.fixture(scope="module")
+def default_transformer():
+    altair.data_transformers.enable("default")
+    yield
 
 
 @pytest.fixture

--- a/tests/evaluation/test_backtest_plot.py
+++ b/tests/evaluation/test_backtest_plot.py
@@ -1,7 +1,6 @@
 import itertools
 from pathlib import Path
 
-import altair
 import pandas as pd
 import pytest
 
@@ -23,12 +22,6 @@ from chap_core.assessment.backtest_plots.sample_bias_plot import SampleBiasPlot
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.cli_endpoints.utils import plot_backtest
 from chap_core.database.tables import Backtest
-
-
-@pytest.fixture(scope="module")
-def default_transformer():
-    altair.data_transformers.enable("default")
-    yield
 
 
 def test_backtest_plot_registry():

--- a/tests/evaluation/test_causal_plot.py
+++ b/tests/evaluation/test_causal_plot.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+
+import altair as alt
+import pandas as pd
+import pytest
+
+from chap_core.assessment.causal_plot import plot_counterfactual
+from chap_core.assessment.evaluation import Evaluation
+from chap_core.database.dataset_tables import DataSet, Observation
+from chap_core.database.tables import Backtest, BacktestForecast
+
+_EXAMPLE_DATA = Path(__file__).parent.parent.parent / "example_data"
+
+
+def _load_vietnam_geojson(locations: list[str]) -> str:
+    raw = json.loads((_EXAMPLE_DATA / "vietnam_monthly.geojson").read_text())
+    raw["features"] = [f for f in raw["features"] if f["id"] in locations]
+    return json.dumps(raw)
+
+
+def _make_vietnam_evaluation(df: pd.DataFrame, periods: list[str], geojson: str, scale: float) -> Evaluation:
+    obs = [
+        Observation(
+            feature_name="disease_cases",
+            id=i,
+            dataset_id=1,
+            period=row["time_period"],
+            org_unit=row["location"],
+            value=float(row["disease_cases"]),
+        )
+        for i, (_, row) in enumerate(df.iterrows())
+    ]
+    dataset = DataSet(id=1, name="vietnam", type="test", geojson=geojson, covariates=[], observations=obs, created=None)
+    forecasts = [
+        BacktestForecast(
+            id=i,
+            backtest_id=1,
+            period=row["time_period"],
+            org_unit=row["location"],
+            last_train_period=periods[0],
+            last_seen_period=periods[0],
+            values=[float(row["disease_cases"]) * scale + j for j in range(3)],
+        )
+        for i, (_, row) in enumerate(df.iterrows())
+    ]
+    backtest = Backtest(
+        id=1,
+        dataset_id=1,
+        dataset=dataset,
+        model_id="test",
+        model_db_id=1,
+        name="vietnam_test",
+        created=None,
+        aggregate_metrics={},
+        forecasts=forecasts,
+        metrics=[],
+    )
+    return Evaluation.from_backtest(backtest)
+
+
+@pytest.fixture(scope="module")
+def vietnam_evaluation_pair():
+    df = pd.read_csv(_EXAMPLE_DATA / "vietnam_monthly.csv")
+    locations = sorted(df["location"].unique())[:2]
+    df = df[df["location"].isin(locations)]
+    periods = sorted(df["time_period"].unique())[-6:]
+    df = df[df["time_period"].isin(periods)].reset_index(drop=True)
+    geojson = _load_vietnam_geojson(locations)
+    return (
+        _make_vietnam_evaluation(df, periods, geojson, scale=1.0),
+        _make_vietnam_evaluation(df, periods, geojson, scale=0.7),
+    )
+
+
+def test_plot_counterfactual_returns_chart(vietnam_evaluation_pair, default_transformer):
+    eval_orig, eval_cf = vietnam_evaluation_pair
+    assert plot_counterfactual(eval_orig, eval_cf, ["rainfall"]) is not None
+
+
+def test_plot_counterfactual_is_hconcat(vietnam_evaluation_pair, default_transformer):
+    eval_orig, eval_cf = vietnam_evaluation_pair
+    assert isinstance(plot_counterfactual(eval_orig, eval_cf), alt.HConcatChart)
+
+
+def test_plot_counterfactual_saves_html(vietnam_evaluation_pair, default_transformer, tmp_path):
+    eval_orig, eval_cf = vietnam_evaluation_pair
+    out = tmp_path / "causal.html"
+    plot_counterfactual(eval_orig, eval_cf, ["rainfall"]).save(str(out))
+    assert out.exists() and out.stat().st_size > 0

--- a/tests/evaluation/test_causal_plot.py
+++ b/tests/evaluation/test_causal_plot.py
@@ -5,7 +5,7 @@ import altair as alt
 import pandas as pd
 import pytest
 
-from chap_core.assessment.causal_plot import plot_counterfactual
+from chap_core.assessment.causal_plot import _location_y_domain, plot_counterfactual
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.database.dataset_tables import DataSet, Observation
 from chap_core.database.tables import Backtest, BacktestForecast
@@ -88,3 +88,9 @@ def test_plot_counterfactual_saves_html(vietnam_evaluation_pair, default_transfo
     out = tmp_path / "causal.html"
     plot_counterfactual(eval_orig, eval_cf, ["rainfall"]).save(str(out))
     assert out.exists() and out.stat().st_size > 0
+
+
+def test_location_y_domain_empty_data_returns_fallback(vietnam_evaluation_pair, default_transformer):
+    eval_orig, eval_cf = vietnam_evaluation_pair
+    domain = _location_y_domain(eval_orig, eval_cf, "nonexistent_location")
+    assert domain == [0.0, 1.0]

--- a/tests/evaluation/test_causal_plot.py
+++ b/tests/evaluation/test_causal_plot.py
@@ -94,3 +94,16 @@ def test_location_y_domain_empty_data_returns_fallback(vietnam_evaluation_pair, 
     eval_orig, eval_cf = vietnam_evaluation_pair
     domain = _location_y_domain(eval_orig, eval_cf, "nonexistent_location")
     assert domain == [0.0, 1.0]
+
+
+def test_plot_counterfactual_title_with_columns(vietnam_evaluation_pair, default_transformer):
+    eval_orig, eval_cf = vietnam_evaluation_pair
+    chart = plot_counterfactual(eval_orig, eval_cf, ["rainfall", "temperature"])
+    assert "rainfall, temperature" in chart.title
+
+
+def test_plot_counterfactual_title_without_columns(vietnam_evaluation_pair, default_transformer):
+    eval_orig, eval_cf = vietnam_evaluation_pair
+    chart = plot_counterfactual(eval_orig, eval_cf, None)
+    title = chart.title
+    assert "(" not in title and ")" not in title

--- a/tests/evaluation/test_causal_plot.py
+++ b/tests/evaluation/test_causal_plot.py
@@ -5,7 +5,7 @@ import altair as alt
 import pandas as pd
 import pytest
 
-from chap_core.assessment.causal_plot import _location_y_domain, plot_counterfactual
+from chap_core.assessment.causal_plot import plot_counterfactual
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.database.dataset_tables import DataSet, Observation
 from chap_core.database.tables import Backtest, BacktestForecast
@@ -88,12 +88,6 @@ def test_plot_counterfactual_saves_html(vietnam_evaluation_pair, default_transfo
     out = tmp_path / "causal.html"
     plot_counterfactual(eval_orig, eval_cf, ["rainfall"]).save(str(out))
     assert out.exists() and out.stat().st_size > 0
-
-
-def test_location_y_domain_empty_data_returns_fallback(vietnam_evaluation_pair, default_transformer):
-    eval_orig, eval_cf = vietnam_evaluation_pair
-    domain = _location_y_domain(eval_orig, eval_cf, "nonexistent_location")
-    assert domain == [0.0, 1.0]
 
 
 def test_plot_counterfactual_title_with_columns(vietnam_evaluation_pair, default_transformer):

--- a/tests/evaluation/test_causal_plot.py
+++ b/tests/evaluation/test_causal_plot.py
@@ -78,9 +78,9 @@ def test_plot_counterfactual_returns_chart(vietnam_evaluation_pair, default_tran
     assert plot_counterfactual(eval_orig, eval_cf, ["rainfall"]) is not None
 
 
-def test_plot_counterfactual_is_hconcat(vietnam_evaluation_pair, default_transformer):
+def test_plot_counterfactual_is_vconcat(vietnam_evaluation_pair, default_transformer):
     eval_orig, eval_cf = vietnam_evaluation_pair
-    assert isinstance(plot_counterfactual(eval_orig, eval_cf), alt.HConcatChart)
+    assert isinstance(plot_counterfactual(eval_orig, eval_cf), alt.VConcatChart)
 
 
 def test_plot_counterfactual_saves_html(vietnam_evaluation_pair, default_transformer, tmp_path):

--- a/tests/test_causal_cmd.py
+++ b/tests/test_causal_cmd.py
@@ -21,13 +21,14 @@ def _write_csvs(tmp_path, original_df, cf_df):
     return original_csv, cf_csv
 
 
-def _call_causal_cmd(tmp_path, original_csv, cf_csv, columns=None):
+def _call_causal_cmd(tmp_path, original_csv, cf_csv, columns=None, cf_start_period=None):
     causal_cmd(
         model_name="nonexistent",
         dataset_csv=str(original_csv),
         counterfactual_csv=str(cf_csv),
         counterfactual_columns=columns or ["rainfall"],
         split_period="2022-01",
+        cf_start_period=cf_start_period,
         output_file=tmp_path / "out.nc",
     )
 
@@ -65,6 +66,22 @@ def test_validation_no_differences_row_order_independent(tmp_path):
         _call_causal_cmd(tmp_path, original_csv, cf_csv)
 
 
+def test_cf_start_period_at_split_raises(tmp_path):
+    original = _make_df(["A"], ["2021-01", "2022-01", "2022-02"])
+    cf = _make_df(["A"], ["2021-01", "2022-01", "2022-02"], extra_col_val=2.0)
+    original_csv, cf_csv = _write_csvs(tmp_path, original, cf)
+    with pytest.raises(ValueError, match="strictly before"):
+        _call_causal_cmd(tmp_path, original_csv, cf_csv, cf_start_period="2022-01")
+
+
+def test_cf_start_period_after_split_raises(tmp_path):
+    original = _make_df(["A"], ["2021-01", "2022-01", "2022-02"])
+    cf = _make_df(["A"], ["2021-01", "2022-01", "2022-02"], extra_col_val=2.0)
+    original_csv, cf_csv = _write_csvs(tmp_path, original, cf)
+    with pytest.raises(ValueError, match="strictly before"):
+        _call_causal_cmd(tmp_path, original_csv, cf_csv, cf_start_period="2022-02")
+
+
 @pytest.mark.slow
 def test_causal_cmd_integration(tmp_path):
     from chap_core.api_types import RunConfig
@@ -91,6 +108,41 @@ def test_causal_cmd_integration(tmp_path):
         counterfactual_csv=str(cf_csv),
         counterfactual_columns=["rainfall"],
         split_period=split_period,
+        output_file=output_file,
+        run_config=RunConfig(),
+    )
+
+    assert output_file.exists(), "Original predictions NetCDF not created"
+    cf_output = tmp_path / "causal_out_cf.nc"
+    assert cf_output.exists(), "Counterfactual predictions NetCDF not created"
+
+
+@pytest.mark.slow
+def test_causal_cmd_cf_start_period_integration(tmp_path):
+    from chap_core.api_types import RunConfig
+    from chap_core.file_io.example_data_set import datasets
+
+    dataset = datasets["hydromet_5_filtered"].load()
+    original_csv = tmp_path / "original.csv"
+    dataset.to_csv(original_csv)
+
+    df = pd.read_csv(original_csv)
+    df["rainfall"] = df["rainfall"] + 10.0
+    cf_csv = tmp_path / "counterfactual.csv"
+    df.to_csv(cf_csv, index=False)
+
+    periods = sorted(df["time_period"].unique())
+    split_period = periods[-3]
+    cf_start_period = periods[-6]
+
+    output_file = tmp_path / "causal_out.nc"
+    causal_cmd(
+        model_name="https://github.com/dhis2-chap/minimalist_example_lag",
+        dataset_csv=str(original_csv),
+        counterfactual_csv=str(cf_csv),
+        counterfactual_columns=["rainfall"],
+        split_period=split_period,
+        cf_start_period=cf_start_period,
         output_file=output_file,
         run_config=RunConfig(),
     )

--- a/tests/test_causal_cmd.py
+++ b/tests/test_causal_cmd.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+from xarray import plot
 
 from chap_core.cli_endpoints.causal import causal_cmd
 
@@ -110,11 +111,14 @@ def test_causal_cmd_integration(tmp_path):
         split_period=split_period,
         output_file=output_file,
         run_config=RunConfig(),
+        plot=True
     )
 
     assert output_file.exists(), "Original predictions NetCDF not created"
     cf_output = tmp_path / "causal_out_cf.nc"
     assert cf_output.exists(), "Counterfactual predictions NetCDF not created"
+    plot_path = tmp_path / "causal_out.html"
+    assert plot_path.exists(), "Causal effect plot not created"
 
 
 @pytest.mark.slow

--- a/tests/test_causal_cmd.py
+++ b/tests/test_causal_cmd.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import pytest
-from xarray import plot
 
 from chap_core.cli_endpoints.causal import causal_cmd
 

--- a/tests/test_causal_cmd.py
+++ b/tests/test_causal_cmd.py
@@ -111,7 +111,7 @@ def test_causal_cmd_integration(tmp_path):
         split_period=split_period,
         output_file=output_file,
         run_config=RunConfig(),
-        plot=True
+        plot=True,
     )
 
     assert output_file.exists(), "Original predictions NetCDF not created"


### PR DESCRIPTION
## Summary

- Adds `plot_counterfactual` in `chap_core/assessment/causal_plot.py` that produces a per-location side-by-side Altair chart comparing original vs counterfactual predictions. Both panels for a given location share the same y-axis via Altair's native `resolve_scale(y="shared")` so case counts are directly comparable.
- Adds a `--plot` flag to `causal_cmd` that saves the comparison chart as an HTML file alongside the NetCDF output.
- Adds a `--cf-start-period` argument to `causal_cmd` so that counterfactual covariates can be introduced before `split_period` (i.e. as historical context during prediction), with original data used prior to that point.
- Exposes 6 years of historical context in both original and counterfactual `Evaluation` objects so the plot includes pre-split observations.
- Promotes `Evaluation._calculate_periods_from_years` and `Evaluation._extract_historical_observations` to public methods so they can be reused from `causal_cmd` without accessing private API.
- Adds a `y_domain` parameter to `EvaluationPlot.plot` so callers can enforce a fixed y-axis scale across multiple charts.

## Test plan

- [x] `tests/evaluation/test_causal_plot.py` — unit tests covering `plot_counterfactual`, shared y-domain, and single/multi-location rendering
- [x] `tests/test_causal_cmd.py` — tests for `cf_start_period` validation and the `--plot` flag
- [x] `make lint && make test` pass locally