### PR TITLE
feat: add reusable CLI argument annotations (CLIM-684, PR1/2)

### DIFF
--- a/chap_core/cli_endpoints/_args.py
+++ b/chap_core/cli_endpoints/_args.py
@@ -1,0 +1,60 @@
+"""Reusable cyclopts argument annotations for CHAP CLI commands.
+
+Defining the ``Annotated[..., Parameter(...)]`` blocks once here keeps help
+strings in sync across commands and avoids duplication.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+from cyclopts import Parameter
+
+from chap_core.api_types import BacktestParams, RunConfig
+
+ModelNameArg = Annotated[
+    str,
+    Parameter(
+        help="Model path (local directory), GitHub URL, or chapkit service URL. "
+        "Examples: /path/to/model, https://github.com/org/model, http://localhost:8000"
+    ),
+]
+
+DatasetCsvArg = Annotated[
+    str,
+    Parameter(
+        help="Path or URL to CSV file containing disease data with columns: time_period, "
+        "location, disease_cases, and climate covariates (rainfall, temperature, etc.)"
+    ),
+]
+
+RunConfigArg = Annotated[
+    RunConfig,
+    Parameter(
+        help="Model execution configuration. Use --run-config.is-chapkit-model for chapkit models, "
+        "--run-config.debug for verbose logging, --run-config.ignore-environment to skip env setup"
+    ),
+]
+
+BacktestParamsArg = Annotated[
+    BacktestParams,
+    Parameter(
+        help="Backtest configuration. Use --backtest-params.n-periods for forecast horizon, "
+        "--backtest-params.n-splits for number of train/test splits, "
+        "--backtest-params.stride for step size between splits"
+    ),
+]
+
+ModelConfigYamlArg = Annotated[
+    Path | None,
+    Parameter(help="Path to YAML file with model-specific configuration parameters"),
+]
+
+DataSourceMappingArg = Annotated[
+    Path | None,
+    Parameter(
+        help="Path to JSON file mapping model covariate names to CSV column names. "
+        'Format: {"model_name": "csv_column"}. Example: {"rainfall": "precipitation_mm"}'
+    ),
+]

--- a/chap_core/cli_endpoints/causal.py
+++ b/chap_core/cli_endpoints/causal.py
@@ -10,6 +10,12 @@ import pandas as pd
 from cyclopts import Parameter
 
 from chap_core.api_types import RunConfig
+from chap_core.cli_endpoints._args import (  # noqa: TC001 — used at runtime via cyclopts get_type_hints()
+    DatasetCsvArg,
+    ModelConfigYamlArg,
+    ModelNameArg,
+    RunConfigArg,
+)
 from chap_core.cli_endpoints._common import (
     discover_geojson,
     get_estimator,
@@ -48,8 +54,8 @@ def _validate_datasets(original_df: pd.DataFrame, cf_df: pd.DataFrame, counterfa
 
 
 def causal_cmd(
-    model_name: Annotated[str, Parameter(help="Model path (local directory), GitHub URL, or chapkit service URL")],
-    dataset_csv: Annotated[str, Parameter(help="Path or URL to the original dataset CSV")],
+    model_name: ModelNameArg,
+    dataset_csv: DatasetCsvArg,
     counterfactual_csv: Annotated[str, Parameter(help="Path or URL to the counterfactual dataset CSV")],
     counterfactual_columns: Annotated[list[str], Parameter(help="Column names that hold counterfactual values")],
     split_period: Annotated[
@@ -60,14 +66,8 @@ def causal_cmd(
         Path,
         Parameter(help="Path for original predictions NetCDF file; counterfactual saved to {stem}_cf.nc"),
     ],
-    run_config: Annotated[
-        RunConfig,
-        Parameter(help="Model execution configuration"),
-    ] = RunConfig(),
-    model_configuration_yaml: Annotated[
-        Path | None,
-        Parameter(help="Path to YAML file with model-specific configuration parameters"),
-    ] = None,
+    run_config: RunConfigArg = RunConfig(),
+    model_configuration_yaml: ModelConfigYamlArg = None,
 ):
     """Train a model on the original dataset up to split_period and predict on both datasets.
 

--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -9,6 +9,14 @@ from typing import TYPE_CHECKING, Annotated
 from cyclopts import Parameter
 
 from chap_core.api_types import BacktestParams, EstimatorMode, EstimatorOptions, RunConfig
