### PR TITLE
fix: support CHAP_ROOT_PATH env var for serving behind a path prefix

### DIFF
--- a/chap_core/rest_api/app.py
+++ b/chap_core/rest_api/app.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import traceback
 
 from fastapi import FastAPI, Request
@@ -29,6 +30,7 @@ openapi_tags = [
 app = FastAPI(
     title="CHAP Core API",
     openapi_tags=openapi_tags,
+    root_path=os.environ.get("CHAP_ROOT_PATH", ""),
 )
 
 origins = [

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,7 @@ services:
       CELERY_BROKER: redis://redis:6379/0
       CHAP_LOGS_DIR: /data/logs
       CHAP_RUNS_DIR: /data/runs
+      CHAP_ROOT_PATH: ${CHAP_ROOT_PATH:-}
     # for now some of the tests uses hardcoded names so we need to set the container name
     # TODO: Update the tests so they don't rely on hardcoded container names
     container_name: chap

--- a/tests/integration/rest_api/test_root_path.py
+++ b/tests/integration/rest_api/test_root_path.py
@@ -1,0 +1,22 @@
+import importlib
+
+import chap_core.rest_api.app as app_module
+
+
+class TestRootPath:
+    def test_root_path_defaults_to_empty(self, monkeypatch):
+        monkeypatch.delenv("CHAP_ROOT_PATH", raising=False)
+        reloaded = importlib.reload(app_module)
+        try:
+            assert reloaded.app.root_path == ""
+        finally:
+            importlib.reload(app_module)
+
+    def test_root_path_uses_env_var(self, monkeypatch):
+        monkeypatch.setenv("CHAP_ROOT_PATH", "/master")
+        reloaded = importlib.reload(app_module)
+        try:
+            assert reloaded.app.root_path == "/master"
+        finally:
+            monkeypatch.delenv("CHAP_ROOT_PATH", raising=False)
+            importlib.reload(app_module)


### PR DESCRIPTION
## Summary
- Read `CHAP_ROOT_PATH` env var and pass it to `FastAPI(root_path=...)`. Fixes Swagger UI `/docs` when the API is deployed behind a reverse proxy under a path prefix (e.g. `/master/`, `/stable/`) — without this, Swagger fetches `/openapi.json` at the proxy root and gets 404.
- Forward the env var through `compose.yml`; defaults to empty so nothing changes for local/dev runs.
- Test covers default-empty and env-set behaviour by reloading the app module.

## Background
Nightly chap-core deployments are served by nginx as `http://<host>/master/` and `http://<host>/stable/`, both reverse-proxied to in-container chap-core. The Swagger UI's "Failed to load API definition" error was caused by FastAPI not knowing about the prefix. Pairs with an infra change that sets `CHAP_ROOT_PATH=/master` and `CHAP_ROOT_PATH=/stable` in the per-container `.env` (chap-core-infrastructure-example).

Note: the `/stable` deployment runs the latest tagged image, so it will only pick this up after the next release; `/master` picks it up on the next nightly build.

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] New unit test `tests/integration/rest_api/test_root_path.py` passes