### PR TITLE
refactor: drop no-op response_model_by_alias / router_get magic in v1 routers [CLIM-720]

### DIFF
--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -10,14 +10,14 @@ Get endpoints will return a single object with full data
 We try to make the returned objects look as much as possible like the objects in the database
 This is achieved by subclassing common basemodels in the read objects and database table objects
 
-Magic is used to make the returned objects camelCase while internal objects are snake_case
+Returned objects come out camelCase while internal objects stay snake_case because DBModel sets
+alias_generator=to_camel and FastAPI's response_model_by_alias defaults to True.
 
 """
 
 import datetime
 import json
 import logging
-from functools import partial
 from typing import Annotated, Any
 
 import numpy as np
@@ -242,7 +242,6 @@ def _sync_chapkit_configured_models(
 
 router = APIRouter(prefix="/crud")
 
-router_get = partial(router.get, response_model_by_alias=True)  # MAGIC!: This makes the endpoints return camelCase
 worker: CeleryPool[Any] = CeleryPool()
 
 
@@ -264,7 +263,7 @@ async def get_backtests(session: Session = Depends(get_session)):
     return backtests
 
 
-@router_get("/backtests/{backtestId}/full", response_model=Backtest, tags=["Backtests"])
+@router.get("/backtests/{backtestId}/full", response_model=Backtest, tags=["Backtests"])
 async def get_backtest(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
@@ -272,8 +271,8 @@ async def get_backtest(backtest_id: Annotated[int, Path(alias="backtestId")], se
     return backtest
 
 
-@router_get("/backtests/{backtestId}/info", response_model=BacktestRead, tags=["Backtests"])
-@router_get("/backtests/{backtestId}", response_model=BacktestRead, tags=["Backtests"])
+@router.get("/backtests/{backtestId}/info", response_model=BacktestRead, tags=["Backtests"])
+@router.get("/backtests/{backtestId}", response_model=BacktestRead, tags=["Backtests"])
 def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
     backtest = session.exec(
         select(Backtest)
@@ -598,7 +597,7 @@ def list_configured_models(session: Session = Depends(get_session)):
     return configured_models_read
 
 
-@router_get(
+@router.get(
     "/configured-models/{configuredModelId}",
     response_model=ConfiguredModelInfoRead,
     tags=["Models"],
@@ -666,7 +665,6 @@ async def delete_configured_model(
 @router.get(
     "/configured-models-with-data-source",
     response_model=list[ConfiguredModelWithDataSourceRead],
-    response_model_by_alias=True,
     tags=["Models"],
 )
 @api_experimental
@@ -682,7 +680,6 @@ async def list_configured_models_with_data_source(session: Session = Depends(get
 @router.get(
     "/configured-models-with-data-source/{configuredModelWithDataSourceId}",
     response_model=ConfiguredModelWithDataSourceReadWithPredictions,
-    response_model_by_alias=True,
     tags=["Models"],
 )
 @api_experimental
@@ -711,7 +708,6 @@ async def get_configured_model_with_data_source(
 @router.post(
     "/configured-models-with-data-source/from-backtest/{backtestId}",
     response_model=ConfiguredModelWithDataSourceRead,
-    response_model_by_alias=True,
     tags=["Models"],
 )
 @api_experimental

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from functools import partial
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session
@@ -26,8 +25,6 @@ from chap_core.rest_api.v1.routers.dependencies import get_session
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/visualization", tags=["Visualizations"])
-
-router_get = partial(router.get, response_model_by_alias=True)  # MAGIC!: This makes the endpoints return camelCase
 
 
 # List visualizations


### PR DESCRIPTION
## Summary

\`response_model_by_alias\` defaults to \`True\` in FastAPI's route decorators (\`router.get\`, \`router.post\`, \`add_api_route\`), so every place in the v1 routers that set this kwarg or wrapped \`router.get\` with a \`partial\` was a **no-op**. Verified on FastAPI 0.135.3 (the pinned version) and confirmed against current \`master\` of \`fastapi/fastapi\`. The default has been \`True\` for a long time — see [discussion #2753](https://github.com/fastapi/fastapi/discussions/2753) and the [APIRouter reference](https://fastapi.tiangolo.com/reference/apirouter/) (\`DEFAULT: True\`).

CamelCase responses come from \`DBModel\` setting \`alias_generator=to_camel\` combined with FastAPI's existing default — **not** from the \`router_get = partial(router.get, response_model_by_alias=True)\` wrapper.

## Changes

- \`visualization.py\`: removed \`router_get = partial(...)\`. The partial was defined but never used here — every endpoint already used \`@router.get(...)\`.
- \`crud.py\`:
  - Removed \`router_get = partial(...)\` and rewrote 4 \`@router_get(...)\` decorators to plain \`@router.get(...)\`.
  - Removed inline \`response_model_by_alias=True\` from 3 endpoints (\`configured-models-with-data-source\` GETs and POST).
  - Removed the now-unused \`from functools import partial\` import.
  - Updated the module docstring: replaced the misleading \"Magic is used to make the returned objects camelCase\" line with the actual mechanism (\`DBModel.alias_generator\` + FastAPI default).

## Why FastAPI can't do this at the router level

FastAPI does **not** expose \`response_model_by_alias\` on \`APIRouter(...)\` or \`include_router(...)\` in any released version, and feature request [PR #2187](https://github.com/fastapi/fastapi/pull/2187) has been open since 2020 with no path to merge. But since \`True\` is already the default, no router-level setting is needed — the right move is to delete.

## Verification

OpenAPI schemas generated from \`chap_core.rest_api.app.app\` on \`master\` and on this branch are **byte-identical** after both commits:

\`\`\`
MD5 (master) = 8f3fddd467990b2fb2eefc4a064aa897
MD5 (branch) = 8f3fddd467990b2fb2eefc4a064aa897
6622 lines each, 52 paths each, diff exit 0
\`\`\`

So no endpoint changes its request shape, response shape, alias behavior, or schema. This is purely dead-code removal.

## Test plan
- [x] \`make lint\` passes
- [x] OpenAPI schema byte-identical to master