### PR TITLE
fix: chapkit configured-model sync silently dropped when schema uses default_factory

### DIFF
--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -175,7 +175,12 @@ class SessionWrapper:
             model_template=model_template,
             uses_chapkit=uses_chapkit,
         )
-        configured_model.validate_user_options(configured_model)
+        # Chapkit owns its config schema and validates server-side; chap-core
+        # stores user_option_values={} as a "use chapkit defaults" sentinel.
+        # The local heuristic-based validator wrongly flags any default_factory
+        # field as required (no literal "default" key in the schema), so skip it.
+        if not uses_chapkit:
+            configured_model.validate_user_options(configured_model)
         # configured_model.validate_user_options(model_template)
         logger.info(f"Adding configured model: {configured_model}")
         self.session.add(configured_model)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -138,6 +138,49 @@ def test_add_model_template_unarchives_existing(model_template_yaml_config, engi
         assert template.archived is False
 
 
+def test_add_configured_model_chapkit_skips_required_validation(engine):
+    # Mimics what chapkit's /api/v1/configs/$schema returns for a field declared
+    # with Field(default_factory=lambda: [3]): the property has no literal
+    # "default" key. chap-core's heuristic-based validator would mark it
+    # required, but with uses_chapkit=True we trust chapkit's own validation
+    # and store user_option_values={} as a "use chapkit defaults" sentinel.
+    chapkit_schema_user_options = {
+        "n_lags": {
+            "items": {"type": "integer"},
+            "title": "N Lags",
+            "type": "array",
+        },
+    }
+    config = ModelTemplateConfigV2(
+        name="chapkit_default_factory",
+        required_covariates=["population"],
+        allow_free_additional_continuous_covariates=False,
+        user_options=chapkit_schema_user_options,
+        meta_data=ModelTemplateMetaData(
+            author="chap_temp",
+            author_assessed_status="orange",
+            description="chapkit model with default_factory field",
+            display_name="Chapkit Default Factory",
+        ),
+    )
+    with SessionWrapper(engine) as session:
+        template_id = session.add_model_template_from_yaml_config(config)
+        cm_id = session.add_configured_model(
+            template_id,
+            ModelConfiguration(user_option_values={}),
+            "default",
+            uses_chapkit=True,
+        )
+        assert cm_id is not None
+        with pytest.raises(ValueError, match="n_lags"):
+            session.add_configured_model(
+                template_id,
+                ModelConfiguration(user_option_values={}),
+                "no_chapkit",
+                uses_chapkit=False,
+            )
+
+
 def test_yaml_update_preserves_uses_chapkit(model_template_yaml_config, engine):
     with SessionWrapper(engine) as session:
         template_id = session.add_model_template_from_yaml_config(model_template_yaml_config)


### PR DESCRIPTION
## Summary

Chapkit-managed models stopped appearing in `/v1/crud/configured-models` after services that use `Field(default_factory=...)` for any user-tuneable option (e.g. `chapkit_ewars_model` after commit 918a40e renamed `n_lags: int` → `n_lags: list[int] = Field(default_factory=lambda: [3])`).

**Root cause**

`chap_core/database/model_templates_and_config_tables.py:102` derives JSON-schema `required` as:

\`\`\`python
"required": list({key for key, value in user_options.items() if "default" not in value}),
\`\`\`

That heuristic treats *"no literal `default` key in the property dict"* as a proxy for *"field is required"*. It's wrong: pydantic does **not** emit a literal `default` for `default_factory` fields in `model_json_schema()`. So chapkit's `/api/v1/configs/$schema` returns `n_lags` with no `default` → chap-core's heuristic flags it required → `add_configured_model(..., user_option_values={})` raises during chapkit sync → the outer `try/except` in `_sync_live_chapkit_services` (`crud.py:125`) swallows the failure → no `ConfiguredModelDB` row is created → the model silently disappears from the listing.

Production traceback (provided by user):

\`\`\`
WARNING [chap_core.rest_api.v1.routers.crud] Failed to sync chapkit service chapkit-ewars-model
...
jsonschema.exceptions.ValidationError: 'n_lags' is a required property
\`\`\`

**Fix**

Skip `validate_user_options` in `add_configured_model` when `uses_chapkit=True`. chapkit owns the schema and validates server-side; chap-core stores `user_option_values={}` as a deliberate "use chapkit defaults" sentinel — there is nothing locally meaningful to validate.

Fixing the heuristic itself (propagate the JSON schema's top-level `required` array instead of inferring it from missing `default` keys) is a larger, more general correctness fix and is out of scope here.

## Test plan

- [x] New regression test `test_add_configured_model_chapkit_skips_required_validation` reproduces the production traceback (`ValidationError: 'n_lags' is a required property`) when run against unpatched `database.py`, and passes with the fix
- [x] Same test asserts the non-chapkit code path still rejects `user_option_values={}` against the same schema (i.e. we only loosened validation for chapkit-managed configs)
- [x] `make lint` clean
- [x] Full `tests/test_database.py` passes (18 passed, 2 pre-existing skips)