+from chap_core.cli_endpoints._args import (  # noqa: TC001 — used at runtime via cyclopts get_type_hints()
+    BacktestParamsArg,
+    DatasetCsvArg,
+    DataSourceMappingArg,
+    ModelConfigYamlArg,
+    ModelNameArg,
+    RunConfigArg,
+)
 from chap_core.cli_endpoints._common import (
     discover_geojson,
     get_estimator,
@@ -26,43 +34,15 @@ logger = logging.getLogger(__name__)
 
 
 def eval_cmd(
-    model_name: Annotated[
-        str,
-        Parameter(
-            help="Model path (local directory), GitHub URL, or chapkit service URL. "
-            "Examples: /path/to/model, https://github.com/org/model, http://localhost:8000"
-        ),
-    ],
-    dataset_csv: Annotated[
-        str,
-        Parameter(
-            help="Path or URL to CSV file containing disease data with columns: time_period, "
-            "location, disease_cases, and climate covariates (rainfall, temperature, etc.)"
-        ),
-    ],
+    model_name: ModelNameArg,
+    dataset_csv: DatasetCsvArg,
     output_file: Annotated[
         Path,
         Parameter(help="Path for output NetCDF file containing evaluation results (.nc extension)"),
     ],
-    backtest_params: Annotated[
-        BacktestParams,
-        Parameter(
-            help="Backtest configuration. Use --backtest-params.n-periods for forecast horizon, "
-            "--backtest-params.n-splits for number of train/test splits, "
-            "--backtest-params.stride for step size between splits"
-        ),
-    ] = BacktestParams(n_periods=3, n_splits=7, stride=1),
-    run_config: Annotated[
-        RunConfig,
-        Parameter(
-            help="Model execution configuration. Use --run-config.is-chapkit-model for chapkit models, "
-            "--run-config.debug for verbose logging, --run-config.ignore-environment to skip env setup"
-        ),
-    ] = RunConfig(),
-    model_configuration_yaml: Annotated[
-        Path | None,
-        Parameter(help="Path to YAML file with model-specific configuration parameters"),
-    ] = None,
+    backtest_params: BacktestParamsArg = BacktestParams(n_periods=3, n_splits=7, stride=1),
+    run_config: RunConfigArg = RunConfig(),
+    model_configuration_yaml: ModelConfigYamlArg = None,
     historical_context_years: Annotated[
         int,
         Parameter(
@@ -70,13 +50,7 @@ def eval_cmd(
             "Calculated as periods based on dataset frequency (e.g., 6 years = 312 weeks or 72 months)"
         ),
     ] = 6,
-    data_source_mapping: Annotated[
-        Path | None,
-        Parameter(
-            help="Path to JSON file mapping model covariate names to CSV column names. "
-            'Format: {"model_name": "csv_column"}. Example: {"rainfall": "precipitation_mm"}'
-        ),
-    ] = None,
+    data_source_mapping: DataSourceMappingArg = None,
     dry_run: Annotated[
         bool,
         Parameter(

--- a/chap_core/cli_endpoints/explain.py
+++ b/chap_core/cli_endpoints/explain.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path  # noqa: TC003 — used at runtime via cyclopts get_type_hints()
 from typing import Annotated
 
 from cyclopts import Parameter
 from pydantic import BaseModel
 
 from chap_core.api_types import RunConfig
+from chap_core.cli_endpoints._args import (  # noqa: TC001 — used at runtime via cyclopts get_type_hints()
+    DatasetCsvArg,
+    ModelConfigYamlArg,
+    ModelNameArg,
+    RunConfigArg,
+)
 from chap_core.cli_endpoints._common import (
     discover_geojson,
     load_dataset_from_csv,
+    resolve_csv_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -34,14 +40,8 @@ class LimeParams(BaseModel):
 
 
 def explain_lime(
-    model_path: Annotated[
-        Path,
-        Parameter(help="Path to a trained model run directory"),
-    ],
-    dataset_csv: Annotated[
-        Path,
-        Parameter(help="Path to CSV file with disease data"),
-    ],
+    model_name: ModelNameArg,
+    dataset_csv: DatasetCsvArg,
     location: Annotated[
         str,
         Parameter(help="Location name for which to explain the prediction"),
@@ -60,14 +60,8 @@ def explain_lime(
             "--lime-params.adaptive to enable adaptive mode"
         ),
     ] = LimeParams(),
-    run_config: Annotated[
-        RunConfig,
-        Parameter(help="Model execution configuration"),
-    ] = RunConfig(),
-    model_configuration_yaml: Annotated[
-        Path | None,
-        Parameter(help="Path to YAML file with model configuration"),
-    ] = None,
+    run_config: RunConfigArg = RunConfig(),
+    model_configuration_yaml: ModelConfigYamlArg = None,
     save: Annotated[
         bool,
         Parameter(help="Save explanation as a markdown file under runs/explainability/"),
@@ -83,7 +77,7 @@ def explain_lime(
     from chap_core.models.model_template import ModelTemplate
 
     # TODO: Fix too much printing in console when running
-    logger.info(f"Evaluating model {model_path} using LIME")
+    logger.info(f"Evaluating model {model_name} using LIME")
 
     if lime_params.adaptive:
         from chap_core.explainability.lime import explain_adaptive as explain_fn
@@ -92,17 +86,18 @@ def explain_lime(
 
     initialize_logging(run_config.debug, run_config.log_file)
 
-    geojson_path = discover_geojson(dataset_csv)
-    dataset = load_dataset_from_csv(dataset_csv, geojson_path)
+    csv_path, url_geojson_path = resolve_csv_path(dataset_csv)
+    geojson_path = url_geojson_path or discover_geojson(csv_path)
+    dataset = load_dataset_from_csv(csv_path, geojson_path)
 
     configuration = None
     if model_configuration_yaml is not None:
         logger.info(f"Loading model configuration from {model_configuration_yaml}")
         configuration = ModelConfiguration.model_validate(yaml.safe_load(open(model_configuration_yaml)))
 
-    logger.info(f"Loading model template from {model_path}")
+    logger.info(f"Loading model template from {model_name}")
     template = ModelTemplate.from_directory_or_github_url(
-        model_path,
+        model_name,
         ignore_env=run_config.ignore_environment,
         run_dir_type="use_existing",
         is_chapkit_model=run_config.is_chapkit_model,

--- a/chap_core/cli_endpoints/report.py
+++ b/chap_core/cli_endpoints/report.py
@@ -8,7 +8,13 @@ import yaml
 from cyclopts import Parameter
 
 from chap_core.api_types import RunConfig
-from chap_core.cli_endpoints._common import discover_geojson, load_dataset_from_csv
+from chap_core.cli_endpoints._args import (
+    DatasetCsvArg,
+    ModelConfigYamlArg,
+    ModelNameArg,
+    RunConfigArg,
+)
+from chap_core.cli_endpoints._common import discover_geojson, load_dataset_from_csv, resolve_csv_path
 from chap_core.database.model_templates_and_config_tables import ModelConfiguration
 from chap_core.log_config import initialize_logging
 from chap_core.models.model_template import ModelTemplate
@@ -17,29 +23,27 @@ logger = logging.getLogger(__name__)
 
 
 def report(
-    model_path: Annotated[Path, Parameter(help="Path to an MLProject directory or GitHub URL")],
-    dataset_csv: Annotated[Path, Parameter(help="Path to CSV file with historic data")],
+    model_name: ModelNameArg,
+    dataset_csv: DatasetCsvArg,
     out_file: Annotated[Path, Parameter(help="Output path for the generated PDF report")],
-    run_config: Annotated[RunConfig, Parameter(help="Model execution configuration")] = RunConfig(),
-    model_configuration_yaml: Annotated[
-        Path | None,
-        Parameter(help="Path to YAML file with model configuration"),
-    ] = None,
+    run_config: RunConfigArg = RunConfig(),
+    model_configuration_yaml: ModelConfigYamlArg = None,
 ):
     """Train an MLProject model on the supplied dataset and generate a PDF report via its ``report`` entry point."""
     initialize_logging(run_config.debug, run_config.log_file)
 
-    geojson_path = discover_geojson(dataset_csv)
-    dataset = load_dataset_from_csv(dataset_csv, geojson_path)
+    csv_path, url_geojson_path = resolve_csv_path(dataset_csv)
+    geojson_path = url_geojson_path or discover_geojson(csv_path)
+    dataset = load_dataset_from_csv(csv_path, geojson_path)
 
     configuration = None
     if model_configuration_yaml is not None:
         logger.info(f"Loading model configuration from {model_configuration_yaml}")
         configuration = ModelConfiguration.model_validate(yaml.safe_load(open(model_configuration_yaml)))
 
-    logger.info(f"Loading model template from {model_path}")
+    logger.info(f"Loading model template from {model_name}")
     template = ModelTemplate.from_directory_or_github_url(
-        model_path,
+        model_name,
         ignore_env=run_config.ignore_environment,
         run_dir_type=run_config.run_directory_type,
     )

--- a/chap_core/cli_endpoints/validate.py
+++ b/chap_core/cli_endpoints/validate.py
@@ -6,12 +6,15 @@ import itertools
 import json
 import logging
 import sys
-from pathlib import Path  # noqa: TC003 — used at runtime via cyclopts get_type_hints()
 from typing import TYPE_CHECKING, Annotated
 
 from cyclopts import Parameter
 
-from chap_core.cli_endpoints._common import discover_geojson, load_dataset_from_csv
+from chap_core.cli_endpoints._args import (  # noqa: TC001 — used at runtime via cyclopts get_type_hints()
+    DatasetCsvArg,
+    DataSourceMappingArg,
+)
+from chap_core.cli_endpoints._common import discover_geojson, load_dataset_from_csv, resolve_csv_path
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -22,24 +25,12 @@ logger = logging.getLogger(__name__)
 
 
 def validate_cmd(
-    dataset_csv: Annotated[
-        Path,
-        Parameter(
-            help="Path to CSV file containing disease data with columns: time_period, "
-            "location, disease_cases, and climate covariates"
-        ),
-    ],
+    dataset_csv: DatasetCsvArg,
     model_name: Annotated[
         str | None,
         Parameter(help="Model path (local directory) or GitHub URL to validate dataset against"),
     ] = None,
-    data_source_mapping: Annotated[
-        Path | None,
-        Parameter(
-            help="Path to JSON file mapping model covariate names to CSV column names. "
-            'Format: {"model_name": "csv_column"}'
-        ),
-    ] = None,
+    data_source_mapping: DataSourceMappingArg = None,
 ):
     """Validate a CSV dataset for CHAP compatibility.
 
@@ -65,7 +56,8 @@ def validate_cmd(
         with open(data_source_mapping) as f:
             column_mapping = json.load(f)
 
-    raw_df = pd.read_csv(dataset_csv)
+    csv_path, url_geojson_path = resolve_csv_path(dataset_csv)
+    raw_df = pd.read_csv(csv_path)
     if column_mapping is not None:
         raw_df.rename(columns={v: k for k, v in column_mapping.items()}, inplace=True)
 
@@ -76,8 +68,8 @@ def validate_cmd(
             sys.exit(1)
 
     try:
-        geojson_path = discover_geojson(dataset_csv)
-        dataset = load_dataset_from_csv(dataset_csv, geojson_path, column_mapping)
+        geojson_path = url_geojson_path or discover_geojson(csv_path)
+        dataset = load_dataset_from_csv(csv_path, geojson_path, column_mapping)
     except ValueError as e:
         print(f"Error loading dataset: {e}")
         _report_period_gaps(raw_df)

--- a/tests/test_cli_arg_aliases.py
+++ b/tests/test_cli_arg_aliases.py
@@ -1,0 +1,95 @@
+"""Tests for the shared CLI argument annotations in chap_core.cli_endpoints._args.
+
+These tests lock in that commands using the shared aliases (e.g. ModelNameArg,
+DatasetCsvArg) end up with the canonical help text in their resolved type hints,
+so help strings stay in sync across the CLI.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, get_args, get_type_hints
+
+import pytest
+
+from chap_core.cli_endpoints._args import (
+    BacktestParamsArg,
+    DatasetCsvArg,
+    DataSourceMappingArg,
+    ModelConfigYamlArg,
+    ModelNameArg,
+    RunConfigArg,
+)
+from chap_core.cli_endpoints.causal import causal_cmd
+from chap_core.cli_endpoints.evaluate import eval_cmd
+from chap_core.cli_endpoints.explain import explain_lime
+from chap_core.cli_endpoints.report import report
+from chap_core.cli_endpoints.validate import validate_cmd
+
+
+def _help_text(annotation) -> str:
+    """Extract the cyclopts Parameter help string from an Annotated type."""
+    metadata = get_args(annotation)[1:]
+    for item in metadata:
+        if hasattr(item, "help") and item.help:
+            return item.help
+    raise AssertionError(f"No Parameter help string found on {annotation!r}")
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected_substring"),
+    [
+        (ModelNameArg, "Model path (local directory), GitHub URL, or chapkit service URL"),
+        (DatasetCsvArg, "Path or URL to CSV file"),
+        (RunConfigArg, "Model execution configuration"),
+        (BacktestParamsArg, "Backtest configuration"),
+        (ModelConfigYamlArg, "YAML file with model-specific configuration parameters"),
+        (DataSourceMappingArg, "JSON file mapping model covariate names to CSV column names"),
+    ],
+)
+def test_alias_help_strings(alias, expected_substring):
+    assert expected_substring in _help_text(alias)
+
+
+@pytest.mark.parametrize(
+    ("command", "param_name", "expected_substring"),
+    [
+        (eval_cmd, "model_name", "GitHub URL, or chapkit service URL"),
+        (eval_cmd, "dataset_csv", "Path or URL to CSV file"),
+        (eval_cmd, "run_config", "Model execution configuration"),
+        (eval_cmd, "backtest_params", "Backtest configuration"),
+        (causal_cmd, "model_name", "GitHub URL, or chapkit service URL"),
+        (causal_cmd, "dataset_csv", "Path or URL to CSV file"),
+        (validate_cmd, "dataset_csv", "Path or URL to CSV file"),
+        (explain_lime, "model_name", "GitHub URL, or chapkit service URL"),
+        (explain_lime, "dataset_csv", "Path or URL to CSV file"),
+        (report, "model_name", "GitHub URL, or chapkit service URL"),
+        (report, "dataset_csv", "Path or URL to CSV file"),
+    ],
+)
+def test_commands_inherit_shared_help(command, param_name, expected_substring):
+    hints = get_type_hints(command, include_extras=True)
+    annotation = hints[param_name]
+    assert expected_substring in _help_text(annotation)
+
+
+def test_renamed_outliers_no_longer_use_model_path():
+    """report and explain previously exposed `model_path`; they now use `model_name`."""
+    for command in (report, explain_lime):
+        hints = get_type_hints(command, include_extras=True)
+        assert "model_name" in hints
+        assert "model_path" not in hints
+
+
+def test_aliases_are_annotated_types():
+    """Sanity-check that each alias is an Annotated[...] with cyclopts Parameter metadata."""
+    for alias in (
+        ModelNameArg,
+        DatasetCsvArg,
+        RunConfigArg,
+        BacktestParamsArg,
+        ModelConfigYamlArg,
+        DataSourceMappingArg,
+    ):
+        # Annotated unwraps to (origin_type, *metadata)
+        args = get_args(alias)
+        assert len(args) >= 2, f"{alias!r} is not a properly formed Annotated type"

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -20,8 +20,8 @@ def test_report_cli_trains_then_reports(dumped_weekly_data_paths, tmp_path):
         return_value=mock_template,
     ) as mock_from:
         report(
-            model_path=tmp_path / "fake_mlproject",
-            dataset_csv=historic_path,
+            model_name=str(tmp_path / "fake_mlproject"),
+            dataset_csv=str(historic_path),
             out_file=out_file,
         )
 


### PR DESCRIPTION
## Summary

First of two PRs for CLIM-684. Extracts the repeated `Annotated[..., Parameter(help=...)]` blocks used across the CLI commands (`evaluate`, `causal`, `validate`, `explain`, `report`, `preference_learn`, `generate_modelcard`) into shared aliases in `chap_core/cli_endpoints/_args.py`, so help strings live in one place.

Also normalizes the two outliers:
- `model_path` -> `model_name` in `explain` and `report`
- `dataset_csv` standardized on URL-capable `str`

PR2 will follow up with a shared `prepare_run(...)` helper for the parsing/setup boilerplate.

Jira: CLIM-684

## Test plan

- [ ] `make lint` clean
- [ ] `make test` green
- [ ] `chap --help` and `chap eval --help` render with the new aliases
- [ ] Help-text snapshot test added for one representative command