### PR TITLE
fix: derive configured-model required fields from the actual JSON schema

### DIFF
--- a/alembic/versions/d4e5f6a7b8c9_add_required_user_options_to_model_template.py
+++ b/alembic/versions/d4e5f6a7b8c9_add_required_user_options_to_model_template.py
@@ -1,0 +1,34 @@
+"""add_required_user_options_to_model_template
+
+Adds nullable JSON column `required_user_options` to modeltemplatedb. Stores
+the JSON-schema top-level `required` array for the template's user options.
+NULL means "legacy template predating this column", in which case the
+configured-model validator falls back to its old heuristic (infer required
+from missing literal "default" keys in the properties dict).
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-05-13
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, Sequence[str], None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "modeltemplatedb",
+        sa.Column("required_user_options", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("modeltemplatedb", "required_user_options")

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -175,12 +175,7 @@ class SessionWrapper:
             model_template=model_template,
             uses_chapkit=uses_chapkit,
         )
-        # Chapkit owns its config schema and validates server-side; chap-core
-        # stores user_option_values={} as a "use chapkit defaults" sentinel.
-        # The local heuristic-based validator wrongly flags any default_factory
-        # field as required (no literal "default" key in the schema), so skip it.
-        if not uses_chapkit:
-            configured_model.validate_user_options(configured_model)
+        configured_model.validate_user_options(configured_model)
         # configured_model.validate_user_options(model_template)
         logger.info(f"Adding configured model: {configured_model}")
         self.session.add(configured_model)

--- a/chap_core/database/model_templates_and_config_tables.py
+++ b/chap_core/database/model_templates_and_config_tables.py
@@ -36,6 +36,12 @@ class ModelTemplateMetaData(SQLModel):
 class ModelTemplateInformation(SQLModel):
     supported_period_type: PeriodType = PeriodType.any
     user_options: dict | None = Field(default_factory=dict, sa_column=Column(JSON))
+    # JSON schema's top-level `required` array for the model's config schema.
+    # None = legacy template (predates the column); validator falls back to a
+    # heuristic. [] = nothing required (chapkit configs where every field has
+    # a default, including default_factory which pydantic does not surface as
+    # a literal "default" key).
+    required_user_options: list[str] | None = Field(default=None, sa_column=Column(JSON))
     hpo_search_space: dict | None = Field(default=None, sa_column=Column(JSON))  # rename to hpo_search_space
     required_covariates: list[str] = Field(default_factory=list, sa_column=Column(JSON))
     min_prediction_length: int | None = None
@@ -92,14 +98,23 @@ class ConfiguredModelDB(ModelConfiguration, DBModel, table=True):
         return f"{template_display_name} [{configuration_display_name}]"
 
     @classmethod
-    def _validate_model_configuration(cls, user_options, user_option_values):
+    def _validate_model_configuration(cls, user_options, user_option_values, required_user_options=None):
         logger.debug("Validating model configuration")
         logger.debug(f"User options keys: {list(user_options.keys()) if user_options else []}")
         logger.debug(f"User option values keys: {list(user_option_values.keys()) if user_option_values else []}")
+        if required_user_options is None:
+            # Legacy template predating required_user_options: infer from missing
+            # "default" keys. This is unsound for pydantic default_factory fields
+            # (which omit the literal "default" in JSON schema) but matches the
+            # historical behavior for yaml-config-driven templates where every
+            # property has an explicit "default".
+            required = list({key for key, value in user_options.items() if "default" not in value})
+        else:
+            required = list(required_user_options)
         schema = {
             "type": "object",
             "properties": user_options,
-            "required": list({key for key, value in user_options.items() if "default" not in value}),
+            "required": required,
             "additionalProperties": False,
         }
         jsonschema.validate(instance=user_option_values, schema=schema)
@@ -107,7 +122,11 @@ class ConfiguredModelDB(ModelConfiguration, DBModel, table=True):
     # @model_validator(mode='after')
     def validate_user_options(self, model):
         try:
-            self._validate_model_configuration(model.model_template.user_options, model.user_option_values)
+            self._validate_model_configuration(
+                model.model_template.user_options,
+                model.user_option_values,
+                model.model_template.required_user_options,
+            )
         except jsonschema.ValidationError as e:
             logger.error(f"Validation error in model configuration: {e}")
             raise ValueError(f"Invalid user options: {e.message}") from e

--- a/chap_core/models/external_chapkit_model.py
+++ b/chap_core/models/external_chapkit_model.py
@@ -21,30 +21,42 @@ def _chapkit_period_to_chap(chapkit_period_type) -> PeriodType:
     return PeriodType(_CHAPKIT_PERIOD_MAP.get(value, value))
 
 
-def _parse_user_options_from_config_schema(config_schema: dict) -> dict:
-    """Extract user-tuneable options from a chapkit config schema response.
+def _parse_user_options_from_config_schema(config_schema: dict) -> tuple[dict, list[str]]:
+    """Extract user-tuneable options and required keys from a chapkit config schema.
 
-    Legacy MLflow-era models store the schema under ``$defs.ModelConfiguration.properties``;
-    chapkit services expose it at the top-level ``properties`` key. Filters out
-    BaseConfig-reserved fields (``prediction_periods``, ``additional_continuous_covariates``)
-    that chap-core handles separately.
+    Returns ``(properties, required)`` where ``properties`` is the JSON-schema
+    properties dict for user-tuneable fields and ``required`` is the schema's
+    top-level ``required`` array (empty when pydantic omitted it because no
+    field is required).
+
+    Legacy MLflow-era models store the schema under ``$defs.ModelConfiguration``;
+    chapkit services expose it at the top level. Filters out BaseConfig-reserved
+    fields (``prediction_periods``, ``additional_continuous_covariates``) that
+    chap-core handles separately, including pruning them out of ``required``.
     """
     user_options: dict = {}
