### PR TITLE
feat: add --track flag to chap eval for MLflow run tracking

### DIFF
--- a/chap_core/api_types.py
+++ b/chap_core/api_types.py
@@ -94,6 +94,7 @@ class RunConfig(BaseModel):
     log_file: str | None = None
     run_directory_type: Literal["latest", "timestamp", "use_existing"] = "timestamp"
     is_chapkit_model: bool = False
+    track: bool = False
 
 
 class EvaluationResponse(BaseModel):

--- a/chap_core/assessment/eval_tracking.py
+++ b/chap_core/assessment/eval_tracking.py
@@ -1,0 +1,179 @@
+"""MLflow tracking for the ``chap eval`` command.
+
+Tracking is opt-in via ``chap eval --track``. The MLflow tracking URI must be
+set explicitly via the ``MLFLOW_TRACKING_URI`` environment variable; this
+module never picks a default location, to avoid surprising the user with files
+written outside their workspace.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import mlflow
+
+import chap_core
+from chap_core.assessment.metrics import available_metrics, calculate_metrics
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from chap_core.api_types import BacktestParams
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_EXPERIMENT_NAME = "chap-backtests"
+
+
+class TrackingConfigError(RuntimeError):
+    """Raised when --track is requested but MLFLOW_TRACKING_URI is not set."""
+
+
+class Tracker:
+    """Yielded by :func:`tracked_eval_run`. When tracking is disabled every
+    method is a no-op, which lets the caller treat tracked and untracked runs
+    uniformly without an ``if track`` branch.
+    """
+
+    def __init__(self, enabled: bool) -> None:
+        self.enabled = enabled
+
+    def log_outputs_from_files(
+        self,
+        nc_path: Path,
+        plot_path: Path | None = None,
+    ) -> None:
+        """Log the NetCDF (and optional plot) as artifacts and log metrics
+        computed by re-loading the NetCDF. Called after the eval has finished
+        writing its outputs to disk."""
+        if not self.enabled:
+            return
+        _log_outputs_from_files(nc_path, plot_path)
+
+
+@contextmanager
+def tracked_eval_run(
+    *,
+    track: bool,
+    model_name: str,
+    dataset_csv: str,
+    backtest_params: BacktestParams,
+    historical_context_years: int,
+) -> Iterator[Tracker]:
+    """Context manager that opens an MLflow run when ``track`` is True.
+
+    When ``track`` is False this is a no-op. When True it requires
+    ``MLFLOW_TRACKING_URI`` to be set, sets the experiment (honoring
+    ``MLFLOW_EXPERIMENT_NAME`` if set, else ``"chap-backtests"``), and logs the
+    run-identifying params and tags before yielding.
+    """
+    if not track:
+        yield Tracker(enabled=False)
+        return
+
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI")
+    if not tracking_uri:
+        raise TrackingConfigError(
+            "chap eval --track requires MLFLOW_TRACKING_URI to be set "
+            "(e.g. export MLFLOW_TRACKING_URI=file://$HOME/chap-evaluations/mlruns)"
+        )
+
+    experiment_name = os.environ.get("MLFLOW_EXPERIMENT_NAME", DEFAULT_EXPERIMENT_NAME)
+    mlflow.set_experiment(experiment_name)
+
+    run_name = f"{_short_name(model_name)}-{_short_name(dataset_csv)}"
+    with mlflow.start_run(run_name=run_name):
+        params: dict[str, object] = {
+            "model_name": model_name,
+            "dataset_csv": dataset_csv,
+            "n_periods": backtest_params.n_periods,
+            "n_splits": backtest_params.n_splits,
+            "stride": backtest_params.stride,
+            "prediction_length": backtest_params.n_periods,
+            "historical_context_years": historical_context_years,
+            "chap_version": chap_core.__version__,
+        }
+        sha = _maybe_file_sha256(dataset_csv)
+        if sha is not None:
+            params["dataset_sha256"] = sha
+        mlflow.log_params(params)
+
+        tags: dict[str, str] = {
+            "dataset.name": _short_name(dataset_csv),
+            "model.name": _short_name(model_name),
+        }
+        git_sha = _chap_core_git_sha()
+        if git_sha is not None:
+            tags["git_sha"] = git_sha
+        mlflow.set_tags(tags)
+
+        yield Tracker(enabled=True)
+
+
+def _log_outputs_from_files(nc_path: Path, plot_path: Path | None) -> None:
+    if not nc_path.exists():
+        logger.warning("No NetCDF at %s; skipping artifact + metric logging", nc_path)
+        return
+
+    mlflow.log_artifact(str(nc_path))
+    if plot_path is not None and plot_path.exists():
+        mlflow.log_artifact(str(plot_path))
+
+    from chap_core.assessment.evaluation import Evaluation
+
+    try:
+        evaluation = Evaluation.from_file(nc_path)
+        raw = calculate_metrics(evaluation, list(available_metrics.keys()))
+    except Exception:
+        logger.exception("Failed to compute metrics for MLflow tracking; skipping log_metrics")
+        return
+
+    numeric = {k: float(v) for k, v in raw.items() if isinstance(v, (int, float))}
+    if numeric:
+        mlflow.log_metrics(numeric)
+    skipped = sorted(set(raw) - set(numeric))
+    if skipped:
+        logger.info("Skipped non-numeric / inapplicable metrics: %s", ", ".join(skipped))
+
+
+def _short_name(value: str) -> str:
+    """Derive a short display name from a path, URL, or repo identifier."""
+    parsed = urlparse(value)
+    candidate = parsed.path if parsed.scheme else value
+    base = Path(candidate).name or candidate
+    return Path(base).stem or base
+
+
+def _maybe_file_sha256(dataset_csv: str) -> str | None:
+    parsed = urlparse(dataset_csv)
+    if parsed.scheme in {"http", "https", "s3", "gs"}:
+        return None
+    path = Path(dataset_csv)
+    if not path.is_file():
+        return None
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _chap_core_git_sha() -> str | None:
+    """Return the short SHA of the chap-core repo if chap-core is installed
+    from a git checkout, else None."""
+    try:
+        import git
+    except ImportError:
+        return None
+    pkg_dir = Path(chap_core.__file__).resolve().parent
+    try:
+        repo = git.Repo(pkg_dir, search_parent_directories=True)
+        return repo.head.commit.hexsha[:12]
+    except Exception:
+        return None

--- a/chap_core/assessment/eval_tracking.py
+++ b/chap_core/assessment/eval_tracking.py
@@ -1,9 +1,9 @@
 """MLflow tracking for the ``chap eval`` command.
 
