### PR TITLE
feat: add ChapUserOptions with COVID mask support

### DIFF
--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -180,6 +180,8 @@ class SessionWrapper:
         # The local heuristic-based validator wrongly flags any default_factory
         # field as required (no literal "default" key in the schema), so skip it.
         if not uses_chapkit:
+            # Add CHAP options to template for validation
+            model_template.with_chap_options()
             configured_model.validate_user_options(configured_model)
         # configured_model.validate_user_options(model_template)
         logger.info(f"Adding configured model: {configured_model}")

--- a/chap_core/database/model_templates_and_config_tables.py
+++ b/chap_core/database/model_templates_and_config_tables.py
@@ -58,6 +58,18 @@ class ModelTemplateDB(DBModel, ModelTemplateMetaData, ModelTemplateInformation, 
     archived: bool = Field(default=False)
     uses_chapkit: bool = Field(default=False)
 
+    def with_chap_options(self) -> "ModelTemplateDB":
+        """Add CHAP-specific options to this template's user_options."""
+        from chap_core.models.chap_user_options import ChapUserOptions
+
+        chap_options = ChapUserOptions().to_json_schema_properties()
+
+        if self.user_options is None:
+            self.user_options = {}
+        self.user_options.update(chap_options)
+
+        return self
+
 
 class ModelConfiguration(SQLModel):
     model_config = ConfigDict(extra="forbid")  # type: ignore[assignment]

--- a/chap_core/models/chap_user_options.py
+++ b/chap_core/models/chap_user_options.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, Field
+
+
+class ChapUserOptions(BaseModel):
+    """CHAP-specific user options available for all models."""
+
+    chap__covid_mask: bool | None = Field(
+        default=False, description="Exclude COVID-19 period (2020-2021) from training data"
+    )
+
+    @classmethod
+    def extract_from_config(cls, user_option_values: dict) -> "ChapUserOptions":
+        """Extract only chap__ prefixed options from user_option_values."""
+        chap_values = {key: value for key, value in (user_option_values or {}).items() if key.startswith("chap__")}
+        return cls(**chap_values)
+
+    def to_json_schema_properties(self) -> dict:
+        """Generate JSON schema properties to merge into user_options."""
+        return {
+            "chap__covid_mask": {
+                "type": "boolean",
+                "title": "Mask COVID-19 Period",
+                "description": "Exclude 2020-2021 COVID period from training data",
+                "default": False,
+            }
+        }

--- a/chap_core/models/external_model.py
+++ b/chap_core/models/external_model.py
@@ -166,6 +166,25 @@ class ExternalModel(ExternalModelBase):
     def model_information(self):
         return self._model_information
 
+    def _apply_chap_transformations(self, data: DataSet) -> DataSet:
+        """Apply CHAP-specific transformations based on ChapUserOptions."""
+        from chap_core.models.chap_user_options import ChapUserOptions
+        from chap_core.transformations.covid_mask import mask_covid_data
+
+        if isinstance(self._configuration, dict):
+            raw_values = self._configuration.get("user_option_values", {})
+        else:
+            raw_values = getattr(self._configuration, "user_option_values", {})
+        user_option_values: dict = raw_values if isinstance(raw_values, dict) else {}
+
+        chap_options = ChapUserOptions.extract_from_config(user_option_values)
+
+        if chap_options.chap__covid_mask:
+            logger.info("Applying COVID mask to training data")
+            data = mask_covid_data(data)
+
+        return data
+
     def _apply_generated_features(self, dataset: DataSet) -> DataSet:
         """Apply any gen:-prefixed feature generators to the dataset."""
         from chap_core.feature_generators import apply_feature_generators, parse_generated_covariates
@@ -222,6 +241,10 @@ class ExternalModel(ExternalModelBase):
             logging.info(f"Will pass polygons file {self._polygons_file_name} to train command and predict command")
 
         frequency = self._get_frequency(train_data)
+
+        # Apply CHAP transformations
+        train_data = self._apply_chap_transformations(train_data)
+
         pd = train_data.to_pandas()
         new_pd = self._adapt_data(pd, frequency=frequency)
         new_pd.to_csv(train_file_name_full)

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -571,13 +571,16 @@ async def list_model_templates(session: Session = Depends(get_session)):
     """
     Lists all model templates from the db, including archived.
     Also syncs live chapkit services from the v2 service registry
-    into the database (upsert by name).
+    into the database (upsert by name). CHAP-wide options (chap__*) are
+    merged into each template's user_options before serialization.
     """
     live_ids = _sync_live_chapkit_services(session)
     model_templates = session.exec(select(ModelTemplateDB)).all()
 
     results = []
     for t in model_templates:
+        if not any(key.startswith("chap__") for key in (t.user_options or {})):
+            t.with_chap_options()
         read = ModelTemplateRead.model_validate(t)
         if t.name in live_ids:
             read.health_status = "live"

--- a/tests/integration/rest_api/test_chap_options_endpoints.py
+++ b/tests/integration/rest_api/test_chap_options_endpoints.py
@@ -1,0 +1,122 @@
+import logging
+
+from fastapi.testclient import TestClient
+
+from chap_core.rest_api.app import app
+from chap_core.rest_api.v1.routers.crud import ModelConfigurationCreate
+
+logger = logging.getLogger(__name__)
+client = TestClient(app)
+
+
+def get_content(url):
+    response = client.get(url)
+    assert response.status_code == 200, response.json()
+    return response.json()
+
+
+def test_list_model_templates_includes_chap_options(celery_session_worker, dependency_overrides):
+    """Test that /crud/model-templates endpoint includes chap__ options."""
+    response = client.get("/v1/crud/model-templates")
+    assert response.status_code == 200, response.json()
+    templates = response.json()
+    assert len(templates) > 0
+
+    # Check that at least one template has chap__ options
+    template = templates[0]
+    assert "userOptions" in template
+    user_options = template["userOptions"]
+
+    # Should have chap__covid_mask option
+    assert "chap__covid_mask" in user_options
+    assert user_options["chap__covid_mask"]["type"] == "boolean"
+    assert user_options["chap__covid_mask"]["default"] is False
+
+
+def test_create_configured_model_without_chap_options(celery_session_worker, dependency_overrides):
+    """Test creating a configured model without chap__ options (backward compatibility)."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+
+    model = next(m for m in content if m["name"] == "ewars_template")
+    template_id = model["id"]
+
+    config = ModelConfigurationCreate(
+        name="test_without_chap_options",
+        model_template_id=template_id,
+        additional_continuous_covariates=["rainfall"],
+        user_option_values={"precision": 2.0, "n_lags": 3},
+    )
+
+    response = client.post("/v1/crud/configured-models", json=config.model_dump())
+    assert response.status_code == 200, response.json()
+    configured_model = response.json()
+    assert "test_without_chap_options" in configured_model["name"]
+
+
+def test_create_configured_model_with_chap_covid_mask_false(celery_session_worker, dependency_overrides):
+    """Test creating a configured model with chap__covid_mask set to False."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+
+    model = next(m for m in content if m["name"] == "ewars_template")
+    template_id = model["id"]
+
+    config = ModelConfigurationCreate(
+        name="test_with_chap_covid_mask_false",
+        model_template_id=template_id,
+        additional_continuous_covariates=["rainfall"],
+        user_option_values={"precision": 2.0, "n_lags": 3, "chap__covid_mask": False},
+    )
+
+    response = client.post("/v1/crud/configured-models", json=config.model_dump())
+    assert response.status_code == 200, response.json()
+    configured_model = response.json()
+    assert "test_with_chap_covid_mask_false" in configured_model["name"]
+    assert configured_model["userOptionValues"]["chap__covid_mask"] is False
+
+
+def test_create_configured_model_with_chap_covid_mask_true(celery_session_worker, dependency_overrides):
+    """Test creating a configured model with chap__covid_mask set to True."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+
+    model = next(m for m in content if m["name"] == "ewars_template")
+    template_id = model["id"]
+
+    config = ModelConfigurationCreate(
+        name="test_with_chap_covid_mask_true",
+        model_template_id=template_id,
+        additional_continuous_covariates=["rainfall"],
+        user_option_values={"precision": 2.0, "n_lags": 3, "chap__covid_mask": True},
+    )
+
+    response = client.post("/v1/crud/configured-models", json=config.model_dump())
+    assert response.status_code == 200, response.json()
+    configured_model = response.json()
+    assert "test_with_chap_covid_mask_true" in configured_model["name"]
+    assert configured_model["userOptionValues"]["chap__covid_mask"] is True
+
+
+def test_create_configured_model_mixed_options(celery_session_worker, dependency_overrides):
+    """Test creating a configured model with both model-specific and chap options."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+
+    model = next(m for m in content if m["name"] == "ewars_template")
+    template_id = model["id"]
+
+    config = ModelConfigurationCreate(
+        name="test_mixed_options",
+        model_template_id=template_id,
+        additional_continuous_covariates=["rainfall", "mean_temperature"],
+        user_option_values={"precision": 1.5, "n_lags": 5, "chap__covid_mask": True},
+    )
+
+    response = client.post("/v1/crud/configured-models", json=config.model_dump())
+    assert response.status_code == 200, response.json()
+    configured_model = response.json()
+    assert "test_mixed_options" in configured_model["name"]
+    assert configured_model["userOptionValues"]["precision"] == 1.5
+    assert configured_model["userOptionValues"]["n_lags"] == 5
+    assert configured_model["userOptionValues"]["chap__covid_mask"] is True

--- a/tests/integration/rest_api/test_ewars_model_configuration.py
+++ b/tests/integration/rest_api/test_ewars_model_configuration.py
@@ -1,0 +1,106 @@
+"""
+Tests for chap__covid_mask handling through the configure-model endpoint, using
+the EWARS template as a representative model template with required covariates
+and additional user options.
+
+Related: CLIM-191 (ChapUserOptions / covid_mask).
+"""
+
+import logging
+
+from fastapi.testclient import TestClient
+
+from chap_core.rest_api.app import app
+from chap_core.rest_api.v1.routers.crud import ModelConfigurationCreate
+
+logger = logging.getLogger(__name__)
+client = TestClient(app)
+
+
+def get_content(url):
+    response = client.get(url)
+    assert response.status_code == 200, response.json()
+    return response.json()
+
+
+def get_ewars_template_id():
+    """Get the ID of the ewars_template model template."""
+    url = "/v1/crud/model-templates"
+    content = get_content(url)
+    model = next(m for m in content if m["name"] == "ewars_template")
+    return model["id"]
+
+
+class TestEwarsCovidMaskConfiguration:
+    """Tests for chap__covid_mask option flowing through the EWARS template."""
+
+    def test_create_ewars_config_with_covid_mask_false(self, celery_session_worker, dependency_overrides):
+        """Test creating EWARS config with chap__covid_mask=false."""
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_covid_mask_false",
+            model_template_id=template_id,
+            additional_continuous_covariates=["rainfall", "mean_temperature"],
+            user_option_values={
+                "precision": 0.01,
+                "n_lags": 3,
+                "chap__covid_mask": False,
+            },
+        )
+
+        response = client.post("/v1/crud/configured-models", json=config.model_dump())
+        assert response.status_code == 200, response.json()
+        configured_model = response.json()
+        assert configured_model["userOptionValues"]["chap__covid_mask"] is False
+
+    def test_create_ewars_config_with_covid_mask_true(self, celery_session_worker, dependency_overrides):
+        """Test creating EWARS config with chap__covid_mask=true."""
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_covid_mask_true",
+            model_template_id=template_id,
+            additional_continuous_covariates=["rainfall", "mean_temperature"],
+            user_option_values={
+                "precision": 0.01,
+                "n_lags": 3,
+                "chap__covid_mask": True,
+            },
+        )
+
+        response = client.post("/v1/crud/configured-models", json=config.model_dump())
+        assert response.status_code == 200, response.json()
+        configured_model = response.json()
+        assert configured_model["userOptionValues"]["chap__covid_mask"] is True
+
+    def test_create_ewars_config_bugfix_scenario(self, celery_session_worker, dependency_overrides):
+        """
+        Regression scenario: bug report mentioned a barebone variant with
+        n_lags=3, precision=0.01, covariates rainfall + mean_temperature.
+        chap__covid_mask=false should round-trip cleanly alongside those.
+        """
+        template_id = get_ewars_template_id()
+
+        config = ModelConfigurationCreate(
+            name="test_ewars_bugfix_scenario",
+            model_template_id=template_id,
+            additional_continuous_covariates=["rainfall", "mean_temperature"],
+            user_option_values={
+                "n_lags": 3,
+                "precision": 0.01,
+                "chap__covid_mask": False,
+            },
+        )
+
+        response = client.post("/v1/crud/configured-models", json=config.model_dump())
+        assert response.status_code == 200, response.json()
+        configured_model = response.json()
+
+        assert configured_model["userOptionValues"]["n_lags"] == 3
+        assert configured_model["userOptionValues"]["precision"] == 0.01
+        assert configured_model["userOptionValues"]["chap__covid_mask"] is False
+        assert set(configured_model["additionalContinuousCovariates"]) == {
+            "rainfall",
+            "mean_temperature",
+        }

