### PR TITLE
fix: copy chap report output from runs directory to --out-file path

### DIFF
--- a/chap_core/models/external_model.py
+++ b/chap_core/models/external_model.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 from pathlib import Path
 
 import pandas as pd
@@ -320,15 +321,22 @@ class ExternalModel(ExternalModelBase):
         adapted = self._adapt_data(historic_data.to_pandas(), frequency=self._get_frequency(historic_data))
         adapted.to_csv(historic_data_name)
 
+        out_file = Path(out_file)
+        # The model command runs with cwd=working_dir, so pass a relative
+        # filename and copy the produced file back to the user-supplied path.
+        report_filename = out_file.name
+
         try:
             self._runner.report(
                 self._model_file_name,
                 "report_historic_data.csv",
-                str(out_file),
+                report_filename,
                 "polygons.geojson" if self._polygons_file_name is not None else None,
             )
         except CommandLineException as e:
             logger.error("Error generating report, command failed")
             raise ModelFailedException(str(e)) from e
+
+        shutil.copyfile(Path(self._working_dir) / report_filename, out_file)
 
         self._runner.teardown()

--- a/tests/external/test_external_models.py
+++ b/tests/external/test_external_models.py
@@ -105,14 +105,23 @@ def _report_model_template_config(with_report: bool) -> ModelTemplateConfigV2:
 
 
 def test_external_model_report_invokes_runner(weekly_full_data, tmp_path):
+    working_dir = tmp_path / "workdir"
+    working_dir.mkdir()
+    out_file = tmp_path / "report.pdf"
+
+    def _fake_report(model, historic, out_filename, polygons):
+        # The model command runs with cwd=working_dir, so it writes the report
+        # there using the relative filename it was given.
+        (working_dir / out_filename).write_bytes(b"%PDF-fake")
+
     runner = Mock()
+    runner.report.side_effect = _fake_report
     model = ExternalModel(
         runner=runner,
         name="test_report_model",
-        working_dir=str(tmp_path),
+        working_dir=str(working_dir),
         model_information=_report_model_template_config(with_report=True),
     )
-    out_file = tmp_path / "report.pdf"
 
     model.report(weekly_full_data, out_file)
 
@@ -120,8 +129,12 @@ def test_external_model_report_invokes_runner(weekly_full_data, tmp_path):
     args, _ = runner.report.call_args
     assert args[0] == "model"
     assert args[1] == "report_historic_data.csv"
-    assert args[2] == str(out_file)
-    assert (tmp_path / "report_historic_data.csv").exists()
+    # The runner is given a relative filename, not the user's full out path,
+    # because the model command runs in working_dir.
+    assert args[2] == "report.pdf"
+    assert (working_dir / "report_historic_data.csv").exists()
+    # The generated file is copied from working_dir to the user-supplied path.
+    assert out_file.read_bytes() == b"%PDF-fake"
 
 
 def test_external_model_report_without_entry_point_raises(weekly_full_data, tmp_path):


### PR DESCRIPTION
## Summary
- The model command in `ExternalModel.report` runs with `cwd` set to the runs/working directory, so passing the user-supplied `--out-file` straight through caused relative paths to be written inside the runs directory rather than where the user asked.
- Pass a relative basename to the runner and copy the produced file back to the user-supplied `out_file` after the model command completes.

## Test plan
- [x] `uv run pytest tests/external/test_external_models.py tests/test_report_cli.py tests/runners/test_runners.py`
- [x] Full suite: `uv run pytest -q` (882 passed)
- [x] `make lint`