-Tracking is opt-in via ``chap eval --track``. The MLflow tracking URI must be
-set explicitly via the ``MLFLOW_TRACKING_URI`` environment variable; this
-module never picks a default location, to avoid surprising the user with files
-written outside their workspace.
+Tracking is opt-in via ``chap eval --run-config.track``. The MLflow tracking
+URI must be set explicitly via the ``MLFLOW_TRACKING_URI`` environment
+variable; this module never picks a default location, to avoid surprising the
+user with files written outside their workspace.
 """
 
 from __future__ import annotations
@@ -32,7 +32,23 @@ DEFAULT_EXPERIMENT_NAME = "chap-backtests"
 
 
 class TrackingConfigError(RuntimeError):
-    """Raised when --track is requested but MLFLOW_TRACKING_URI is not set."""
+    """Raised when tracking is requested but MLFLOW_TRACKING_URI is not set."""
+
+
+def load_model_configuration(yaml_path: Path | None) -> dict | None:
+    """Load a model configuration YAML file into a plain dict, or return None.
+
+    Lives here (not in ``_common.py``) because the wrapper needs the dict for
+    MLflow param logging before the rest of the eval flow validates it through
+    :class:`ModelConfiguration`.
+    """
+    if yaml_path is None:
+        return None
+    import yaml
+
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f)
+    return data if isinstance(data, dict) else None
 
 
 class Tracker:
@@ -65,13 +81,16 @@ def tracked_eval_run(
     dataset_csv: str,
     backtest_params: BacktestParams,
     historical_context_years: int,
+    model_configuration: dict | None = None,
 ) -> Iterator[Tracker]:
     """Context manager that opens an MLflow run when ``track`` is True.
 
     When ``track`` is False this is a no-op. When True it requires
     ``MLFLOW_TRACKING_URI`` to be set, sets the experiment (honoring
     ``MLFLOW_EXPERIMENT_NAME`` if set, else ``"chap-backtests"``), and logs the