--- a/tests/models/test_chap_user_options.py
+++ b/tests/models/test_chap_user_options.py
@@ -1,0 +1,45 @@
+import pytest
+from chap_core.models.chap_user_options import ChapUserOptions
+
+
+def test_chap_user_options_defaults():
+    """Test that ChapUserOptions has correct default values."""
+    options = ChapUserOptions()
+    assert options.chap__covid_mask is False
+
+
+def test_extract_from_config_empty():
+    """Test extraction from empty config."""
+    options = ChapUserOptions.extract_from_config({})
+    assert options.chap__covid_mask is False
+
+
+def test_extract_from_config_with_chap_options():
+    """Test extraction with chap__ prefixed options."""
+    config = {"chap__covid_mask": True, "other_option": "value"}
+    options = ChapUserOptions.extract_from_config(config)
+    assert options.chap__covid_mask is True
+
+
+def test_extract_from_config_filters_non_chap():
+    """Test that only chap__ prefixed options are extracted."""
+    config = {"chap__covid_mask": True, "model_specific_param": 10, "another_param": "test"}
+    options = ChapUserOptions.extract_from_config(config)
+    assert options.chap__covid_mask is True
+
+
+def test_to_json_schema_properties():
+    """Test JSON schema generation."""
+    options = ChapUserOptions()
+    schema = options.to_json_schema_properties()
+
+    assert "chap__covid_mask" in schema
+    assert schema["chap__covid_mask"]["type"] == "boolean"
+    assert schema["chap__covid_mask"]["default"] is False
+    assert "description" in schema["chap__covid_mask"]
+
+
+def test_extract_from_none():
+    """Test extraction when user_option_values is None."""
+    options = ChapUserOptions.extract_from_config(None)
+    assert options.chap__covid_mask is False

