### PR TITLE
ci: rename workflow jobs to unique IDs

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master, dev ]
 
 jobs:
-  build:
+  docs:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -14,7 +14,7 @@ permissions:
   packages: read
 
 jobs:
-  build:
+  test-all:
     env:
       REDIS_HOST: redis
 

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
Three workflows define `jobs.build:`, so they all surface a status check named `build (ubuntu-latest, 3.13)` in PRs. That collision makes it impossible to write an unambiguous `required_status_checks` ruleset rule (any one of the three workflows would satisfy the gate). Rename each so each check name has a single owner:

- `ci-test-python-install.yml`: `build` → `test`
- `ci-build-docs.yml`: `build` → `docs`
- `ci-test-external-models.yml`: `build` → `test-all`

The lint workflow already uses a unique `check` id; left alone. No `needs:` cross-references between renamed jobs, so this is a local rename.

After this lands the checks on every PR will be:
- `check`
- `test (ubuntu-latest, 3.13)`, `test (macos-latest, 3.13)`, `test (windows-latest, 3.13)`
- `docs (ubuntu-latest, 3.13)`
- `test-all (ubuntu-latest, 3.13)`

After this lands, the master ruleset can be tightened with a `required_status_checks` rule against a subset of these names. That change lives in GitHub repo settings (Settings → Rules → Rulesets → "Default branch rules") or via `gh api -X PUT repos/dhis2-chap/chap-core/rulesets/16225427` — not a code PR.

## Test plan
- [ ] All four workflows succeed on this PR.
- [ ] Checks tab shows the new names; the old `build (…)` name no longer appears.