### PR TITLE
feat: add /actual-cases alias for /actualCases analytics endpoint [CLIM-727]

### DIFF
--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -453,6 +453,7 @@ def get_prediction_entries(
     ]
 
 
+@router.get("/actual-cases/{backtestId}", response_model=DataList, tags=["Backtests"], name="get_actual_cases_alias")
 @router.get("/actualCases/{backtestId}", response_model=DataList, tags=["Backtests"])
 async def get_actual_cases(
     backtest_id: Annotated[int, Path(alias="backtestId")],

--- a/tests/integration/rest_api/test_from_seeded_engine.py
+++ b/tests/integration/rest_api/test_from_seeded_engine.py
@@ -53,6 +53,11 @@ def test_actual_cases_dataset(override_session):
     assert len(actual_cases) >= 3
 
 
+def test_actual_cases_alias(override_session):
+    actual_cases = client.get_json("/v1/analytics/actual-cases/1")
+    assert len(actual_cases) >= 3
+
+
 def test_get_prediction_entries(override_session):
     params = {"predictionId": 1, "quantiles": [0.0, 0.5, 0.9]}
     prediction_entries = client.get_json("/v1/analytics/prediction-entry", params=params)


### PR DESCRIPTION
## Summary
- Adds `/v1/analytics/actual-cases/{backtestId}` as an alias for the existing `/v1/analytics/actualCases/{backtestId}` endpoint so callers can use the kebab-case path that matches the rest of the analytics router.
- The original camelCase path is kept for backwards compatibility.

## Test plan
- [x] `make lint`
- [x] `make test`
- [x] New `test_actual_cases_alias` integration test verifies the alias path returns the same data.