+    required: list[str] = []
     if "$defs" in config_schema and "ModelConfiguration" in config_schema["$defs"]:
-        user_options = config_schema["$defs"]["ModelConfiguration"].get("properties", {})
+        model_config = config_schema["$defs"]["ModelConfiguration"]
+        user_options = dict(model_config.get("properties", {}))
+        required = list(model_config.get("required", []))
     elif "properties" in config_schema:
         user_options = dict(config_schema["properties"])
+        required = list(config_schema.get("required", []))
 
-    for reserved in ("prediction_periods", "additional_continuous_covariates"):
+    reserved_keys = ("prediction_periods", "additional_continuous_covariates")
+    for reserved in reserved_keys:
         user_options.pop(reserved, None)
+    required = [k for k in required if k not in reserved_keys]
 
-    return user_options
+    return user_options, required
 
 
 def ml_service_info_to_model_template_config(
     info: "Any",
     rest_api_url: str,
     user_options: dict | None = None,
+    required_user_options: list[str] | None = None,
 ) -> ModelTemplateConfigV2:
     """Convert an MLServiceInfo object to a ModelTemplateConfigV2.
 
@@ -76,6 +88,7 @@ def ml_service_info_to_model_template_config(
         "requires_geo": getattr(info, "requires_geo", False),
         "supported_period_type": _chapkit_period_to_chap(info.period_type),
         "user_options": user_options or {},
+        "required_user_options": required_user_options if required_user_options is not None else [],
         "min_prediction_length": info.min_prediction_periods,
         "max_prediction_length": info.max_prediction_periods,
         "entry_points": None,
@@ -299,9 +312,11 @@ class ExternalChapkitModelTemplate:
         model_info = self.client.info()
 
         config_schema = self.client.get_config_schema()
-        user_options = _parse_user_options_from_config_schema(config_schema)
+        user_options, required_user_options = _parse_user_options_from_config_schema(config_schema)
 
-        return ml_service_info_to_model_template_config(model_info, self.rest_api_url, user_options)
+        return ml_service_info_to_model_template_config(
+            model_info, self.rest_api_url, user_options, required_user_options
+        )
 
 
 class ExternalChapkitModel(ExternalModelBase):

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -108,14 +108,17 @@ def _sync_live_chapkit_services(session: Session) -> set[str]:
                 # on every subsequent sync so schema changes propagate without a
                 # DB wipe.
                 user_options: dict = {}
+                required_user_options: list[str] = []
                 try:
                     client = CHAPKitRestAPIWrapper(service.url, timeout=5)
                     schema = client.get_config_schema()
-                    user_options = _parse_user_options_from_config_schema(schema)
+                    user_options, required_user_options = _parse_user_options_from_config_schema(schema)
                 except Exception:
                     logger.debug("Could not fetch config schema from %s", service.url)
 
-                config = ml_service_info_to_model_template_config(service.info, service.url, user_options)
+                config = ml_service_info_to_model_template_config(
+                    service.info, service.url, user_options, required_user_options
+                )
                 template_id = session_wrapper.add_model_template_from_yaml_config(config)
                 # Mark template as chapkit-originated for archival tracking
                 template = session.exec(select(ModelTemplateDB).where(ModelTemplateDB.id == template_id)).one()

--- a/tests/external/test_external_chapkit_model.py
+++ b/tests/external/test_external_chapkit_model.py
@@ -200,6 +200,49 @@ class TestGetModelTemplateConfig:
         config = template.get_model_template_config()
         assert config.user_options == {}
 
+    def test_top_level_required_array_propagates(self):
+        """When the chapkit schema declares required fields, they propagate to
+        ModelTemplateConfigV2.required_user_options so the configured-model
+        validator can use the actual schema instead of guessing from "default"."""
+        schema = {
+            "properties": {
+                "n_lags": {"type": "array", "items": {"type": "integer"}},
+                "precision": {"type": "number", "default": 0.01},
+            },
+            "required": ["n_lags"],
+            "type": "object",
+        }
+        template = self._make_template_with_schema(schema)
+        config = template.get_model_template_config()
+        assert config.required_user_options == ["n_lags"]
+
+    def test_missing_required_array_means_empty(self):
+        """Pydantic omits the top-level "required" entirely when no field is
+        required (e.g. all fields have default or default_factory). The parser
+        must surface this as [] (chapkit's intent), not None (legacy heuristic
+        fallback)."""
+        schema = {
+            "properties": {"n_lags": {"type": "array", "items": {"type": "integer"}}},
+            "type": "object",
+        }
+        template = self._make_template_with_schema(schema)
+        config = template.get_model_template_config()
+        assert config.required_user_options == []
+
+    def test_required_filters_reserved_keys(self):
+        """Reserved keys must not leak into required_user_options either."""
+        schema = {
+            "properties": {
+                "prediction_periods": {"type": "integer"},
+                "n_lags": {"type": "array", "items": {"type": "integer"}},
+            },
+            "required": ["prediction_periods", "n_lags"],
+            "type": "object",
+        }
+        template = self._make_template_with_schema(schema)
+        config = template.get_model_template_config()
+        assert config.required_user_options == ["n_lags"]
+
 
 class TestExternalChapkitModelTemplateDetection:
     def test_detects_url_mode(self):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -138,24 +138,19 @@ def test_add_model_template_unarchives_existing(model_template_yaml_config, engi
         assert template.archived is False
 
 
-def test_add_configured_model_chapkit_skips_required_validation(engine):
+def test_required_user_options_explicit_empty_accepts_empty_values(engine):
     # Mimics what chapkit's /api/v1/configs/$schema returns for a field declared
     # with Field(default_factory=lambda: [3]): the property has no literal
-    # "default" key. chap-core's heuristic-based validator would mark it
-    # required, but with uses_chapkit=True we trust chapkit's own validation
-    # and store user_option_values={} as a "use chapkit defaults" sentinel.
-    chapkit_schema_user_options = {
-        "n_lags": {
-            "items": {"type": "integer"},
-            "title": "N Lags",
-            "type": "array",
-        },
-    }
+    # "default" key, and the schema's top-level "required" array is empty
+    # (omitted by pydantic). With required_user_options=[] explicitly set, the
+    # validator uses that directly instead of falling back to the unsound
+    # "no default key" heuristic, so user_option_values={} passes.
     config = ModelTemplateConfigV2(
         name="chapkit_default_factory",
         required_covariates=["population"],
         allow_free_additional_continuous_covariates=False,
-        user_options=chapkit_schema_user_options,
+        user_options={"n_lags": {"items": {"type": "integer"}, "title": "N Lags", "type": "array"}},
+        required_user_options=[],
         meta_data=ModelTemplateMetaData(
             author="chap_temp",
             author_assessed_status="orange",
@@ -169,16 +164,61 @@ def test_add_configured_model_chapkit_skips_required_validation(engine):
             template_id,
             ModelConfiguration(user_option_values={}),
             "default",
-            uses_chapkit=True,
         )
         assert cm_id is not None
+
+
+def test_required_user_options_explicit_enforces_listed_required(engine):
+    # Inverse: when required_user_options names a field, omitting it must fail
+    # regardless of whether the property has a "default" key.
+    config = ModelTemplateConfigV2(
+        name="explicit_required",
+        required_covariates=["population"],
+        allow_free_additional_continuous_covariates=False,
+        user_options={
+            "n_lags": {"items": {"type": "integer"}, "title": "N Lags", "type": "array"},
+            "precision": {"default": 0.01, "type": "number"},
+        },
+        required_user_options=["n_lags"],
+        meta_data=ModelTemplateMetaData(
+            author="chap_temp",
+            author_assessed_status="orange",
+            description="explicit required",
+            display_name="Explicit Required",
+        ),
+    )
+    with SessionWrapper(engine) as session:
+        template_id = session.add_model_template_from_yaml_config(config)
         with pytest.raises(ValueError, match="n_lags"):
-            session.add_configured_model(
-                template_id,
-                ModelConfiguration(user_option_values={}),
-                "no_chapkit",
-                uses_chapkit=False,
-            )
+            session.add_configured_model(template_id, ModelConfiguration(user_option_values={}))
+        cm_id = session.add_configured_model(template_id, ModelConfiguration(user_option_values={"n_lags": [3]}))
+        assert cm_id is not None
+
+
+def test_required_user_options_none_falls_back_to_heuristic(engine):
+    # Legacy templates predating the column have required_user_options=None.
+    # The validator must fall back to the historical heuristic so behaviour
+    # for existing yaml-config-driven templates is unchanged.
+    config = ModelTemplateConfigV2(
+        name="legacy_yaml_no_default",
+        required_covariates=["population"],
+        allow_free_additional_continuous_covariates=False,
+        user_options={"thing": {"type": "string"}},  # no "default" key
+        # required_user_options omitted → defaults to None
+        meta_data=ModelTemplateMetaData(
+            author="chap_temp",
+            author_assessed_status="orange",
+            description="legacy yaml",
+            display_name="Legacy",
+        ),
+    )
+    with SessionWrapper(engine) as session:
+        template_id = session.add_model_template_from_yaml_config(config)
+        # required_user_options gets persisted as None via model_dump pass-through.
+        template = session.session.get(ModelTemplateDB, template_id)
+        assert template.required_user_options is None
+        with pytest.raises(ValueError, match="thing"):
+            session.add_configured_model(template_id, ModelConfiguration(user_option_values={}))
 
 
 def test_yaml_update_preserves_uses_chapkit(model_template_yaml_config, engine):


### PR DESCRIPTION
## Summary

Follow-up to #348. That PR patched the chapkit-sync symptom by skipping `validate_user_options` when `uses_chapkit=True`. This PR fixes the root cause and reverts the short-circuit.

**The defect**

`_validate_model_configuration` at `model_templates_and_config_tables.py:102` inferred JSON-schema \`required\` from \"property has no literal `default` key\":

```python
\"required\": list({key for key, value in user_options.items() if \"default\" not in value}),
```

That heuristic is unsound: pydantic does NOT surface `default_factory` results as a literal `default` in `model_json_schema()`. Verified locally against the actual chapkit schema for EwarsConfig — every field has a default (mix of `default` and `default_factory`), and pydantic omits the top-level `required` key entirely. The heuristic invents required-ness that doesn't exist.

**The fix**

Trust the schema's real `required` list instead of guessing.

- New column `required_user_options: list[str] | None` on `ModelTemplateDB`, declared on `ModelTemplateInformation` so it lands on both the YAML schema (`ModelTemplateConfigV2`) and the DB table by inheritance. Nullable: `None` means \"legacy template predating this column\" and the validator falls back to the historical heuristic for backwards compatibility with existing rows.
- Alembic migration `d4e5f6a7b8c9` adds the JSON column.
- `_parse_user_options_from_config_schema` now returns `(properties, required)`. The schema's top-level `required` array (defaulted to `[]` when absent, which is pydantic's idiom for \"nothing required\") is filtered the same way reserved keys are filtered from `properties`.
- `ml_service_info_to_model_template_config` accepts and forwards `required_user_options`.
- `crud.py` chapkit sync and `ExternalChapkitModelTemplate.get_model_template_config` thread it through.
- Validator uses the explicit list when present; falls back to the legacy heuristic only when `None`.
- Revert the `if not uses_chapkit:` short-circuit from #348 — the validator now handles chapkit correctly for the right reason.

**Size / blast radius**

156 source lines / 41 deletions across 6 files, plus the migration. ~3 of the source files are 1–3 line changes. The bulk is the new column declaration, the validator update, and tests.

## Test plan

- [x] `test_required_user_options_explicit_empty_accepts_empty_values` — chapkit-shaped template with `required_user_options=[]` accepts `user_option_values={}` (reproduces the production scenario from the chapkit_ewars_model n_lags rename)
- [x] `test_required_user_options_explicit_enforces_listed_required` — when the schema names a required field, omitting it raises and providing it passes
- [x] `test_required_user_options_none_falls_back_to_heuristic` — legacy template with `required_user_options=None` still uses the historical heuristic so existing yaml-driven templates are unaffected
- [x] `test_top_level_required_array_propagates` — chapkit schema with `\"required\": [...]` propagates correctly through `get_model_template_config`
- [x] `test_missing_required_array_means_empty` — chapkit schema omitting `required` (the EwarsConfig case) yields `[]`, distinguishing chapkit intent from legacy `None`
- [x] `test_required_filters_reserved_keys` — reserved keys (`prediction_periods`, `additional_continuous_covariates`) pruned from both properties and required
- [x] `make lint` clean
- [x] Full `tests/test_database.py` + `tests/external/test_external_chapkit_model.py` pass (42 passed, 4 skipped)
- [x] `tests/` excluding external/integration: 568 passed
- [x] `tests/integration/rest_api/test_db_endpoints.py`: 28 passed