--- a/tests/models/test_external_model_chap_options.py
+++ b/tests/models/test_external_model_chap_options.py
@@ -1,0 +1,137 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pathlib import Path
+import tempfile
+
+from chap_core.models.external_model import ExternalModel
+from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+from chap_core.runners.mlflow_runner import MlFlowTrainPredictRunner
+
+
+@pytest.fixture
+def sample_dataset():
+    """Create a sample dataset spanning 2019-2022 including COVID period."""
+    # Create a DataFrame with monthly data from 2019-2022
+    rows = []
+    for year in range(2019, 2023):
+        for month in range(1, 13):
+            rows.append(
+                {
+                    "location": "location1",
+                    "time_period": f"{year}-{month:02d}",
+                    "disease_cases": 100.0,
+                    "rainfall": 50.0,
+                    "mean_temperature": 25.0,
+                }
+            )
+
+    df = pd.DataFrame(rows)
+    return DataSet.from_pandas(df)
+
+
+@pytest.fixture
+def mock_runner(tmp_path):
+    """Create a mock MLFlow runner that doesn't actually run anything."""
+
+    class MockRunner(MlFlowTrainPredictRunner):
+        def train(self, *args, **kwargs):
+            pass
+
+        def predict(self, *args, **kwargs):
+            pass
+
+    return MockRunner(str(tmp_path / "model"))
+
+
+def test_apply_chap_transformations_without_covid_mask(sample_dataset, mock_runner):
+    """Test that data is unchanged when covid_mask is False."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {"user_option_values": {"chap__covid_mask": False}}
+
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        # Data should be unchanged
+        location_data = transformed_data["location1"]
+        assert np.all(location_data.disease_cases == 100)
+        assert not np.any(np.isnan(location_data.disease_cases))
+
+
+def test_apply_chap_transformations_with_covid_mask(sample_dataset, mock_runner):
+    """Test that COVID period data is masked when covid_mask is True."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {"user_option_values": {"chap__covid_mask": True}}
+
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        # Check that COVID period has NaN values
+        location_data = transformed_data["location1"]
+        time_periods = location_data.time_period
+        disease_cases = location_data.disease_cases
+
+        # Check pre-COVID period (2019) - should be intact
+        pre_covid_mask = np.array([str(p).startswith("2019") for p in time_periods])
+        assert np.all(disease_cases[pre_covid_mask] == 100)
+
+        # Check COVID period (2020-03 to 2021-12-31) - should be NaN
+        covid_mask = np.array([str(p) >= "2020-03" and str(p) <= "2021-12" for p in time_periods])
+        assert np.all(np.isnan(disease_cases[covid_mask]))
+
+        # Check post-COVID period (2022) - should be intact
+        post_covid_mask = np.array([str(p).startswith("2022") for p in time_periods])
+        assert np.all(disease_cases[post_covid_mask] == 100)
+
+
+def test_apply_chap_transformations_with_empty_config(sample_dataset, mock_runner):
+    """Test that data is unchanged with empty configuration."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {}
+
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        # Data should be unchanged (default is False)
+        location_data = transformed_data["location1"]
+        assert np.all(location_data.disease_cases == 100)
+        assert not np.any(np.isnan(location_data.disease_cases))
+
+
+def test_apply_chap_transformations_with_dict_configuration(sample_dataset, mock_runner):
+    """Test that transformation works when configuration is a dict."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Configuration as dict (not ModelConfiguration object)
+        config = {"user_option_values": {"chap__covid_mask": True, "other_param": 10}}
+
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        # COVID period should be masked
+        location_data = transformed_data["location1"]
+        time_periods = location_data.time_period
+
+        covid_mask = np.array([str(p) >= "2020-03" and str(p) <= "2021-12" for p in time_periods])
+        assert np.all(np.isnan(location_data.disease_cases[covid_mask]))
+
+
+def test_apply_chap_transformations_preserves_other_fields(sample_dataset, mock_runner):
+    """Test that COVID mask only affects disease_cases, not other fields."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = {"user_option_values": {"chap__covid_mask": True}}
+
+        model = ExternalModel(runner=mock_runner, working_dir=tmpdir, configuration=config)
+
+        transformed_data = model._apply_chap_transformations(sample_dataset)
+
+        location_data = transformed_data["location1"]
+
+        # Other fields should be unchanged
+        assert np.all(location_data.rainfall == 50)
+        assert np.all(location_data.mean_temperature == 25)
+        assert not np.any(np.isnan(location_data.rainfall))
+        assert not np.any(np.isnan(location_data.mean_temperature))


### PR DESCRIPTION
## Summary

Introduces CHAP-wide user options prefixed with `chap__` that apply automatically to every model template via the REST API. The first option, `chap__covid_mask`, masks the 2020-03 to 2021-12-31 COVID period from training data using the existing `chap_core.transformations.covid_mask.mask_covid_data` helper.

Extracted from the Laos workshop bundle (#261) so the feature can land independently of the other unrelated changes in that PR (aggregated-metrics plot, weekly stride, HMC hash bump, incidental refactors). Related: CLIM-191.

## What's in the change

- **`ChapUserOptions`** (`chap_core/models/chap_user_options.py`) — Pydantic model with `chap__covid_mask: bool = False`. `extract_from_config()` pulls chap keys out of a configured-model's `user_option_values`; `to_json_schema_properties()` emits the schema fragment.
- **`ModelTemplateDB.with_chap_options()`** — merges chap options into `user_options` so the schema downstream sees them.
- **`GET /v1/crud/model-templates`** — injects chap options into each template at API time (not stored in the DB), preserving the existing live-chapkit-sync flow.
- **Configured-model creation** — `database.py` calls `model_template.with_chap_options()` before validation so schemas with `additionalProperties: False` accept the `chap__` keys.
- **`ExternalModel.train`** — calls `_apply_chap_transformations()` before writing the training CSV; when `chap__covid_mask=true` the helper masks 2020-03 to 2021-12-31.

## Test plan

- [x] `make lint` clean
- [x] `uv run pytest tests/models/test_chap_user_options.py tests/models/test_external_model_chap_options.py -q` -> 11 passed
- [x] `make test` -> 813 passed, integration tests Redis-gated (skip locally), two pre-existing untracked-doc failures unrelated to this branch
- [ ] CI: run integration tests with Redis available so `tests/integration/rest_api/test_chap_options_endpoints.py` and `tests/integration/rest_api/test_ewars_model_configuration.py` execute end-to-end
- [ ] Manual: `GET /v1/crud/model-templates` returns `chap__covid_mask` in each template's `userOptions`
- [ ] Manual: create a configured model with `chap__covid_mask=true`, run training on a 2019-2022 dataset, confirm rows from `[2020-03, 2021-12-31]` are absent from the written training CSV