-    run-identifying params and tags before yielding.
+    run-identifying params and tags before yielding. The model configuration
+    dict, if provided, is flattened and logged as ``model.<key>`` params and
+    also stored verbatim as ``model_configuration.json``.
     """
     if not track:
         yield Tracker(enabled=False)
@@ -80,7 +99,7 @@ def tracked_eval_run(
     tracking_uri = os.environ.get("MLFLOW_TRACKING_URI")
     if not tracking_uri:
         raise TrackingConfigError(
-            "chap eval --track requires MLFLOW_TRACKING_URI to be set "
+            "chap eval --run-config.track requires MLFLOW_TRACKING_URI to be set "
             "(e.g. export MLFLOW_TRACKING_URI=file://$HOME/chap-evaluations/mlruns)"
         )
 
@@ -102,7 +121,12 @@ def tracked_eval_run(
         sha = _maybe_file_sha256(dataset_csv)
         if sha is not None:
             params["dataset_sha256"] = sha
+        if model_configuration:
+            params.update(_flatten_params(model_configuration, prefix="model"))
         mlflow.log_params(params)
+
+        if model_configuration:
+            mlflow.log_dict(model_configuration, "model_configuration.json")
 
         tags: dict[str, str] = {
             "dataset.name": _short_name(dataset_csv),
@@ -140,6 +164,24 @@ def _log_outputs_from_files(nc_path: Path, plot_path: Path | None) -> None:
     skipped = sorted(set(raw) - set(numeric))
     if skipped:
         logger.info("Skipped non-numeric / inapplicable metrics: %s", ", ".join(skipped))
+
+
+def _flatten_params(d: dict, prefix: str) -> dict[str, object]:
+    """Flatten a nested dict into ``prefix.key`` entries for MLflow params.
+
+    Scalars are passed through; non-scalar leaves (lists, etc.) are stringified
+    so MLflow can store them. Use the full JSON artifact for fidelity.
+    """
+    out: dict[str, object] = {}
+    for k, v in d.items():
+        key = f"{prefix}.{k}"
+        if isinstance(v, dict):
+            out.update(_flatten_params(v, prefix=key))
+        elif isinstance(v, (str, int, float, bool)) or v is None:
+            out[key] = v
+        else:
+            out[key] = str(v)
+    return out
 
 
 def _short_name(value: str) -> str:

--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -45,6 +45,68 @@ def eval_cmd(
     model_configuration_yaml: ModelConfigYamlArg = None,
     historical_context_years: Annotated[
         int,
+        Parameter(help="Years of historical data to include for plotting context."),
+    ] = 6,
+    data_source_mapping: DataSourceMappingArg = None,
+    dry_run: Annotated[bool, Parameter(help="Write inputs and print commands without executing.")] = False,
+    plot: Annotated[bool, Parameter(help="Generate an HTML evaluation plot alongside the NetCDF.")] = False,
+    estimator_options: Annotated[
+        EstimatorOptions | None,
+        Parameter(help="Estimator behavior (normal | hpo | ensemble), optional metric."),
+    ] = None,
+    track: Annotated[
+        bool,
+        Parameter(
+            help="Record this run to MLflow: params, metrics, NetCDF + plot artifacts. Requires MLFLOW_TRACKING_URI."
+        ),
+    ] = False,
+):
+    """Evaluate a model using backtesting and export results to NetCDF format.
+
+    Thin wrapper around :func:`_run_eval` that optionally records the run to
+    MLflow when ``--track`` is set. See :func:`_run_eval` for the detailed
+    backtest workflow.
+    """
+    from chap_core.assessment.eval_tracking import tracked_eval_run
+
+    with tracked_eval_run(
+        track=track,
+        model_name=model_name,
+        dataset_csv=str(dataset_csv),
+        backtest_params=backtest_params,
+        historical_context_years=historical_context_years,
+    ) as tracker:
+        _run_eval(
+            model_name=model_name,
+            dataset_csv=dataset_csv,
+            output_file=output_file,
+            backtest_params=backtest_params,
+            run_config=run_config,
+            model_configuration_yaml=model_configuration_yaml,
+            historical_context_years=historical_context_years,
+            data_source_mapping=data_source_mapping,
+            dry_run=dry_run,
+            plot=plot,
+            estimator_options=estimator_options,
+        )
+        tracker.log_outputs_from_files(
+            output_file,
+            plot_path=output_file.with_suffix(".html") if plot else None,
+        )
+
+
+def _run_eval(
+    model_name: ModelNameArg,
+    dataset_csv: DatasetCsvArg,
+    output_file: Annotated[
+        Path,
+        Parameter(help="Path for output NetCDF file containing evaluation results (.nc extension)"),
+    ],
+    backtest_params: BacktestParamsArg = BacktestParams(n_periods=3, n_splits=7, stride=1),
+    run_config: RunConfigArg = RunConfig(),
+    model_configuration_yaml: ModelConfigYamlArg = None,
+    historical_context_years: Annotated[
+        int,
         Parameter(
             help="Years of historical data to include for plotting context. "
             "Calculated as periods based on dataset frequency (e.g., 6 years = 312 weeks or 72 months)"

--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -54,27 +54,24 @@ def eval_cmd(
         EstimatorOptions | None,
         Parameter(help="Estimator behavior (normal | hpo | ensemble), optional metric."),
     ] = None,
-    track: Annotated[
-        bool,
-        Parameter(
-            help="Record this run to MLflow: params, metrics, NetCDF + plot artifacts. Requires MLFLOW_TRACKING_URI."
-        ),
-    ] = False,
 ):
     """Evaluate a model using backtesting and export results to NetCDF format.
 
     Thin wrapper around :func:`_run_eval` that optionally records the run to
