### PR TITLE
fix: return the actual entity from /prediction_result and /evaluation_result

### DIFF
--- a/chap_core/rest_api/v1/jobs.py
+++ b/chap_core/rest_api/v1/jobs.py
@@ -1,14 +1,15 @@
 import logging
 from typing import Any, cast
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from sqlmodel import Session
 
-from chap_core.api_types import EvaluationResponse
+from chap_core.database.tables import Backtest, BacktestRead, Prediction, PredictionInfo
 from chap_core.log_config import initialize_logging
 from chap_core.rest_api.celery_tasks import CeleryPool, JobDescription, get_job_meta
 from chap_core.rest_api.celery_tasks import r as redis
-from chap_core.rest_api.data_models import FullPredictionResponse
+from chap_core.rest_api.v1.routers.dependencies import get_session
 
 initialize_logging()
 logger = logging.getLogger(__name__)
@@ -122,14 +123,28 @@ def get_logs(job_id: str) -> str:
     return logs
 
 
-@router.get("/{job_id}/prediction_result")
-def get_prediction_result(job_id: str) -> FullPredictionResponse:
-    return cast("FullPredictionResponse", _get_successful_job(job_id).result)
+@router.get("/{job_id}/prediction_result", response_model=PredictionInfo)
+def get_prediction_result(
+    job_id: str,
+    session: Session = Depends(get_session),
+):
+    prediction_id = _get_successful_job(job_id).result
+    prediction = session.get(Prediction, prediction_id)
+    if prediction is None:
+        raise HTTPException(status_code=404, detail=f"Prediction {prediction_id} not found")
+    return prediction
 
 
-@router.get("/{job_id}/evaluation_result")
-def get_evaluation_result(job_id: str) -> EvaluationResponse:
-    return cast("EvaluationResponse", _get_successful_job(job_id).result)
+@router.get("/{job_id}/evaluation_result", response_model=BacktestRead)
+def get_evaluation_result(
+    job_id: str,
+    session: Session = Depends(get_session),
+):
+    backtest_id = _get_successful_job(job_id).result
+    backtest = session.get(Backtest, backtest_id)
+    if backtest is None:
+        raise HTTPException(status_code=404, detail=f"Backtest {backtest_id} not found")
+    return backtest
 
 
 class DataBaseResponse(BaseModel):

--- a/tests/integration/rest_api/test_jobs_routes.py
+++ b/tests/integration/rest_api/test_jobs_routes.py
@@ -80,3 +80,53 @@ def test_get_logs_unknown_id_returns_404(unknown_job_id):
 def test_result_endpoints_unknown_id_return_404(unknown_job_id, suffix):
     response = client.get(f"{base_path}/{unknown_job_id}/{suffix}")
     assert response.status_code == 404, response.text
+
+
+class _FakeJob:
+    def __init__(self, result):
+        self.result = result
+        self.status = "SUCCESS"
+        self.is_finished = True
+
+
+def _stub_successful_job(monkeypatch, result: int, job_id: str = "job-1"):
+    """Make `/result` endpoints see job_id as an existing, successful job returning `result`."""
+    from chap_core.rest_api.v1 import jobs as jobs_module
+
+    monkeypatch.setattr(jobs_module, "get_job_meta", lambda _job_id: {"status": "success"})
+    monkeypatch.setattr(jobs_module.worker, "get_job", lambda _job_id: _FakeJob(result))
+    return job_id
+
+
+def test_prediction_result_returns_prediction(monkeypatch, override_session):
+    job_id = _stub_successful_job(monkeypatch, result=1)
+    response = client.get(f"{base_path}/{job_id}/prediction_result")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == 1
+    assert body["modelId"] == "naive_model"
+    assert body["nPeriods"] == 3
+    assert body["name"] == "test prediction"
+
+
+def test_evaluation_result_returns_backtest(monkeypatch, override_session):
+    job_id = _stub_successful_job(monkeypatch, result=1)
+    response = client.get(f"{base_path}/{job_id}/evaluation_result")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["id"] == 1
+    assert body["modelId"] == "naive_model"
+    assert body["name"] == "test backtest"
+    assert body["aggregateMetrics"] == {"MAE": 1.5}
+
+
+def test_prediction_result_missing_row_returns_404(monkeypatch, override_session):
+    job_id = _stub_successful_job(monkeypatch, result=999999)
+    response = client.get(f"{base_path}/{job_id}/prediction_result")
+    assert response.status_code == 404, response.text
+
+
+def test_evaluation_result_missing_row_returns_404(monkeypatch, override_session):
+    job_id = _stub_successful_job(monkeypatch, result=999999)
+    response = client.get(f"{base_path}/{job_id}/evaluation_result")
+    assert response.status_code == 404, response.text


### PR DESCRIPTION
## Summary
- `/v1/jobs/{job_id}/prediction_result` and `/v1/jobs/{job_id}/evaluation_result` declared rich response models (`FullPredictionResponse`, `EvaluationResponse`) and used `typing.cast` to keep the type checker happy, but the worker functions (`run_prediction`, `run_backtest`, `predict_pipeline_from_composite_dataset`) all return an `int` (the DB row id). FastAPI's runtime response-model validation rejected the int with a 500 `model_attributes_type` error, so both endpoints were unusable for any real job.
- Look up the row from the returned id and return the existing read model: `PredictionInfo` (mirrors `GET /v1/crud/predictions/{id}`) and `BacktestRead` (mirrors `GET /v1/crud/backtests/{id}`). 404 when the id no longer resolves.
- `/database_result` is unchanged.

## Why now
Hit this after running a prediction via the new `/v1/crud/prediction-setups/{id}/run` flow: job succeeded, `/prediction_result` returned 500. Pre-existing on master (the `cast` dates back to the type-error-cleanup PR #172). Same bug on `/evaluation_result`, so fixing both keeps the trio (`/database_result`, `/prediction_result`, `/evaluation_result`) symmetric.

## Test plan
- [x] `make lint`
- [x] `make test` (834 passed)
- [x] New tests in `tests/integration/rest_api/test_jobs_routes.py` cover happy path + missing-row 404 for both endpoints, exercising the `override_session` fixture from `conftest.py` and a stubbed worker.
- [x] Existing parametrized 404 test for unknown job ids still passes for all three result endpoints.