-    MLflow when ``--track`` is set. See :func:`_run_eval` for the detailed
-    backtest workflow.
+    MLflow when ``run_config.track`` is True. See :func:`_run_eval` for the
+    detailed backtest workflow.
     """
-    from chap_core.assessment.eval_tracking import tracked_eval_run
+    from chap_core.assessment.eval_tracking import load_model_configuration, tracked_eval_run
+
+    model_configuration = load_model_configuration(model_configuration_yaml)
 
     with tracked_eval_run(
-        track=track,
+        track=run_config.track,
         model_name=model_name,
         dataset_csv=str(dataset_csv),
         backtest_params=backtest_params,
         historical_context_years=historical_context_years,
+        model_configuration=model_configuration,
     ) as tracker:
         _run_eval(
             model_name=model_name,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -191,6 +191,84 @@ def test_eval_cmd_does_not_wrap_when_bounds_unspecified(tmp_path):
     assert forwarded is fake_estimator
 
 
+def test_eval_cmd_track_logs_params_metrics_and_artifacts(tmp_path, monkeypatch):
+    """With --track, params, metrics, and the .nc artifact end up in MLflow."""
+    from pathlib import Path
+
+    import mlflow
+    from chap_core.api_types import BacktestParams, RunConfig
+
+    tracking_dir = tmp_path / "mlruns"
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", f"file://{tracking_dir}")
+    mlflow.set_tracking_uri(f"file://{tracking_dir}")
+
+    output_file = tmp_path / "out.nc"
+
+    def _write_nc(filepath, **_kwargs):
+        Path(filepath).write_bytes(b"netcdf-placeholder")
+
+    fake_estimator = _make_fake_estimator(min_prediction_length=None, max_prediction_length=None)
+    stack, eval_mock = _patched_eval_chain(fake_estimator)
+    eval_instance = MagicMock(name="EvaluationInstance")
+    eval_instance.to_file.side_effect = _write_nc
+    eval_mock.create.return_value = eval_instance
+
+    metrics_stub = patch(
+        "chap_core.assessment.eval_tracking.calculate_metrics",
+        return_value={"mae": 1.23, "rmse": 4.56, "non_numeric": None},
+    )
+
+    with stack, metrics_stub:
+        eval_cmd(
+            model_name="dummy-model",
+            dataset_csv="dummy.csv",
+            output_file=output_file,
+            backtest_params=BacktestParams(n_periods=3, n_splits=2, stride=1),
+            run_config=RunConfig(),
+            track=True,
+        )
+
+    runs = mlflow.search_runs(experiment_names=["chap-backtests"], output_format="list")
+    assert len(runs) == 1
+    run = runs[0]
+
+    assert run.data.params["model_name"] == "dummy-model"
+    assert run.data.params["dataset_csv"] == "dummy.csv"
+    assert run.data.params["n_periods"] == "3"
+    assert run.data.params["n_splits"] == "2"
+    assert run.data.params["stride"] == "1"
+    assert run.data.params["prediction_length"] == "3"
+
+    assert run.data.metrics["mae"] == 1.23
+    assert run.data.metrics["rmse"] == 4.56
+    assert "non_numeric" not in run.data.metrics
+
+    client = mlflow.MlflowClient(tracking_uri=f"file://{tracking_dir}")
+    artifacts = {a.path for a in client.list_artifacts(run.info.run_id)}  # type: ignore[union-attr]
+    assert "out.nc" in artifacts
+
+
+def test_eval_cmd_track_without_tracking_uri_raises(tmp_path, monkeypatch):
+    """--track without MLFLOW_TRACKING_URI raises before any heavy work."""
+    from chap_core.api_types import BacktestParams, RunConfig
+    from chap_core.assessment.eval_tracking import TrackingConfigError
+
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+
+    fake_estimator = _make_fake_estimator(min_prediction_length=None, max_prediction_length=None)
+    stack, _ = _patched_eval_chain(fake_estimator)
+
+    with stack, pytest.raises(TrackingConfigError, match="MLFLOW_TRACKING_URI"):
+        eval_cmd(
+            model_name="dummy",
+            dataset_csv="dummy.csv",
+            output_file=tmp_path / "out.nc",
+            backtest_params=BacktestParams(n_periods=3, n_splits=2, stride=1),
+            run_config=RunConfig(),
+            track=True,
+        )
+
+
 def test_eval_cmd_with_data_source_mapping(tmp_path):
     import json
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,10 +192,11 @@ def test_eval_cmd_does_not_wrap_when_bounds_unspecified(tmp_path):
 
 
 def test_eval_cmd_track_logs_params_metrics_and_artifacts(tmp_path, monkeypatch):
-    """With --track, params, metrics, and the .nc artifact end up in MLflow."""
+    """With run_config.track, params (incl. model config), metrics, and the .nc artifact end up in MLflow."""
     from pathlib import Path
 
     import mlflow
+    import yaml
     from chap_core.api_types import BacktestParams, RunConfig
 
     tracking_dir = tmp_path / "mlruns"
@@ -203,6 +204,11 @@ def test_eval_cmd_track_logs_params_metrics_and_artifacts(tmp_path, monkeypatch)
     mlflow.set_tracking_uri(f"file://{tracking_dir}")
 
     output_file = tmp_path / "out.nc"
+
+    model_config_yaml = tmp_path / "model_config.yaml"
+    model_config_yaml.write_text(
+        yaml.safe_dump({"learning_rate": 0.01, "n_estimators": 100, "optimizer": {"name": "adam", "momentum": 0.9}})
+    )
 
     def _write_nc(filepath, **_kwargs):
         Path(filepath).write_bytes(b"netcdf-placeholder")
@@ -224,8 +230,8 @@ def test_eval_cmd_track_logs_params_metrics_and_artifacts(tmp_path, monkeypatch)
             dataset_csv="dummy.csv",
             output_file=output_file,
             backtest_params=BacktestParams(n_periods=3, n_splits=2, stride=1),
-            run_config=RunConfig(),
-            track=True,
+            run_config=RunConfig(track=True),
+            model_configuration_yaml=model_config_yaml,
         )
 
     runs = mlflow.search_runs(experiment_names=["chap-backtests"], output_format="list")
@@ -239,6 +245,11 @@ def test_eval_cmd_track_logs_params_metrics_and_artifacts(tmp_path, monkeypatch)
     assert run.data.params["stride"] == "1"
     assert run.data.params["prediction_length"] == "3"
 
+    assert run.data.params["model.learning_rate"] == "0.01"
+    assert run.data.params["model.n_estimators"] == "100"
+    assert run.data.params["model.optimizer.name"] == "adam"
+    assert run.data.params["model.optimizer.momentum"] == "0.9"
+
     assert run.data.metrics["mae"] == 1.23
     assert run.data.metrics["rmse"] == 4.56
     assert "non_numeric" not in run.data.metrics
@@ -246,10 +257,11 @@ def test_eval_cmd_track_logs_params_metrics_and_artifacts(tmp_path, monkeypatch)
     client = mlflow.MlflowClient(tracking_uri=f"file://{tracking_dir}")
     artifacts = {a.path for a in client.list_artifacts(run.info.run_id)}  # type: ignore[union-attr]
     assert "out.nc" in artifacts
+    assert "model_configuration.json" in artifacts
 
 
 def test_eval_cmd_track_without_tracking_uri_raises(tmp_path, monkeypatch):
-    """--track without MLFLOW_TRACKING_URI raises before any heavy work."""
+    """run_config.track=True without MLFLOW_TRACKING_URI raises before any heavy work."""
     from chap_core.api_types import BacktestParams, RunConfig
     from chap_core.assessment.eval_tracking import TrackingConfigError
 
@@ -264,8 +276,7 @@ def test_eval_cmd_track_without_tracking_uri_raises(tmp_path, monkeypatch):
             dataset_csv="dummy.csv",
             output_file=tmp_path / "out.nc",
             backtest_params=BacktestParams(n_periods=3, n_splits=2, stride=1),
-            run_config=RunConfig(),
-            track=True,
+            run_config=RunConfig(track=True),
         )
 
 


### PR DESCRIPTION
## Summary
- Adds an opt-in `--track` flag to `chap eval` that records the run to MLflow (params, tags, numeric metrics, and artifacts) under the `chap-backtests` experiment.
- Logs all numeric metrics from the existing metric registry (via `calculate_metrics`), the NetCDF output, the optional HTML plot, and a `model_run_config.json` artifact capturing the model configuration + `prediction_length` actually used.
- Requires `MLFLOW_TRACKING_URI` to be set so runs always land in a location the user picked explicitly; raises `TrackingConfigError` with a clear hint otherwise.
- No new dependency: `mlflow-skinny` is already a hard dep, which provides the full client API.

## Usage
```bash
export MLFLOW_TRACKING_URI=file://$HOME/chap-evaluations/mlruns
chap eval --model-name <model> --dataset-csv <csv> --output-file out.nc --track --plot
```

## Test plan
- [x] `uv run pytest tests/test_cli.py::test_eval_cmd_track_logs_params_metrics_and_artifacts tests/test_cli.py::test_eval_cmd_track_without_tracking_uri_raises`
- [x] `make lint` clean
- [x] `make test` passes (failures only in untracked local draft docs unrelated to this change)
- [ ] Manual: run `chap eval --track` on a real dataset with `MLFLOW_TRACKING_URI` set, then `mlflow ui` to confirm the run shows params + metrics + artifacts as expected