### PR TITLE
docs(api): add summary and description to every exposed FastAPI route

### DIFF
--- a/chap_core/rest_api/app.py
+++ b/chap_core/rest_api/app.py
@@ -28,16 +28,47 @@ openapi_tags = [
 ]
 
 
-api_description = (
-    "Chap is a Climate & Health Modeling Platform that brings together disease "
-    "forecasting models into a unified ecosystem, connecting researchers with "
-    "cutting-edge epidemiological models to policy makers and health practitioners.\n\n"
-    "The platform makes sophisticated modeling workflows more accessible, performs "
-    "automated rigorous model evaluation, supplies broad generic functionality for "
-    "modelers, and provides direct integration with DHIS2.\n\n"
-    "See [chap.dhis2.org](https://chap.dhis2.org/chap-modeling-platform/) for the "
-    "full documentation."
-)
+api_description = """\
+**Chap** is a Climate & Health Modeling Platform that brings together
+disease forecasting models into a unified ecosystem, connecting researchers
+with cutting-edge epidemiological models to policy makers and health
+practitioners.
+
+## What it does
+
+- Makes sophisticated modeling workflows more accessible.
+- Performs automated, rigorous model evaluation.
+- Supplies broad generic functionality for modelers.
+- Provides direct integration with [DHIS2](https://dhis2.org).
+
+## Concepts
+
+- **Datasets** — observation series (disease cases, climate covariates,
+  population) attached to org-unit polygons. Imported once, reused.
+- **Model templates** are the registered model implementations. A
+  **configured model** binds a template to a specific set of options
+  (lags, precision, covariates, ...).
+- **Backtests** evaluate a configured model on historical data and produce
+  scored forecasts you can plot, export, and compare.
+- **Predictions** are forecasts of future periods produced by a configured
+  model, queryable as quantile series.
+- **Prediction setups** promote a backtest into a reusable forecast config —
+  run it ad-hoc against fresh data, or on a cron schedule.
+
+## Asynchronous work
+
+`POST` endpoints that train, score, or import (most of `/v1/analytics/*`,
+`POST /v1/crud/backtests`, `POST /v1/crud/datasets`,
+`POST /v1/crud/prediction-setups/{id}/run`) return a `JobResponse` with an
+id. Poll `GET /v1/jobs/{id}` for status; once it finishes, fetch the
+produced row directly via `GET /v1/jobs/{id}/prediction_result`,
+`/evaluation_result`, or `/database_result`.
+
+## Further reading
+
+- [Platform documentation](https://chap.dhis2.org/chap-modeling-platform/)
+- Contact: <chap@dhis2.org>
+"""
 
 
 app = FastAPI(

--- a/chap_core/rest_api/app.py
+++ b/chap_core/rest_api/app.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
 
+from chap_core import __version__ as chap_core_version
 from chap_core.rest_api.common_routes import router as common_router
 from chap_core.rest_api.v1.rest_api import router as v1_router
 from chap_core.rest_api.v2.rest_api import router as v2_router
@@ -29,6 +30,7 @@ openapi_tags = [
 
 app = FastAPI(
     title="CHAP Core API",
+    version=chap_core_version,
     openapi_tags=openapi_tags,
     root_path=os.environ.get("CHAP_ROOT_PATH", ""),
 )

--- a/chap_core/rest_api/app.py
+++ b/chap_core/rest_api/app.py
@@ -28,8 +28,21 @@ openapi_tags = [
 ]
 
 
+api_description = (
+    "Chap is a Climate & Health Modeling Platform that brings together disease "
+    "forecasting models into a unified ecosystem, connecting researchers with "
+    "cutting-edge epidemiological models to policy makers and health practitioners.\n\n"
+    "The platform makes sophisticated modeling workflows more accessible, performs "
+    "automated rigorous model evaluation, supplies broad generic functionality for "
+    "modelers, and provides direct integration with DHIS2.\n\n"
+    "See [chap.dhis2.org](https://chap.dhis2.org/chap-modeling-platform/) for the "
+    "full documentation."
+)
+
+
 app = FastAPI(
     title="CHAP Core API",
+    description=api_description,
     version=chap_core_version,
     openapi_tags=openapi_tags,
     root_path=os.environ.get("CHAP_ROOT_PATH", ""),

--- a/chap_core/rest_api/app.py
+++ b/chap_core/rest_api/app.py
@@ -28,47 +28,12 @@ openapi_tags = [
 ]
 
 
-api_description = """\
-**Chap** is a Climate & Health Modeling Platform that brings together
-disease forecasting models into a unified ecosystem, connecting researchers
-with cutting-edge epidemiological models to policy makers and health
-practitioners.
-
-## What it does
-
-- Makes sophisticated modeling workflows more accessible.
-- Performs automated, rigorous model evaluation.
-- Supplies broad generic functionality for modelers.
-- Provides direct integration with [DHIS2](https://dhis2.org).
-
-## Concepts
-
-- **Datasets** — observation series (disease cases, climate covariates,
-  population) attached to org-unit polygons. Imported once, reused.
-- **Model templates** are the registered model implementations. A
-  **configured model** binds a template to a specific set of options
-  (lags, precision, covariates, ...).
-- **Backtests** evaluate a configured model on historical data and produce
-  scored forecasts you can plot, export, and compare.
-- **Predictions** are forecasts of future periods produced by a configured
-  model, queryable as quantile series.
-- **Prediction setups** promote a backtest into a reusable forecast config —
-  run it ad-hoc against fresh data, or on a cron schedule.
-
-## Asynchronous work
-
-`POST` endpoints that train, score, or import (most of `/v1/analytics/*`,
-`POST /v1/crud/backtests`, `POST /v1/crud/datasets`,
-`POST /v1/crud/prediction-setups/{id}/run`) return a `JobResponse` with an
-id. Poll `GET /v1/jobs/{id}` for status; once it finishes, fetch the
-produced row directly via `GET /v1/jobs/{id}/prediction_result`,
-`/evaluation_result`, or `/database_result`.
-
-## Further reading
-
-- [Platform documentation](https://chap.dhis2.org/chap-modeling-platform/)
-- Contact: <chap@dhis2.org>
-"""
+api_description = (
+    "Chap is a Climate & Health Modeling Platform that brings together "
+    "disease forecasting models into a unified ecosystem, connecting "
+    "researchers with cutting-edge epidemiological models to policy "
+    "makers and health practitioners."
+)
 
 
 app = FastAPI(

--- a/chap_core/rest_api/v1/jobs.py
+++ b/chap_core/rest_api/v1/jobs.py
@@ -20,14 +20,18 @@ router = APIRouter(prefix="/jobs", tags=["Jobs"])
 worker: CeleryPool[Any] = CeleryPool()
 
 
-@router.get("")
+@router.get(
+    "",
+    summary="List jobs in the queue",
+)
 def list_jobs(
     ids: list[str] = Query(None), status: list[str] = Query(None), job_type: str = Query(None, alias="type")
 ) -> list[JobDescription]:
-    """
-    List all jobs currently in the queue.
-    Optionally filters by a list of job IDs, a list of statuses, and/or a job type.
-    Filtering order: IDs, then type, then status.
+    """List every job tracked by the worker, optionally filtered by id, status, and type.
+
+    Filters are applied in this order: ``ids``, then ``type``, then ``status``. Status
+    values are matched case-insensitively. Returns an empty list when no jobs match (no
+    404).
     """
     jobs_to_return = worker.list_jobs()
 
@@ -67,16 +71,31 @@ def _get_successful_job(job_id):
     return job
 
 
-@router.get("/{job_id}")
+@router.get(
+    "/{job_id}",
+    summary="Get a job's status",
+)
 def get_job_status(job_id: str) -> str:
+    """Return the current Celery status string for the job (e.g. ``PENDING``, ``SUCCESS``, ``FAILURE``).
+
+    Returns 404 if the job id is unknown to the worker's Redis metadata.
+    """
     _ensure_job_exists(job_id)
     status: str = worker.get_job(job_id).status
     logger.info(f"status of job {job_id}: {status}")
     return status
 
 
-@router.delete("/{job_id}")
+@router.delete(
+    "/{job_id}",
+    summary="Delete a finished job's metadata",
+)
 def delete_job(job_id: str) -> dict:
+    """Remove the job's metadata entry from Redis. Cannot delete a running job - cancel it first.
+
+    Returns 400 if the job is still ``pending``/``started``/``running`` and 404 if the id
+    is unknown.
+    """
     job = worker.get_job(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -93,10 +112,15 @@ def delete_job(job_id: str) -> dict:
     return {"message": f"Job {job_id} deleted successfully"}
 
 
-@router.post("/{job_id}/cancel")
+@router.post(
+    "/{job_id}/cancel",
+    summary="Cancel a running job",
+)
 def cancel_job(job_id: str) -> dict:
-    """
-    Cancel a running job
+    """Revoke a job that is currently ``pending``, ``started``, or ``running``.
+
+    Returns 400 if the job has already finished (``success``/``failure``/``revoked``) or
+    is in an unexpected state, and 404 if the id is unknown.
     """
     _ensure_job_exists(job_id)
     job = worker.get_job(job_id)
@@ -113,8 +137,15 @@ def cancel_job(job_id: str) -> dict:
     return {"message": f"Job {job_id} has been cancelled"}
 
 
-@router.get("/{job_id}/logs")
+@router.get(
+    "/{job_id}/logs",
+    summary="Get a job's captured logs",
+)
 def get_logs(job_id: str) -> str:
+    """Return the concatenated log output the worker captured while running the job.
+
+    Returns 404 if the job id is unknown and 400 if the log file is not (yet) available.
+    """
     _ensure_job_exists(job_id)
     job = worker.get_job(job_id)
     logs: str = job.get_logs()
@@ -123,11 +154,20 @@ def get_logs(job_id: str) -> str:
     return logs
 
 
-@router.get("/{job_id}/prediction_result", response_model=PredictionInfo)
+@router.get(
+    "/{job_id}/prediction_result",
+    response_model=PredictionInfo,
+    summary="Get the prediction created by a finished prediction job",
+)
 def get_prediction_result(
     job_id: str,
     session: Session = Depends(get_session),
 ):
+    """Resolve the job's stored result as a prediction id and return the matching ``PredictionInfo`` row.
+
+    Returns 400 if the job is still running or has failed, and 404 if the job id or the
+    resulting prediction row is missing.
+    """
     prediction_id = _get_successful_job(job_id).result
     prediction = session.get(Prediction, prediction_id)
     if prediction is None:
@@ -135,11 +175,20 @@ def get_prediction_result(
     return prediction
 
 
-@router.get("/{job_id}/evaluation_result", response_model=BacktestRead)
+@router.get(
+    "/{job_id}/evaluation_result",
+    response_model=BacktestRead,
+    summary="Get the backtest created by a finished evaluation job",
+)
 def get_evaluation_result(
     job_id: str,
     session: Session = Depends(get_session),
 ):
+    """Resolve the job's stored result as a backtest id and return the matching ``BacktestRead`` row.
+
+    Returns 400 if the job is still running or has failed, and 404 if the job id or the
+    resulting backtest row is missing.
+    """
     backtest_id = _get_successful_job(job_id).result
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
@@ -151,8 +200,16 @@ class DataBaseResponse(BaseModel):
     id: int
 
 
-@router.get("/{job_id}/database_result")
+@router.get(
+    "/{job_id}/database_result",
+    summary="Get the database id produced by a finished job",
+)
 def get_database_result(job_id: str) -> DataBaseResponse:
+    """Return the raw integer database id stored as the finished job's result, wrapped in a ``DataBaseResponse``.
+
+    Used when a job's result is just an id (e.g. a dataset id from a dataset-import
+    job). Returns 400 if the job is still running or has failed.
+    """
     result = _get_successful_job(job_id).result
     return DataBaseResponse(id=result)
 

--- a/chap_core/rest_api/v1/jobs.py
+++ b/chap_core/rest_api/v1/jobs.py
@@ -99,8 +99,10 @@ def get_job_status(job_id: str) -> str:
 def delete_job(job_id: str) -> dict:
     """Remove the job's metadata entry from Redis. Cannot delete a running job - cancel it first.
 
-    Returns 400 if the job is still ``pending``/``started``/``running`` and 404 if the id
-    is unknown.
+    Returns 400 if the job looks ``pending``/``started``/``running``. Unknown job ids
+    also surface as 400 here because Celery's ``AsyncResult`` fabricates a ``PENDING``
+    state for them; the 404 branch only fires once a non-running job's metadata entry
+    has been cleared from Redis.
     """
     job = worker.get_job(job_id)
     if job is None:

--- a/chap_core/rest_api/v1/jobs.py
+++ b/chap_core/rest_api/v1/jobs.py
@@ -100,12 +100,11 @@ def get_job_status(job_id: str) -> str:
     summary="Forget a finished job",
 )
 def delete_job(job_id: str) -> dict:
-    """Drop a finished or cancelled job from the tracker once you no longer need to see it in the listing — cancel it first if it's still running.
+    """Drop a finished or cancelled job from the tracker once you no longer need to see it in the listing.
 
-    Quirk: Celery treats unknown job ids as ``PENDING`` for safety, so passing an
-    unknown id currently surfaces as 400 ("cannot delete a running job") rather than
-    404. 404 only fires once metadata has actually been cleared. Cancel a running job
-    via ``POST /{job_id}/cancel`` before deleting.
+    Cancel a running job via ``POST /{job_id}/cancel`` first; this endpoint refuses to
+    delete jobs that look ``pending``, ``started``, or ``running`` and returns 400 in
+    those cases.
     """
     job = worker.get_job(job_id)
     if job is None:
@@ -128,10 +127,10 @@ def delete_job(job_id: str) -> dict:
     summary="Stop a running job",
 )
 def cancel_job(job_id: str) -> dict:
-    """Revoke a queued or in-flight job so it stops eating worker cycles, e.g. when the user navigates away from a backtest creation flow or kills a slow prediction.
+    """Revoke a queued or in-flight job so the worker stops processing it — used when a user abandons a backtest creation flow or aborts a long-running prediction.
 
-    400 if the job has already finished (``success`` / ``failure`` / ``revoked``) or is
-    in an unexpected state; 404 if the id is unknown.
+    Returns 400 if the job has already finished (``success`` / ``failure`` / ``revoked``)
+    or is in an unexpected state; 404 if the id is unknown.
     """
     _ensure_job_exists(job_id)
     job = worker.get_job(job_id)
@@ -155,8 +154,9 @@ def cancel_job(job_id: str) -> dict:
 def get_logs(job_id: str) -> str:
     """Tail the log output the worker captured while running this job — useful for debugging a failure or watching progress.
 
-    404 if the job id is unknown; 400 if the log file hasn't been written yet (the job
-    may not have started, or may be running on a worker that doesn't expose logs).
+    The response is the captured log text, or an empty string if the worker has not
+    written anything yet (for example because the job has not started). Returns 404
+    if the job id is unknown.
     """
     _ensure_job_exists(job_id)
     job = worker.get_job(job_id)

--- a/chap_core/rest_api/v1/jobs.py
+++ b/chap_core/rest_api/v1/jobs.py
@@ -22,7 +22,7 @@ worker: CeleryPool[Any] = CeleryPool()
 
 @router.get(
     "",
-    summary="List jobs in the queue",
+    summary="Track background work",
 )
 def list_jobs(
     ids: list[str] = Query(None),
@@ -30,11 +30,12 @@ def list_jobs(
     job_type: str = Query(None, alias="type"),
     prediction_setup_id: int | None = Query(None, alias="predictionSetupId"),
 ) -> list[JobDescription]:
-    """List every job tracked by the worker, optionally filtered by id, type, prediction setup id, and status.
+    """See every backtest, prediction, or dataset-import job currently being tracked, so a UI can render a progress dashboard or a script can wait for a batch to finish.
 
-    Filters are applied in this order: ``ids``, then ``type``, then ``predictionSetupId``,
-    then ``status``. Status values are matched case-insensitively. Returns an empty list
-    when no jobs match (no 404).
+    Optionally narrow the list by ``ids``, ``type`` (e.g. ``PREDICTION``, ``EVALUATION``),
+    ``predictionSetupId`` (every job a given setup has launched), and/or ``status``
+    (case-insensitive). Filters compose. An empty list just means nothing matched — no
+    404.
     """
     jobs_to_return = worker.list_jobs()
 
@@ -79,12 +80,14 @@ def _get_successful_job(job_id):
 
 @router.get(
     "/{job_id}",
-    summary="Get a job's status",
+    summary="Check whether a job is done yet",
 )
 def get_job_status(job_id: str) -> str:
-    """Return the current Celery status string for the job (e.g. ``PENDING``, ``SUCCESS``, ``FAILURE``).
+    """Return the current state of a queued job (``PENDING``, ``STARTED``, ``SUCCESS``, ``FAILURE``, ...).
 
-    Returns 404 if the job id is unknown to the worker's Redis metadata.
+    The canonical way to poll a background job started by any of the
+    ``POST /v1/analytics/*`` or ``POST /v1/crud/*`` endpoints. 404 if the job id is
+    unknown.
     """
     _ensure_job_exists(job_id)
     status: str = worker.get_job(job_id).status
@@ -94,15 +97,15 @@ def get_job_status(job_id: str) -> str:
 
 @router.delete(
     "/{job_id}",
-    summary="Delete a finished job's metadata",
+    summary="Forget a finished job",
 )
 def delete_job(job_id: str) -> dict:
-    """Remove the job's metadata entry from Redis. Cannot delete a running job - cancel it first.
+    """Drop a finished or cancelled job from the tracker once you no longer need to see it in the listing — cancel it first if it's still running.
 
-    Returns 400 if the job looks ``pending``/``started``/``running``. Unknown job ids
-    also surface as 400 here because Celery's ``AsyncResult`` fabricates a ``PENDING``
-    state for them; the 404 branch only fires once a non-running job's metadata entry
-    has been cleared from Redis.
+    Quirk: Celery treats unknown job ids as ``PENDING`` for safety, so passing an
+    unknown id currently surfaces as 400 ("cannot delete a running job") rather than
+    404. 404 only fires once metadata has actually been cleared. Cancel a running job
+    via ``POST /{job_id}/cancel`` before deleting.
     """
     job = worker.get_job(job_id)
     if job is None:
@@ -122,13 +125,13 @@ def delete_job(job_id: str) -> dict:
 
 @router.post(
     "/{job_id}/cancel",
-    summary="Cancel a running job",
+    summary="Stop a running job",
 )
 def cancel_job(job_id: str) -> dict:
-    """Revoke a job that is currently ``pending``, ``started``, or ``running``.
+    """Revoke a queued or in-flight job so it stops eating worker cycles, e.g. when the user navigates away from a backtest creation flow or kills a slow prediction.
 
-    Returns 400 if the job has already finished (``success``/``failure``/``revoked``) or
-    is in an unexpected state, and 404 if the id is unknown.
+    400 if the job has already finished (``success`` / ``failure`` / ``revoked``) or is
+    in an unexpected state; 404 if the id is unknown.
     """
     _ensure_job_exists(job_id)
     job = worker.get_job(job_id)
@@ -147,12 +150,13 @@ def cancel_job(job_id: str) -> dict:
 
 @router.get(
     "/{job_id}/logs",
-    summary="Get a job's captured logs",
+    summary="Read a job's captured logs",
 )
 def get_logs(job_id: str) -> str:
-    """Return the concatenated log output the worker captured while running the job.
+    """Tail the log output the worker captured while running this job — useful for debugging a failure or watching progress.
 
-    Returns 404 if the job id is unknown and 400 if the log file is not (yet) available.
+    404 if the job id is unknown; 400 if the log file hasn't been written yet (the job
+    may not have started, or may be running on a worker that doesn't expose logs).
     """
     _ensure_job_exists(job_id)
     job = worker.get_job(job_id)
@@ -165,16 +169,16 @@ def get_logs(job_id: str) -> str:
 @router.get(
     "/{job_id}/prediction_result",
     response_model=PredictionInfo,
-    summary="Get the prediction created by a finished prediction job",
+    summary="Fetch the prediction a finished forecast job produced",
 )
 def get_prediction_result(
     job_id: str,
     session: Session = Depends(get_session),
 ):
-    """Resolve the job's stored result as a prediction id and return the matching ``PredictionInfo`` row.
+    """Get the prediction row a successful forecast job wrote, in one hop instead of polling for status then looking up the id by hand.
 
-    Returns 400 if the job is still running or has failed, and 404 if the job id or the
-    resulting prediction row is missing.
+    Useful right after the job's status flips to ``SUCCESS``. 400 if the job is still
+    running or has failed; 404 if the job id or the resulting prediction is missing.
     """
     prediction_id = _get_successful_job(job_id).result
     prediction = session.get(Prediction, prediction_id)
@@ -186,16 +190,16 @@ def get_prediction_result(
 @router.get(
     "/{job_id}/evaluation_result",
     response_model=BacktestRead,
-    summary="Get the backtest created by a finished evaluation job",
+    summary="Fetch the backtest a finished evaluation job produced",
 )
 def get_evaluation_result(
     job_id: str,
     session: Session = Depends(get_session),
 ):
-    """Resolve the job's stored result as a backtest id and return the matching ``BacktestRead`` row.
+    """Get the backtest a successful evaluation job wrote, in one hop instead of polling for status then looking up the id by hand.
 
-    Returns 400 if the job is still running or has failed, and 404 if the job id or the
-    resulting backtest row is missing.
+    Useful right after the job's status flips to ``SUCCESS``. 400 if the job is still
+    running or has failed; 404 if the job id or the resulting backtest is missing.
     """
     backtest_id = _get_successful_job(job_id).result
     backtest = session.get(Backtest, backtest_id)
@@ -210,13 +214,13 @@ class DataBaseResponse(BaseModel):
 
 @router.get(
     "/{job_id}/database_result",
-    summary="Get the database id produced by a finished job",
+    summary="Fetch the row id a generic finished job produced",
 )
 def get_database_result(job_id: str) -> DataBaseResponse:
-    """Return the raw integer database id stored as the finished job's result, wrapped in a ``DataBaseResponse``.
+    """Get the integer id a finished job wrote — used by job types whose only output is "a thing was created with id N" (most commonly dataset imports).
 
-    Used when a job's result is just an id (e.g. a dataset id from a dataset-import
-    job). Returns 400 if the job is still running or has failed.
+    Once you have the id, follow up with the appropriate CRUD endpoint to load the row.
+    400 if the job is still running or has failed.
     """
     result = _get_successful_job(job_id).result
     return DataBaseResponse(id=result)

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -257,7 +257,7 @@ def get_backtest_overlap(
     "/prediction-entry",
     response_model=list[PredictionEntry],
     tags=["Predictions"],
-    summary="Read forecast quantiles for a prediction (queryString id)",
+    summary="Read forecast quantiles for a prediction (query parameter id)",
 )
 async def get_prediction_entry(
     prediction_id: Annotated[int, Query(alias="predictionId")],
@@ -408,11 +408,11 @@ async def create_backtest(
 async def make_prediction(
     request: MakePredictionRequest, database_url=Depends(get_database_url), worker_settings=Depends(get_settings)
 ):
-    """Fire a forecast using observations you ship in the request body — no stored dataset needed.
+    """Run a forecast against observations supplied directly in the request body — no stored dataset needed.
 
     Use this for ad-hoc work when DHIS2 (or another source) already has the data and you
-    just want it run through a configured model once. Forecasting happens in the
-    background; you get a job id back and poll ``/v1/jobs/{id}`` for the result. For a
+    want it run through a configured model once. Forecasting happens in the background;
+    the response carries a job id you poll via ``/v1/jobs/{id}`` for the result. For a
     recurring or scheduled version of the same workflow, use a prediction setup. The
     legacy ``data_to_be_fetched`` field is rejected — supply the observations directly.
     """
@@ -447,7 +447,7 @@ async def make_prediction(
     "/prediction-entry/{predictionId}",
     response_model=list[PredictionEntry],
     tags=["Predictions"],
-    summary="Read forecast quantiles for a prediction (path id)",
+    summary="Read forecast quantiles for a prediction (path parameter id)",
 )
 def get_prediction_entries(
     prediction_id: Annotated[int, Path(alias="predictionId")],
@@ -637,11 +637,11 @@ async def create_backtest_with_data(
     database_url: str = Depends(get_database_url),
     worker_settings=Depends(get_settings),
 ):
-    """Train and evaluate a model on observations you ship in the request body, without first creating a reusable dataset.
+    """Train and evaluate a model on observations supplied directly in the request body, without first creating a reusable dataset.
 
-    Convenient for quick experiments where the data isn't worth persisting. Use
-    ``dryRun=true`` to only run validation (cheap, synchronous) and inspect which
-    regions would be rejected — handy as a preflight before committing to an import. A
+    Convenient for quick experiments where the data is not worth persisting. Pass
+    ``dryRun=true`` to run validation only (cheap, synchronous) and inspect which
+    regions would be rejected — useful as a preflight before committing to an import. A
     real run returns a job id; poll ``/v1/jobs/{id}`` for status. The response also
     surfaces any per-location rejections that came out of validation.
     """

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -48,13 +48,19 @@ logger = logging.getLogger(__name__)
 worker: CeleryPool[Any] = CeleryPool()
 
 
-@router.post("/make-dataset", response_model=ImportSummaryResponse, tags=["Datasets"])
+@router.post(
+    "/make-dataset",
+    response_model=ImportSummaryResponse,
+    tags=["Datasets"],
+    summary="Create a dataset from provided observations",
+)
 def make_dataset(
     request: DatasetMakeRequest, database_url: str = Depends(get_database_url), worker_settings=Depends(get_settings)
 ):
-    """
-    This endpoint creates a dataset from the provided data and the data to be fetched3
-    and puts it in the database
+    """Validate the provided observations against the request's geojson and queue dataset import.
+
+    The response carries the queued job id and any per-location validation rejections; poll
+    ``GET /v1/jobs/{id}`` for the harmonize-and-import job status.
     """
     feature_names, provided_data = _read_dataset(request)
     provided_data, rejections = _validate_full_dataset(feature_names, provided_data)
@@ -183,11 +189,20 @@ def _filter_dataset_by_locations(
     return dataset.__class__(new_data, polygons=dataset.polygons, metadata=dataset.metadata)
 
 
-@router.get("/compatible-backtests/{backtestId}", response_model=list[BacktestRead], tags=["Backtests"])
+@router.get(
+    "/compatible-backtests/{backtestId}",
+    response_model=list[BacktestRead],
+    tags=["Backtests"],
+    summary="List backtests comparable to a given backtest",
+)
 def get_compatible_backtests(
     backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)
 ):
-    """Return a list of backtests that are compatible for comparison with the given backtest"""
+    """Return backtests that share at least one org unit and one split period with the given backtest.
+
+    These are the backtests it makes sense to overlay or diff against. Excludes the input
+    backtest itself.
+    """
     logger.info(f"Checking compatible backtests for {backtest_id}")
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
@@ -209,13 +224,22 @@ def get_compatible_backtests(
     return backtests
 
 
-@router.get("/backtest-overlap/{backtestId1}/{backtestId2}", response_model=BacktestDomain, tags=["Backtests"])
+@router.get(
+    "/backtest-overlap/{backtestId1}/{backtestId2}",
+    response_model=BacktestDomain,
+    tags=["Backtests"],
+    summary="Get the overlap of two backtests",
+)
 def get_backtest_overlap(
     backtest_id1: Annotated[int, Path(alias="backtestId1")],
     backtest_id2: Annotated[int, Path(alias="backtestId2")],
     session: Session = Depends(get_session),
 ):
-    """Return the org units and split periods that are common between two backtests"""
+    """Return the set of org units and split periods that appear in both backtests.
+
+    Useful when comparing two backtests side by side to know which units/periods can be
+    plotted on the same axes. Returns 404 if either backtest id is unknown.
+    """
     backtest1 = session.get(Backtest, backtest_id1)
     backtest2 = session.get(Backtest, backtest_id2)
     if backtest1 is None:
@@ -227,14 +251,22 @@ def get_backtest_overlap(
     return BacktestDomain(org_units=org_units1, split_periods=split_periods1)
 
 
-@router.get("/prediction-entry", response_model=list[PredictionEntry], tags=["Predictions"])
+@router.get(
+    "/prediction-entry",
+    response_model=list[PredictionEntry],
+    tags=["Predictions"],
+    summary="Return prediction quantiles (query-string predictionId)",
+)
 async def get_prediction_entry(
     prediction_id: Annotated[int, Query(alias="predictionId")],
     quantiles: list[float] = Query(...),
     session: Session = Depends(get_session),
 ):
-    """
-    return
+    """Return the requested quantiles of each forecast in a prediction, one entry per (period, org unit, quantile).
+
+    Returns 404 if the prediction id is unknown. Same shape as
+    ``GET /v1/analytics/prediction-entry/{predictionId}`` - that endpoint takes the id as
+    a path parameter instead.
     """
     prediction = session.get(Prediction, prediction_id)
     if prediction is None:
@@ -251,7 +283,12 @@ async def get_prediction_entry(
     ]
 
 
-@router.get("/evaluation-entry", response_model=list[EvaluationEntry], tags=["Backtests"])
+@router.get(
+    "/evaluation-entry",
+    response_model=list[EvaluationEntry],
+    tags=["Backtests"],
+    summary="Return backtest forecast quantiles",
+)
 async def get_evaluation_entries(
     backtest_id: Annotated[int, Query(alias="backtestId")],
     quantiles: list[float] = Query(...),
@@ -259,9 +296,11 @@ async def get_evaluation_entries(
     org_units: list[str] = Query(None, alias="orgUnits"),
     session: Session = Depends(get_session),
 ):
-    """
-    Return quantiles for the forecasts in a backtest. Can optionally be filtered on split period and org units.
-    NOTE: If org_units is set to ["adm0"], the sum over all regions is returned.
+    """Return the requested quantiles for the forecasts in a backtest.
+
+    Can optionally be filtered on split period and org units. If ``orgUnits=["adm0"]`` is
+    passed, the response is the sum over all regions instead of per-region. Returns 404
+    if the backtest id is unknown.
     """
     return_summed = False
     if org_units is not None and len(org_units) == 1 and org_units[0] == "adm0":
@@ -325,12 +364,22 @@ async def get_evaluation_entries(
     ]
 
 
-@router.post("/create-backtest", response_model=JobResponse, tags=["Backtests"])
+@router.post(
+    "/create-backtest",
+    response_model=JobResponse,
+    tags=["Backtests"],
+    summary="Queue a backtest job against a stored dataset",
+)
 async def create_backtest(
     request: MakeBacktestRequest,
     database_url: str = Depends(get_database_url),
     session: Session = Depends(get_session),
 ):
+    """Queue a backtest job that uses an already-imported dataset (referenced by id).
+
+    Returns the queued job id; poll ``GET /v1/jobs/{id}`` for status. Returns 404 if the
+    referenced dataset does not exist.
+    """
     if session.get(DataSetTable, request.dataset_id) is None:
         raise HTTPException(status_code=404, detail=f"Dataset {request.dataset_id} not found")
     job = worker.queue_db(
@@ -346,10 +395,20 @@ async def create_backtest(
     return JobResponse(id=job.id)
 
 
-@router.post("/make-prediction", response_model=JobResponse, tags=["Predictions"])
+@router.post(
+    "/make-prediction",
+    response_model=JobResponse,
+    tags=["Predictions"],
+    summary="Queue a prediction job from provided observations",
+)
 async def make_prediction(
     request: MakePredictionRequest, database_url=Depends(get_database_url), worker_settings=Depends(get_settings)
 ):
+    """Validate the provided observations, attach polygons, and queue a prediction job.
+
+    Returns the queued job id; poll ``GET /v1/jobs/{id}`` for status. Rejects the request
+    if ``data_to_be_fetched`` is set (no longer supported by chap-core).
+    """
     request.type = "prediction"
     feature_names = list({entry.feature_name for entry in request.provided_data})
     dataclass = create_tsdataclass(feature_names)
@@ -387,6 +446,7 @@ class MakePredictionWithDataSourceRequest(DatasetMakeRequest):
     "/make-prediction-with-data-source",
     response_model=JobResponse,
     tags=["Predictions"],
+    summary="Queue a prediction job using a stored configured-model-with-data-source",
 )
 @api_experimental
 async def make_prediction_with_data_source(
@@ -395,6 +455,14 @@ async def make_prediction_with_data_source(
     database_url=Depends(get_database_url),
     worker_settings=Depends(get_settings),
 ):
+    """Resolve a stored ``ConfiguredModelWithDataSource`` and queue a prediction job that uses it.
+
+    Behaves like ``POST /v1/analytics/make-prediction`` but reads the model id from the
+    referenced configured-model-with-data-source record instead of taking it in the
+    request body. Returns the queued job id; poll ``GET /v1/jobs/{id}`` for status.
+    Returns 404 if the referenced record is missing and 400 if it is not linked to a
+    configured model.
+    """
     record = session.exec(
         select(ConfiguredModelWithDataSource)
         .where(ConfiguredModelWithDataSource.id == request.configured_model_with_data_source_id)
@@ -435,12 +503,23 @@ async def make_prediction_with_data_source(
     return JobResponse(id=job.id)
 
 
-@router.get("/prediction-entry/{predictionId}", response_model=list[PredictionEntry], tags=["Predictions"])
+@router.get(
+    "/prediction-entry/{predictionId}",
+    response_model=list[PredictionEntry],
+    tags=["Predictions"],
+    summary="Return prediction quantiles (path predictionId)",
+)
 def get_prediction_entries(
     prediction_id: Annotated[int, Path(alias="predictionId")],
     quantiles: list[float] = Query(...),
     session: Session = Depends(get_session),
 ):
+    """Return the requested quantiles of each forecast in a prediction, one entry per (period, org unit, quantile).
+
+    Path-parameter variant of ``GET /v1/analytics/prediction-entry`` - same response
+    shape; the id comes from the URL instead of a ``predictionId`` query parameter.
+    Returns 404 if the prediction id is unknown.
+    """
     prediction = session.get(Prediction, prediction_id)
     if prediction is None:
         raise HTTPException(status_code=404, detail="Prediction not found")
@@ -453,18 +532,31 @@ def get_prediction_entries(
     ]
 
 
-@router.get("/actual-cases/{backtestId}", response_model=DataList, tags=["Backtests"], name="get_actual_cases_alias")
-@router.get("/actualCases/{backtestId}", response_model=DataList, tags=["Backtests"])
+@router.get(
+    "/actual-cases/{backtestId}",
+    response_model=DataList,
+    tags=["Backtests"],
+    name="get_actual_cases_alias",
+    summary="Return observed disease cases for a backtest",
+)
+@router.get(
+    "/actualCases/{backtestId}",
+    response_model=DataList,
+    tags=["Backtests"],
+    summary="Return observed disease cases for a backtest (camelCase alias)",
+)
 async def get_actual_cases(
     backtest_id: Annotated[int, Path(alias="backtestId")],
     org_units: list[str] = Query(None, alias="orgUnits"),
     is_dataset_id: bool = Query(False, alias="isDatasetId"),
     session: Session = Depends(get_session),
 ):
-    """
-    Return the actual disease cases corresponding to a backtest. Can optionally be filtered on org units.
+    """Return the observed ``disease_cases`` for the dataset behind a backtest.
 
-    Note: If org_units is set to ["adm0"], the sum over all regions is returned.
+    Can optionally be filtered on org units. If ``orgUnits=["adm0"]`` is passed the
+    response is the sum over all regions. When ``isDatasetId=true`` the path id is treated
+    as a dataset id directly, skipping the backtest lookup. Returns 404 if the backtest
+    is unknown (and ``isDatasetId`` is false).
     """
     return_summed = False
     if org_units is not None and len(org_units) == 1 and org_units[0] == "adm0":
@@ -576,12 +668,23 @@ data_sources = [
 ]
 
 
-@router.get("/data-sources", response_model=list[ChapDataSource], tags=["Datasets"])
+@router.get(
+    "/data-sources",
+    response_model=list[ChapDataSource],
+    tags=["Datasets"],
+    summary="List available external data sources",
+)
 async def get_data_sources() -> list[ChapDataSource]:
+    """Return the CHAP-known external data sources (e.g. ERA5 climate variables) and the dataset features they map to."""
     return data_sources
 
 
-@router.post("/create-backtest-with-data/", response_model=ImportSummaryResponse, tags=["Backtests"])
+@router.post(
+    "/create-backtest-with-data/",
+    response_model=ImportSummaryResponse,
+    tags=["Backtests"],
+    summary="Queue a backtest job from provided observations",
+)
 async def create_backtest_with_data(
     request: MakeBacktestWithDataRequest,
     dry_run: bool = Query(
@@ -590,6 +693,12 @@ async def create_backtest_with_data(
     database_url: str = Depends(get_database_url),
     worker_settings=Depends(get_settings),
 ):
+    """Validate observations, attach polygons, and queue a backtest job.
+
+    Returns the queued job id and per-location validation rejections; poll
+    ``GET /v1/jobs/{id}`` for status. Pass ``dryRun=true`` to skip queueing and only
+    return the rejection summary.
+    """
     try:
         feature_names, provided_data_processed = _read_dataset(request)
         provided_data_processed, rejections = _validate_full_dataset(feature_names, provided_data_processed)

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -482,7 +482,13 @@ def get_prediction_entries(
     "/actualCases/{backtestId}",
     response_model=DataList,
     tags=["Backtests"],
-    summary="Read the observed disease cases a backtest was scored against (camelCase alias)",
+    deprecated=True,
+    summary="Deprecated camelCase alias of /actual-cases/{backtestId}",
+    description=(
+        "Deprecated camelCase alias of ``GET /v1/analytics/actual-cases/{backtestId}``. "
+        "Behaviour is identical; new integrations should call the kebab-case path, which "
+        "matches the rest of the API's URL style."
+    ),
 )
 async def get_actual_cases(
     backtest_id: Annotated[int, Path(alias="backtestId")],

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -51,15 +51,18 @@ worker: CeleryPool[Any] = CeleryPool()
     "/make-dataset",
     response_model=ImportSummaryResponse,
     tags=["Datasets"],
-    summary="Create a dataset from provided observations",
+    summary="Import observations as a reusable dataset",
 )
 def make_dataset(
     request: DatasetMakeRequest, database_url: str = Depends(get_database_url), worker_settings=Depends(get_settings)
 ):
-    """Validate the provided observations against the request's geojson and queue dataset import.
+    """Persist observations (with polygons) as a named dataset you can reuse across backtests and predictions.
 
-    The response carries the queued job id and any per-location validation rejections; poll
-    ``GET /v1/jobs/{id}`` for the harmonize-and-import job status.
+    Use this to turn a one-off batch of DHIS2 / file-based observations into something
+    stored, so a single dataset can back multiple evaluations. Import happens in the
+    background — the response gives you a job id plus a per-location rejection summary
+    (validation runs synchronously, the harmonise-and-load step async). Poll
+    ``/v1/jobs/{id}`` to know when the dataset is queryable.
     """
     feature_names, provided_data = _read_dataset(request)
     provided_data, rejections = validate_full_dataset(feature_names, provided_data)
@@ -192,15 +195,15 @@ def _filter_dataset_by_locations(
     "/compatible-backtests/{backtestId}",
     response_model=list[BacktestRead],
     tags=["Backtests"],
-    summary="List backtests comparable to a given backtest",
+    summary="Find backtests that can be compared with this one",
 )
 def get_compatible_backtests(
     backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)
 ):
-    """Return backtests that share at least one org unit and one split period with the given backtest.
+    """Find every other backtest that shares at least one region and one split period with this one — i.e. backtests it makes sense to overlay or diff against in a plot.
 
-    These are the backtests it makes sense to overlay or diff against. Excludes the input
-    backtest itself.
+    Use this to power a "compare to..." picker in the UI without offering choices that
+    would produce empty intersections.
     """
     logger.info(f"Checking compatible backtests for {backtest_id}")
     backtest = session.get(Backtest, backtest_id)
@@ -227,17 +230,17 @@ def get_compatible_backtests(
     "/backtest-overlap/{backtestId1}/{backtestId2}",
     response_model=BacktestDomain,
     tags=["Backtests"],
-    summary="Get the overlap of two backtests",
+    summary="Inspect the shared regions and periods of two backtests",
 )
 def get_backtest_overlap(
     backtest_id1: Annotated[int, Path(alias="backtestId1")],
     backtest_id2: Annotated[int, Path(alias="backtestId2")],
     session: Session = Depends(get_session),
 ):
-    """Return the set of org units and split periods that appear in both backtests.
+    """Get the regions and split periods two backtests have in common — the slice on which side-by-side comparison is even meaningful.
 
-    Useful when comparing two backtests side by side to know which units/periods can be
-    plotted on the same axes. Returns 404 if either backtest id is unknown.
+    Use this before building a side-by-side plot to know which axes are valid for both
+    backtests. 404 if either id is unknown.
     """
     backtest1 = session.get(Backtest, backtest_id1)
     backtest2 = session.get(Backtest, backtest_id2)
@@ -254,18 +257,18 @@ def get_backtest_overlap(
     "/prediction-entry",
     response_model=list[PredictionEntry],
     tags=["Predictions"],
-    summary="Return prediction quantiles (query-string predictionId)",
+    summary="Read forecast quantiles for a prediction (queryString id)",
 )
 async def get_prediction_entry(
     prediction_id: Annotated[int, Query(alias="predictionId")],
     quantiles: list[float] = Query(...),
     session: Session = Depends(get_session),
 ):
-    """Return the requested quantiles of each forecast in a prediction, one entry per (period, org unit, quantile).
+    """Pull the chosen quantiles (median, 10th and 90th percentile, ...) out of a prediction so they can be charted, exported, or fed back into DHIS2.
 
-    Returns 404 if the prediction id is unknown. Same shape as
-    ``GET /v1/analytics/prediction-entry/{predictionId}`` - that endpoint takes the id as
-    a path parameter instead.
+    Returns one entry per (period, region, quantile) tuple. Same response as
+    ``GET /v1/analytics/prediction-entry/{predictionId}`` — only the parameter style
+    differs; that variant takes the id in the path. 404 if the prediction id is unknown.
     """
     prediction = session.get(Prediction, prediction_id)
     if prediction is None:
@@ -286,7 +289,7 @@ async def get_prediction_entry(
     "/evaluation-entry",
     response_model=list[EvaluationEntry],
     tags=["Backtests"],
-    summary="Return backtest forecast quantiles",
+    summary="Read forecast quantiles from a backtest",
 )
 async def get_evaluation_entries(
     backtest_id: Annotated[int, Query(alias="backtestId")],
@@ -295,11 +298,12 @@ async def get_evaluation_entries(
     org_units: list[str] = Query(None, alias="orgUnits"),
     session: Session = Depends(get_session),
 ):
-    """Return the requested quantiles for the forecasts in a backtest.
+    """Pull the chosen quantiles from a backtest's forecasts so they can be charted, exported, or compared against actuals.
 
-    Can optionally be filtered on split period and org units. If ``orgUnits=["adm0"]`` is
-    passed, the response is the sum over all regions instead of per-region. Returns 404
-    if the backtest id is unknown.
+    Optionally narrow the slice with ``splitPeriod`` (a single training horizon) or
+    ``orgUnits`` (specific regions). Passing ``orgUnits=["adm0"]`` collapses the result
+    into one row per period — the sum over every region — which is what you want for
+    national-level overlays. 404 if the backtest id is unknown.
     """
     return_summed = False
     if org_units is not None and len(org_units) == 1 and org_units[0] == "adm0":
@@ -367,17 +371,18 @@ async def get_evaluation_entries(
     "/create-backtest",
     response_model=JobResponse,
     tags=["Backtests"],
-    summary="Queue a backtest job against a stored dataset",
+    summary="Run a backtest against a stored dataset",
 )
 async def create_backtest(
     request: MakeBacktestRequest,
     database_url: str = Depends(get_database_url),
     session: Session = Depends(get_session),
 ):
-    """Queue a backtest job that uses an already-imported dataset (referenced by id).
+    """Train and evaluate a configured model on a dataset that's already been imported, producing a backtest you can score, plot, or promote into a prediction setup.
 
-    Returns the queued job id; poll ``GET /v1/jobs/{id}`` for status. Returns 404 if the
-    referenced dataset does not exist.
+    Runs asynchronously; you get a job id and poll ``/v1/jobs/{id}`` (or
+    ``/v1/jobs/{id}/evaluation_result`` once finished) to find the resulting backtest.
+    404 if the referenced dataset does not exist.
     """
     if session.get(DataSetTable, request.dataset_id) is None:
         raise HTTPException(status_code=404, detail=f"Dataset {request.dataset_id} not found")
@@ -398,15 +403,18 @@ async def create_backtest(
     "/make-prediction",
     response_model=JobResponse,
     tags=["Predictions"],
-    summary="Queue a prediction job from provided observations",
+    summary="Run a one-off forecast from inline data",
 )
 async def make_prediction(
     request: MakePredictionRequest, database_url=Depends(get_database_url), worker_settings=Depends(get_settings)
 ):
-    """Validate the provided observations, attach polygons, and queue a prediction job.
+    """Fire a forecast using observations you ship in the request body — no stored dataset needed.
 
-    Returns the queued job id; poll ``GET /v1/jobs/{id}`` for status. Rejects the request
-    if ``data_to_be_fetched`` is set (no longer supported by chap-core).
+    Use this for ad-hoc work when DHIS2 (or another source) already has the data and you
+    just want it run through a configured model once. Forecasting happens in the
+    background; you get a job id back and poll ``/v1/jobs/{id}`` for the result. For a
+    recurring or scheduled version of the same workflow, use a prediction setup. The
+    legacy ``data_to_be_fetched`` field is rejected — supply the observations directly.
     """
     request.type = "prediction"
     feature_names = list({entry.feature_name for entry in request.provided_data})
@@ -439,18 +447,17 @@ async def make_prediction(
     "/prediction-entry/{predictionId}",
     response_model=list[PredictionEntry],
     tags=["Predictions"],
-    summary="Return prediction quantiles (path predictionId)",
+    summary="Read forecast quantiles for a prediction (path id)",
 )
 def get_prediction_entries(
     prediction_id: Annotated[int, Path(alias="predictionId")],
     quantiles: list[float] = Query(...),
     session: Session = Depends(get_session),
 ):
-    """Return the requested quantiles of each forecast in a prediction, one entry per (period, org unit, quantile).
+    """Path-parameter variant of ``GET /v1/analytics/prediction-entry`` for callers that prefer the id in the URL.
 
-    Path-parameter variant of ``GET /v1/analytics/prediction-entry`` - same response
-    shape; the id comes from the URL instead of a ``predictionId`` query parameter.
-    Returns 404 if the prediction id is unknown.
+    Same forecast-quantile response — pick whichever URL shape your client tooling
+    handles more naturally. 404 if the prediction id is unknown.
     """
     prediction = session.get(Prediction, prediction_id)
     if prediction is None:
@@ -469,13 +476,13 @@ def get_prediction_entries(
     response_model=DataList,
     tags=["Backtests"],
     name="get_actual_cases_alias",
-    summary="Return observed disease cases for a backtest",
+    summary="Read the observed disease cases a backtest was scored against",
 )
 @router.get(
     "/actualCases/{backtestId}",
     response_model=DataList,
     tags=["Backtests"],
-    summary="Return observed disease cases for a backtest (camelCase alias)",
+    summary="Read the observed disease cases a backtest was scored against (camelCase alias)",
 )
 async def get_actual_cases(
     backtest_id: Annotated[int, Path(alias="backtestId")],
@@ -483,12 +490,12 @@ async def get_actual_cases(
     is_dataset_id: bool = Query(False, alias="isDatasetId"),
     session: Session = Depends(get_session),
 ):
-    """Return the observed ``disease_cases`` for the dataset behind a backtest.
+    """Pull the actual ``disease_cases`` series from the dataset that backs a backtest, so a plot can show forecast vs. reality on the same axes.
 
-    Can optionally be filtered on org units. If ``orgUnits=["adm0"]`` is passed the
-    response is the sum over all regions. When ``isDatasetId=true`` the path id is treated
-    as a dataset id directly, skipping the backtest lookup. Returns 404 if the backtest
-    is unknown (and ``isDatasetId`` is false).
+    Filter to specific regions with ``orgUnits``, or pass ``orgUnits=["adm0"]`` to get
+    one summed series across every region (useful for national-level views). Set
+    ``isDatasetId=true`` to skip the backtest lookup and read directly from a dataset
+    id. 404 if the backtest is unknown (and ``isDatasetId`` is false).
     """
     return_summed = False
     if org_units is not None and len(org_units) == 1 and org_units[0] == "adm0":
@@ -604,10 +611,15 @@ data_sources = [
     "/data-sources",
     response_model=list[ChapDataSource],
     tags=["Datasets"],
-    summary="List available external data sources",
+    summary="Discover which external data sources can feed a dataset",
 )
 async def get_data_sources() -> list[ChapDataSource]:
-    """Return the CHAP-known external data sources (e.g. ERA5 climate variables) and the dataset features they map to."""
+    """List the external covariate sources CHAP knows about (ERA5 temperature, precipitation, ...) and the dataset features each one maps to.
+
+    Use this to power a data-source picker when authoring a dataset or a prediction
+    setup, so users can pick covariates by what they cover rather than by their internal
+    identifier.
+    """
     return data_sources
 
 
@@ -615,7 +627,7 @@ async def get_data_sources() -> list[ChapDataSource]:
     "/create-backtest-with-data/",
     response_model=ImportSummaryResponse,
     tags=["Backtests"],
-    summary="Queue a backtest job from provided observations",
+    summary="Run a backtest from inline data",
 )
 async def create_backtest_with_data(
     request: MakeBacktestWithDataRequest,
@@ -625,11 +637,13 @@ async def create_backtest_with_data(
     database_url: str = Depends(get_database_url),
     worker_settings=Depends(get_settings),
 ):
-    """Validate observations, attach polygons, and queue a backtest job.
+    """Train and evaluate a model on observations you ship in the request body, without first creating a reusable dataset.
 
-    Returns the queued job id and per-location validation rejections; poll
-    ``GET /v1/jobs/{id}`` for status. Pass ``dryRun=true`` to skip queueing and only
-    return the rejection summary.
+    Convenient for quick experiments where the data isn't worth persisting. Use
+    ``dryRun=true`` to only run validation (cheap, synchronous) and inspect which
+    regions would be rejected — handy as a preflight before committing to an import. A
+    real run returns a job id; poll ``/v1/jobs/{id}`` for status. The response also
+    surfaces any per-location rejections that came out of validation.
     """
     try:
         feature_names, provided_data_processed = _read_dataset(request)

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -70,7 +70,6 @@ from ...data_models import (
     JobResponse,
     ModelConfigurationCreate,
     ModelTemplateRead,
-    PredictionCreate,
     PredictionParams,
     PredictionSetupCreate,
     PredictionSetupUpdate,
@@ -537,22 +536,6 @@ async def get_prediction(
     if prediction is None:
         raise HTTPException(status_code=404, detail="Prediction not found")
     return prediction
-
-
-@router.post(
-    "/predictions",
-    response_model=JobResponse,
-    tags=["Predictions"],
-    summary="(Not implemented) create a prediction",
-)
-async def create_prediction(prediction: PredictionCreate):
-    """Placeholder - always returns 501 Not Implemented.
-
-    Use ``POST /v1/analytics/make-prediction`` to queue a prediction job from provided
-    observations, or ``POST /v1/crud/prediction-setups/{predictionSetupId}/run`` to fire
-    one off a stored prediction setup.
-    """
-    raise HTTPException(status_code=501, detail="Not implemented")
 
 
 @router.delete(

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -248,10 +248,17 @@ worker: CeleryPool[Any] = CeleryPool()
 # backtests
 
 
-@router.get("/backtests", response_model=list[BacktestRead], tags=["Backtests"])  # This should be called list
+@router.get(
+    "/backtests",
+    response_model=list[BacktestRead],
+    tags=["Backtests"],
+    summary="List all backtests",
+)  # This should be called list
 async def get_backtests(session: Session = Depends(get_session)):
-    """
-    Returns a list of backtests/evaluations with only the id and name
+    """Return every backtest as a ``BacktestRead`` row with its dataset metadata and configured model embedded.
+
+    The dataset's geojson is deferred (not loaded) to keep the response small; use
+    ``GET /v1/crud/backtests/{backtestId}/full`` if you need it.
     """
     backtests = session.exec(
         select(Backtest).options(
@@ -262,17 +269,43 @@ async def get_backtests(session: Session = Depends(get_session)):
     return backtests
 
 
-@router.get("/backtests/{backtestId}/full", response_model=Backtest, tags=["Backtests"])
+@router.get(
+    "/backtests/{backtestId}/full",
+    response_model=Backtest,
+    tags=["Backtests"],
+    summary="Get full backtest with forecasts",
+)
 async def get_backtest(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
+    """Return the full ``Backtest`` row including all forecasts and the dataset geojson.
+
+    Heavy payload - prefer ``/info`` or the plain id endpoint for listing. Returns 404 if
+    the backtest id is unknown.
+    """
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
         raise HTTPException(status_code=404, detail="Backtest not found")
     return backtest
 
 
-@router.get("/backtests/{backtestId}/info", response_model=BacktestRead, tags=["Backtests"])
-@router.get("/backtests/{backtestId}", response_model=BacktestRead, tags=["Backtests"])
+@router.get(
+    "/backtests/{backtestId}/info",
+    response_model=BacktestRead,
+    tags=["Backtests"],
+    summary="Get backtest metadata with embedded relations",
+)
+@router.get(
+    "/backtests/{backtestId}",
+    response_model=BacktestRead,
+    tags=["Backtests"],
+    summary="Get backtest metadata (alias of /info)",
+)
 def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
+    """Return the ``BacktestRead`` row with its dataset and configured-model (incl. template) embedded.
+
+    Dataset geojson is deferred to keep the response small. Returns 404 if the backtest
+    id is unknown. ``/backtests/{backtestId}`` and ``/backtests/{backtestId}/info`` are
+    the same operation under two paths.
+    """
     backtest = session.exec(
         select(Backtest)
         .where(Backtest.id == backtest_id)
@@ -286,19 +319,21 @@ def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], ses
     return backtest
 
 
-@router.get("/metric/csv", tags=["Metrics"])
+@router.get(
+    "/metric/csv",
+    tags=["Metrics"],
+    summary="Download per-location/period/horizon metrics for a backtest as CSV",
+)
 async def get_metrics_csv(
     backtest_id: Annotated[int, Query(alias="backtestId")],
     session: Session = Depends(get_session),
 ):
-    """
-    Download per-location / per-time_period / per-horizon metric values as a
-    long-format CSV. Every applicable metric in
-    `chap_core.assessment.metrics.available_metrics` is included as rows.
+    """Stream a long-format CSV with one row per (location, time_period, horizon, metric) tuple.
 
-    Currently takes a single backtest via the `backtestId` query parameter; the
-    path is scoped to `/metric/` so it can be extended to accept multiple
-    evaluations later without a breaking change.
+    Every metric in ``chap_core.assessment.metrics.available_metrics`` contributes rows.
+    Currently takes a single backtest via the ``backtestId`` query parameter; the path is
+    scoped to ``/metric/`` so it can be extended to accept multiple evaluations later
+    without a breaking change. Returns 404 if the backtest is unknown.
     """
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
@@ -316,12 +351,23 @@ async def get_metrics_csv(
     )
 
 
-@router.post("/backtests", response_model=JobResponse, tags=["Backtests"])
+@router.post(
+    "/backtests",
+    response_model=JobResponse,
+    tags=["Backtests"],
+    summary="Queue a backtest job against a stored dataset",
+)
 async def create_backtest(
     backtest: BacktestCreate,
     database_url: str = Depends(get_database_url),
     session: Session = Depends(get_session),
 ):
+    """Queue a legacy-style backtest job; returns the job id (poll ``GET /v1/jobs/{id}`` for status).
+
+    ``BacktestCreate.model_id`` accepts either the configured-model name or its integer
+    primary key; the worker resolves it. Returns 404 if the referenced dataset does not
+    exist.
+    """
     # `BacktestCreate.model_id` accepts either the configured-model name
     # (what the DB column actually stores) or the integer primary key (what
     # most API clients reach for because that's what GET /v1/crud/configured-models
@@ -341,10 +387,15 @@ async def create_backtest(
     return JobResponse(id=job.id)
 
 
-@router.delete("/backtests/{backtestId}", tags=["Backtests"])
+@router.delete(
+    "/backtests/{backtestId}",
+    tags=["Backtests"],
+    summary="Delete a backtest",
+)
 async def delete_backtest(
     backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)
 ):
+    """Delete the backtest row (and its forecasts via cascade). Returns 404 if the id is unknown."""
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
         raise HTTPException(status_code=404, detail="Backtest not found")
@@ -353,12 +404,22 @@ async def delete_backtest(
     return {"message": "deleted"}
 
 
-@router.patch("/backtests/{backtestId}", response_model=BacktestRead, tags=["Backtests"])
+@router.patch(
+    "/backtests/{backtestId}",
+    response_model=BacktestRead,
+    tags=["Backtests"],
+    summary="Partially update a backtest",
+)
 async def update_backtest(
     backtest_id: Annotated[int, Path(alias="backtestId")],
     backtest_update: BacktestUpdate,
     session: Session = Depends(get_session),
 ):
+    """Apply the provided fields to the backtest and return the refreshed ``BacktestRead`` with embedded relations.
+
+    Only fields explicitly set on the request body are updated (``exclude_unset``).
+    Returns 404 if the id is unknown.
+    """
     db_backtest = session.get(Backtest, backtest_id)
     if not db_backtest:
         raise HTTPException(status_code=404, detail="Backtest not found")
@@ -382,8 +443,17 @@ async def update_backtest(
     return db_backtest
 
 
-@router.delete("/backtests", tags=["Backtests"])
+@router.delete(
+    "/backtests",
+    tags=["Backtests"],
+    summary="Delete multiple backtests by id",
+)
 async def delete_backtest_batch(ids: Annotated[str, Query(alias="ids")], session: Session = Depends(get_session)):
+    """Delete every backtest in the comma-separated ``ids`` query parameter and return the deleted count.
+
+    Unknown ids are silently skipped (only the count of actual deletions is returned).
+    Returns 400 if ``ids`` is empty, blank, or contains a non-integer segment.
+    """
     deleted_count = 0
     backtest_ids_list = []
 
@@ -422,33 +492,63 @@ async def delete_backtest_batch(ids: Annotated[str, Query(alias="ids")], session
 # predictions
 
 
-@router.get("/predictions", response_model=list[PredictionInfo], tags=["Predictions"])
+@router.get(
+    "/predictions",
+    response_model=list[PredictionInfo],
+    tags=["Predictions"],
+    summary="List predictions with a configured model",
+)
 async def get_predictions(session: Session = Depends(get_session)):
+    """Return every prediction whose configured model still exists, as ``PredictionInfo`` rows.
+
+    Predictions whose configured model was deleted are filtered out.
+    """
     session_wrapper = SessionWrapper(session=session)
     return [
         prediction for prediction in session_wrapper.list_all(Prediction) if prediction.configured_model is not None
     ]
 
 
-@router.get("/predictions/{predictionId}", response_model=PredictionInfo, tags=["Predictions"])
+@router.get(
+    "/predictions/{predictionId}",
+    response_model=PredictionInfo,
+    tags=["Predictions"],
+    summary="Get a prediction",
+)
 async def get_prediction(
     prediction_id: Annotated[int, Path(alias="predictionId")], session: Session = Depends(get_session)
 ):
+    """Return the ``PredictionInfo`` row for the given id. Returns 404 if unknown."""
     prediction = session.get(Prediction, prediction_id)
     if prediction is None:
         raise HTTPException(status_code=404, detail="Prediction not found")
     return prediction
 
 
-@router.post("/predictions", response_model=JobResponse, tags=["Predictions"])
+@router.post(
+    "/predictions",
+    response_model=JobResponse,
+    tags=["Predictions"],
+    summary="(Not implemented) create a prediction",
+)
 async def create_prediction(prediction: PredictionCreate):
+    """Placeholder - always returns 501 Not Implemented.
+
+    Use ``POST /v1/analytics/make-prediction`` (or
+    ``/v1/analytics/make-prediction-with-data-source``) to queue a prediction job.
+    """
     raise HTTPException(status_code=501, detail="Not implemented")
 
 
-@router.delete("/predictions/{predictionId}", tags=["Predictions"])
+@router.delete(
+    "/predictions/{predictionId}",
+    tags=["Predictions"],
+    summary="Delete a prediction",
+)
 async def delete_prediction(
     prediction_id: Annotated[int, Path(alias="predictionId")], session: Session = Depends(get_session)
 ):
+    """Delete the prediction row (and its forecasts via cascade). Returns 404 if the id is unknown."""
     prediction = session.get(Prediction, prediction_id)
     if prediction is None:
         raise HTTPException(status_code=404, detail="Prediction not found")
@@ -461,14 +561,30 @@ async def delete_prediction(
 # datasets
 
 
-@router.get("/datasets", response_model=list[DataSetInfo], tags=["Datasets"])
+@router.get(
+    "/datasets",
+    response_model=list[DataSetInfo],
+    tags=["Datasets"],
+    summary="List datasets",
+)
 async def get_datasets(session: Session = Depends(get_session)):
+    """Return every dataset as a ``DataSetInfo`` row (metadata only, no observations)."""
     datasets = session.exec(select(DataSet)).all()
     return datasets
 
 
-@router.get("/datasets/{datasetId}", response_model=DataSetWithObservations, tags=["Datasets"])
+@router.get(
+    "/datasets/{datasetId}",
+    response_model=DataSetWithObservations,
+    tags=["Datasets"],
+    summary="Get a dataset with observations",
+)
 async def get_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
+    """Return the dataset with all its observations embedded.
+
+    Non-finite observation values are coerced to ``null`` so the response is JSON-safe.
+    Returns 404 if the dataset id is unknown.
+    """
     # dataset = session.exec(select(DataSet).where(DataSet.id == dataset_id)).first()
     dataset = session.get(DataSet, dataset_id)
     if dataset is None:
@@ -479,10 +595,18 @@ async def get_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], sessi
     return dataset
 
 
-@router.post("/datasets", tags=["Datasets"])
+@router.post(
+    "/datasets",
+    tags=["Datasets"],
+    summary="Queue a dataset import from observations + geojson",
+)
 async def create_dataset(
     data: DatasetCreate, datababase_url=Depends(get_database_url), worker_settings=Depends(get_settings)
 ) -> JobResponse:
+    """Queue a harmonize-and-import job for health/population observations with attached polygons.
+
+    Returns the queued job id; poll ``GET /v1/jobs/{id}`` for status.
+    """
     health_data = observations_to_dataset(HealthPopulationData, data.observations, fill_missing=True)
     health_data.set_polygons(FeatureCollectionModel.model_validate(data.geojson))
     job = worker.queue_db(
@@ -495,12 +619,22 @@ async def create_dataset(
     return JobResponse(id=job.id)
 
 
-@router.post("/datasets/csvFile", tags=["Datasets"])
+@router.post(
+    "/datasets/csvFile",
+    tags=["Datasets"],
+    summary="Create a dataset from an uploaded CSV + geojson",
+)
 async def create_dataset_csv(
     csv_file: UploadFile = File(...),
     geojson_file: UploadFile = File(...),
     session: Session = Depends(get_session),
 ) -> DataBaseResponse:
+    """Import a CSV of observations and its companion geojson directly (synchronously) into the DB.
+
+    Unlike ``POST /v1/crud/datasets``, this endpoint inserts the dataset inline and
+    returns the new dataset id immediately - no job is queued. Polygons are keyed by the
+    ``NAME_1`` property.
+    """
     import io
 
     csv_content = await csv_file.read()
@@ -513,8 +647,17 @@ async def create_dataset_csv(
     return DataBaseResponse(id=dataset_id)
 
 
-@router.get("/datasets/{datasetId}/df", tags=["Datasets"])
+@router.get(
+    "/datasets/{datasetId}/df",
+    tags=["Datasets"],
+    summary="Get a dataset as JSON records",
+)
 async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
+    """Return the dataset as a list of JSON records, one per (location, period) row.
+
+    Non-finite numeric values are emitted as JSON ``null`` so the response parses cleanly.
+    Returns 404 if the dataset id is unknown.
+    """
     if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
     sw = SessionWrapper(session=session)
@@ -532,8 +675,13 @@ async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], se
     return records
 
 
-@router.get("/datasets/{datasetId}/csv", tags=["Datasets"])
+@router.get(
+    "/datasets/{datasetId}/csv",
+    tags=["Datasets"],
+    summary="Download a dataset as CSV",
+)
 async def get_dataset_csv(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
+    """Stream the dataset as a CSV attachment, one row per (location, time_period) tuple. Returns 404 if unknown."""
     if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
     sw = SessionWrapper(session=session)
@@ -549,8 +697,13 @@ async def get_dataset_csv(dataset_id: Annotated[int, Path(alias="datasetId")], s
     )
 
 
-@router.delete("/datasets/{datasetId}", tags=["Datasets"])
+@router.delete(
+    "/datasets/{datasetId}",
+    tags=["Datasets"],
+    summary="Delete a dataset",
+)
 async def delete_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
+    """Delete the dataset row and its observations via cascade. Returns 404 if the id is unknown."""
     # dataset = session.exec(select(DataSet).where(DataSet.id == dataset_id)).first()
     dataset = session.get(DataSet, dataset_id)
     if dataset is None:
@@ -564,12 +717,18 @@ async def delete_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], se
 # model templates
 
 
-@router.get("/model-templates", response_model=list[ModelTemplateRead], tags=["Models"])
+@router.get(
+    "/model-templates",
+    response_model=list[ModelTemplateRead],
+    tags=["Models"],
+    summary="List model templates (and sync live chapkit services)",
+)
 async def list_model_templates(session: Session = Depends(get_session)):
-    """
-    Lists all model templates from the db, including archived.
-    Also syncs live chapkit services from the v2 service registry
-    into the database (upsert by name).
+    """Return every model template (including archived) and side-effect a chapkit registry sync.
+
+    Before returning, live chapkit services from the v2 service registry are upserted by
+    name into the DB and stale chapkit templates are archived. Templates whose live
+    counterpart is currently registered carry ``health_status = "live"``.
     """
     live_ids = _sync_live_chapkit_services(session)
     model_templates = session.exec(select(ModelTemplateDB)).all()
@@ -587,9 +746,14 @@ async def list_model_templates(session: Session = Depends(get_session)):
 # configured models
 
 
-@router.get("/configured-models", response_model=list[ModelSpecRead], tags=["Models"])
+@router.get(
+    "/configured-models",
+    response_model=list[ModelSpecRead],
+    tags=["Models"],
+    summary="List configured models",
+)
 def list_configured_models(session: Session = Depends(get_session)):
-    """List all configured models from the db"""
+    """Return every configured model as a ``ModelSpecRead`` row (config + template metadata)."""
     configured_models_read = SessionWrapper(session=session).get_configured_models()
 
     # return
@@ -600,13 +764,17 @@ def list_configured_models(session: Session = Depends(get_session)):
     "/configured-models/{configuredModelId}",
     response_model=ConfiguredModelInfoRead,
     tags=["Models"],
+    summary="Get a configured model with its template",
 )
 @api_experimental
 def get_configured_model_info(
     configured_model_id: Annotated[int, Path(alias="configuredModelId")],
     session: Session = Depends(get_session),
 ):
-    """Return the detail view for a single configured model, including its template."""
+    """Return the detail view for a single configured model with the model template eagerly loaded.
+
+    Returns 404 if the id is unknown.
+    """
     configured_model = session.exec(
         select(ConfiguredModelDB)
         .where(ConfiguredModelDB.id == configured_model_id)
@@ -617,12 +785,21 @@ def get_configured_model_info(
     return configured_model
 
 
-@router.post("/configured-models", response_model=ConfiguredModelDB, tags=["Models"])
+@router.post(
+    "/configured-models",
+    response_model=ConfiguredModelDB,
+    tags=["Models"],
+    summary="Create a configured model from a template",
+)
 def add_configured_model(
     model_configuration: ModelConfigurationCreate,
     session: Session = Depends(get_session),
 ):
-    """Add a configured model to the database"""
+    """Persist a new configured model bound to an existing model template, inheriting ``uses_chapkit``.
+
+    Returns the freshly-inserted ``ConfiguredModelDB`` row. Returns 404 if the referenced
+    model template does not exist.
+    """
     session_wrapper = SessionWrapper(session=session)
     model_template_id = model_configuration.model_template_id
     configuration_name = model_configuration.name
@@ -643,11 +820,18 @@ def add_configured_model(
     return session.get(ConfiguredModelDB, db_id)
 
 
-@router.delete("/configured-models/{configuredModelId}", tags=["Models"])
+@router.delete(
+    "/configured-models/{configuredModelId}",
+    tags=["Models"],
+    summary="Archive (soft-delete) a configured model",
+)
 async def delete_configured_model(
     configured_model_id: Annotated[int, Path(alias="configuredModelId")], session: Session = Depends(get_session)
 ):
-    """Soft delete a configured model by setting archived to True"""
+    """Soft-delete the configured model by flipping its ``archived`` flag to ``True``; the row is preserved.
+
+    Returns 404 if the id is unknown.
+    """
     configured_model = session.get(ConfiguredModelDB, configured_model_id)
     if configured_model is None:
         raise HTTPException(status_code=404, detail="Configured model not found")
@@ -665,9 +849,11 @@ async def delete_configured_model(
     "/configured-models-with-data-source",
     response_model=list[ConfiguredModelWithDataSourceRead],
     tags=["Models"],
+    summary="List configured-model-with-data-source records",
 )
 @api_experimental
 async def list_configured_models_with_data_source(session: Session = Depends(get_session)):
+    """Return every ``ConfiguredModelWithDataSource`` with its configured model and template embedded."""
     records = session.exec(
         select(ConfiguredModelWithDataSource).options(
             selectinload(ConfiguredModelWithDataSource.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
@@ -680,12 +866,17 @@ async def list_configured_models_with_data_source(session: Session = Depends(get
     "/configured-models-with-data-source/{configuredModelWithDataSourceId}",
     response_model=ConfiguredModelWithDataSourceReadWithPredictions,
     tags=["Models"],
+    summary="Get a configured-model-with-data-source with its predictions",
 )
 @api_experimental
 async def get_configured_model_with_data_source(
     configured_model_with_data_source_id: Annotated[int, Path(alias="configuredModelWithDataSourceId")],
     session: Session = Depends(get_session),
 ):
+    """Return the record with the configured model, model template, and every related prediction (and its dataset) embedded.
+
+    Dataset geojson on each prediction is deferred. Returns 404 if the id is unknown.
+    """
     record = session.exec(
         select(ConfiguredModelWithDataSource)
         .where(ConfiguredModelWithDataSource.id == configured_model_with_data_source_id)
@@ -708,12 +899,19 @@ async def get_configured_model_with_data_source(
     "/configured-models-with-data-source/from-backtest/{backtestId}",
     response_model=ConfiguredModelWithDataSourceRead,
     tags=["Models"],
+    summary="Create a configured-model-with-data-source from a backtest",
 )
 @api_experimental
 async def create_configured_model_with_data_source_from_backtest(
     backtest_id: Annotated[int, Path(alias="backtestId")],
     session: Session = Depends(get_session),
 ):
+    """Create a new ``ConfiguredModelWithDataSource`` whose configured model, org units, period type, and data sources are copied from the given backtest.
+
+    Used to promote a successful backtest into a reusable prediction configuration.
+    Returns the freshly-inserted record with the configured model and its template
+    embedded. Returns 404 if the backtest id is unknown.
+    """
     backtest = session.exec(
         select(Backtest)
         .where(Backtest.id == backtest_id)

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -548,8 +548,9 @@ async def get_prediction(
 async def create_prediction(prediction: PredictionCreate):
     """Placeholder - always returns 501 Not Implemented.
 
-    Use ``POST /v1/analytics/make-prediction`` (or
-    ``/v1/analytics/make-prediction-with-data-source``) to queue a prediction job.
+    Use ``POST /v1/analytics/make-prediction`` to queue a prediction job from provided
+    observations, or ``POST /v1/crud/prediction-setups/{predictionSetupId}/run`` to fire
+    one off a stored prediction setup.
     """
     raise HTTPException(status_code=501, detail="Not implemented")
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -288,7 +288,7 @@ async def get_backtests(session: Session = Depends(get_session)):
     summary="Fetch a backtest with every forecast inline",
 )
 async def get_backtest(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
-    """Load the complete backtest payload — every forecast row and the dataset's geojson — in one go.
+    """Load the complete backtest payload — every forecast row and the dataset's GeoJSON — in a single response.
 
     Use this when a client genuinely needs the whole evaluation (e.g. exporting it,
     rebuilding it offline). For listings or UI summaries, the cheaper ``/info`` or
@@ -412,7 +412,11 @@ async def create_backtest(
 async def delete_backtest(
     backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)
 ):
-    """Permanently delete a backtest and every forecast attached to it. Use this to clean up failed runs or evaluations you no longer want cluttering the listing. 404 if the id is unknown."""
+    """Permanently delete a backtest and every forecast attached to it.
+
+    Use this to clean up failed runs or evaluations that should no longer appear in the
+    listing. Returns 404 if the id is unknown.
+    """
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
         raise HTTPException(status_code=404, detail="Backtest not found")
@@ -432,10 +436,10 @@ async def update_backtest(
     backtest_update: BacktestUpdate,
     session: Session = Depends(get_session),
 ):
-    """Rename a backtest or tweak its mutable metadata without re-running the evaluation.
+    """Rename a backtest or update its mutable metadata without re-running the evaluation.
 
-    Only the fields you send are touched (semantically: ``exclude_unset``), so you can
-    safely PATCH a single attribute. Returns the refreshed metadata. 404 if the id is
+    Only the fields you send are touched (semantically: ``exclude_unset``), so it is
+    safe to PATCH a single attribute. Returns the refreshed metadata. 404 if the id is
     unknown.
     """
     db_backtest = session.get(Backtest, backtest_id)
@@ -519,10 +523,11 @@ async def delete_backtest_batch(ids: Annotated[str, Query(alias="ids")], session
     summary="Browse stored forecasts",
 )
 async def get_predictions(session: Session = Depends(get_session)):
-    """List every prediction whose configured model still exists, so you can pick a forecast to inspect, plot, push back into DHIS2, or delete.
+    """List every prediction whose configured model row still exists in the database, so you can pick a forecast to inspect, plot, push back into DHIS2, or delete.
 
-    Predictions whose configured model has been archived/deleted are filtered out — they
-    can no longer be re-run and would only confuse the listing.
+    Predictions whose configured model has been deleted outright are filtered out;
+    predictions whose configured model has only been archived (soft-deleted) still
+    appear, since the row is still resolvable.
     """
     session_wrapper = SessionWrapper(session=session)
     return [
@@ -644,11 +649,11 @@ async def create_dataset_csv(
     geojson_file: UploadFile = File(...),
     session: Session = Depends(get_session),
 ) -> DataBaseResponse:
-    """Upload a CSV of observations together with the matching geojson polygons (``NAME_1`` keyed) and persist it as a dataset synchronously.
+    """Upload a CSV of observations together with the matching GeoJSON polygons (``NAME_1`` keyed) and persist it as a dataset synchronously.
 
-    Use this when you have files in hand and don't want to round-trip them through
-    DHIS2 or the JSON import endpoints. Inserts inline — no background job — and
-    returns the new dataset id right away.
+    Use this when you have the files on disk and do not want to round-trip them
+    through DHIS2 or the JSON import endpoints. Inserts inline — no background job —
+    and returns the new dataset id immediately.
     """
     import io
 
@@ -665,10 +670,10 @@ async def create_dataset_csv(
 @router.get(
     "/datasets/{datasetId}/df",
     tags=["Datasets"],
-    summary="Read a dataset as dataframe-style JSON rows",
+    summary="Read a dataset as tabular JSON rows",
 )
 async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
-    """Get a dataset shaped as a list of JSON rows (one row per region and time period), the format pandas / Observable / any tabular tool wants to see.
+    """Get a dataset shaped as a list of JSON rows (one row per region and time period), in the form pandas, Observable, or any tabular tool can consume directly.
 
     Use this when a UI needs to render the dataset as a table, or when a notebook
     consumer wants to drop the result into ``pd.DataFrame``. Non-finite values come
@@ -746,9 +751,9 @@ async def delete_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], se
 async def list_model_templates(session: Session = Depends(get_session)):
     """List every model template that can be configured into a runnable model — including archived ones, so historical references stay resolvable.
 
-    Acts as the discovery endpoint: this is also where the chapkit v2 service registry
+    Acts as the discovery endpoint: it is also where the CHAPKit v2 service registry
     gets pulled in, so a template's ``health_status = "live"`` reflects whether the
-    backing chapkit service is currently registered. Stale chapkit templates whose
+    backing CHAPKit service is currently registered. Stale CHAPKit templates whose
     services have disappeared are auto-archived as a side effect.
     """
     live_ids = _sync_live_chapkit_services(session)
@@ -824,9 +829,9 @@ def add_configured_model(
     """Bind a model template together with user-chosen option values into a new, named configured model — the unit that backtests and predictions actually reference.
 
     Use this when an operator has filled out the configuration form for a template
-    (lags, precision, extra covariates, ...) and wants to save it. The new row inherits
-    whether the template came from a chapkit service. 404 if the template id is
-    unknown.
+    (lags, precision, extra covariates, ...) and wants to save it. The new row
+    inherits whether the template originated from a CHAPKit service. Returns 404 if
+    the template id is unknown.
     """
     session_wrapper = SessionWrapper(session=session)
     model_template_id = model_configuration.model_template_id
@@ -1048,13 +1053,13 @@ async def run_prediction_setup(
     database_url: str = Depends(get_database_url),
     worker_settings=Depends(get_settings),
 ):
-    """Fire a forecast from a saved setup using observations you ship in the body — the manual equivalent of what the cron schedule does automatically.
+    """Run a forecast from a saved setup using observations supplied directly in the request body — the manual equivalent of what the cron schedule does automatically.
 
-    Use this when you want to forecast ahead of the schedule (a new data drop arrived,
-    a model investigation, etc.). Returns a job id; track it via ``/v1/jobs/{id}`` or
-    filter the jobs list with ``predictionSetupId`` to see every job this setup has
-    launched. 404 if the setup is unknown, 409 if its configured model has been
-    archived, 422 if ``provided_data`` is empty.
+    Use this when you want to forecast ahead of the schedule (a new data drop has
+    arrived, a model investigation, etc.). Returns a job id; track it via
+    ``/v1/jobs/{id}`` or filter the jobs list with ``predictionSetupId`` to see every
+    job this setup has launched. Returns 404 if the setup is unknown, 409 if its
+    configured model has been archived, 422 if ``provided_data`` is empty.
     """
     try:
         setup = prediction_setup_service.get_prediction_setup(session, prediction_setup_id)

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -262,13 +262,14 @@ worker: CeleryPool[Any] = CeleryPool()
     "/backtests",
     response_model=list[BacktestRead],
     tags=["Backtests"],
-    summary="List all backtests",
+    summary="Browse stored evaluation runs",
 )  # This should be called list
 async def get_backtests(session: Session = Depends(get_session)):
-    """Return every backtest as a ``BacktestRead`` row with its dataset metadata and configured model embedded.
+    """List every stored backtest so you can pick one to view, compare against another, plot metrics from, or promote into a saved prediction setup.
 
-    The dataset's geojson is deferred (not loaded) to keep the response small; use
-    ``GET /v1/crud/backtests/{backtestId}/full`` if you need it.
+    Each entry carries enough metadata to identify it at a glance (dataset, model,
+    periods, regions) but not the raw forecasts — fetch those via
+    ``/backtests/{id}/full`` only when you actually need them.
     """
     backtests = session.exec(
         select(Backtest).options(
@@ -284,13 +285,14 @@ async def get_backtests(session: Session = Depends(get_session)):
     "/backtests/{backtestId}/full",
     response_model=Backtest,
     tags=["Backtests"],
-    summary="Get full backtest with forecasts",
+    summary="Fetch a backtest with every forecast inline",
 )
 async def get_backtest(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
-    """Return the full ``Backtest`` row including all forecasts and the dataset geojson.
+    """Load the complete backtest payload — every forecast row and the dataset's geojson — in one go.
 
-    Heavy payload - prefer ``/info`` or the plain id endpoint for listing. Returns 404 if
-    the backtest id is unknown.
+    Use this when a client genuinely needs the whole evaluation (e.g. exporting it,
+    rebuilding it offline). For listings or UI summaries, the cheaper ``/info`` or
+    ``/backtests/{id}`` variants are usually what you want. 404 if the id is unknown.
     """
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
@@ -302,20 +304,21 @@ async def get_backtest(backtest_id: Annotated[int, Path(alias="backtestId")], se
     "/backtests/{backtestId}/info",
     response_model=BacktestRead,
     tags=["Backtests"],
-    summary="Get backtest metadata with embedded relations",
+    summary="View one backtest's metadata",
 )
 @router.get(
     "/backtests/{backtestId}",
     response_model=BacktestRead,
     tags=["Backtests"],
-    summary="Get backtest metadata (alias of /info)",
+    summary="View one backtest's metadata (alias of /info)",
 )
 def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)):
-    """Return the ``BacktestRead`` row with its dataset and configured-model (incl. template) embedded.
+    """Read a single backtest's identifying information — name, dataset, configured model + template, the periods and regions it covers — without paying for the forecast payload.
 
-    Dataset geojson is deferred to keep the response small. Returns 404 if the backtest
-    id is unknown. ``/backtests/{backtestId}`` and ``/backtests/{backtestId}/info`` are
-    the same operation under two paths.
+    Use this for detail panes, breadcrumb headers, or anywhere a UI needs to render
+    "what is this backtest" without scrolling through forecasts. Both
+    ``/backtests/{id}`` and ``/backtests/{id}/info`` resolve to this same operation;
+    fetch ``/full`` if you also want the forecasts. 404 if the id is unknown.
     """
     backtest = session.exec(
         select(Backtest)
@@ -334,18 +337,19 @@ def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], ses
 @router.get(
     "/metric/csv",
     tags=["Metrics"],
-    summary="Download per-location/period/horizon metrics for a backtest as CSV",
+    summary="Export backtest metrics for offline analysis",
 )
 async def get_metrics_csv(
     backtest_id: Annotated[int, Query(alias="backtestId")],
     session: Session = Depends(get_session),
 ):
-    """Stream a long-format CSV with one row per (location, time_period, horizon, metric) tuple.
+    """Download every scoring metric computed for a backtest as a CSV, broken down by region, time period, and forecast horizon.
 
-    Every metric in ``chap_core.assessment.metrics.available_metrics`` contributes rows.
-    Currently takes a single backtest via the ``backtestId`` query parameter; the path is
-    scoped to ``/metric/`` so it can be extended to accept multiple evaluations later
-    without a breaking change. Returns 404 if the backtest is unknown.
+    Use this when you want to pull metrics into pandas, Excel, or BI tooling for
+    analysis the built-in plots don't cover — for example comparing several backtests
+    side by side, or weighting locations differently. The path is scoped to ``/metric/``
+    so it can be extended to multi-backtest exports later without breaking callers.
+    404 if the backtest is unknown.
     """
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
@@ -367,18 +371,19 @@ async def get_metrics_csv(
     "/backtests",
     response_model=JobResponse,
     tags=["Backtests"],
-    summary="Queue a backtest job against a stored dataset",
+    summary="Run a backtest against a stored dataset (legacy)",
 )
 async def create_backtest(
     backtest: BacktestCreate,
     database_url: str = Depends(get_database_url),
     session: Session = Depends(get_session),
 ):
-    """Queue a legacy-style backtest job; returns the job id (poll ``GET /v1/jobs/{id}`` for status).
+    """Legacy entrypoint for queueing a backtest against an already-imported dataset; prefer ``POST /v1/analytics/create-backtest`` for new integrations.
 
-    ``BacktestCreate.model_id`` accepts either the configured-model name or its integer
-    primary key; the worker resolves it. Returns 404 if the referenced dataset does not
-    exist.
+    Accepts the model reference either as the configured-model name or its integer id —
+    the worker resolves both. Backtest runs in the background; the response gives a job
+    id, poll ``/v1/jobs/{id}`` (or ``/v1/jobs/{id}/evaluation_result``) for the
+    finished result. 404 if the dataset does not exist.
     """
     # `BacktestCreate.model_id` accepts either the configured-model name
     # (what the DB column actually stores) or the integer primary key (what
@@ -402,12 +407,12 @@ async def create_backtest(
 @router.delete(
     "/backtests/{backtestId}",
     tags=["Backtests"],
-    summary="Delete a backtest",
+    summary="Remove an evaluation run",
 )
 async def delete_backtest(
     backtest_id: Annotated[int, Path(alias="backtestId")], session: Session = Depends(get_session)
 ):
-    """Delete the backtest row (and its forecasts via cascade). Returns 404 if the id is unknown."""
+    """Permanently delete a backtest and every forecast attached to it. Use this to clean up failed runs or evaluations you no longer want cluttering the listing. 404 if the id is unknown."""
     backtest = session.get(Backtest, backtest_id)
     if backtest is None:
         raise HTTPException(status_code=404, detail="Backtest not found")
@@ -420,17 +425,18 @@ async def delete_backtest(
     "/backtests/{backtestId}",
     response_model=BacktestRead,
     tags=["Backtests"],
-    summary="Partially update a backtest",
+    summary="Edit a backtest's editable fields",
 )
 async def update_backtest(
     backtest_id: Annotated[int, Path(alias="backtestId")],
     backtest_update: BacktestUpdate,
     session: Session = Depends(get_session),
 ):
-    """Apply the provided fields to the backtest and return the refreshed ``BacktestRead`` with embedded relations.
+    """Rename a backtest or tweak its mutable metadata without re-running the evaluation.
 
-    Only fields explicitly set on the request body are updated (``exclude_unset``).
-    Returns 404 if the id is unknown.
+    Only the fields you send are touched (semantically: ``exclude_unset``), so you can
+    safely PATCH a single attribute. Returns the refreshed metadata. 404 if the id is
+    unknown.
     """
     db_backtest = session.get(Backtest, backtest_id)
     if not db_backtest:
@@ -459,13 +465,14 @@ async def update_backtest(
 @router.delete(
     "/backtests",
     tags=["Backtests"],
-    summary="Delete multiple backtests by id",
+    summary="Bulk-remove several evaluation runs",
 )
 async def delete_backtest_batch(ids: Annotated[str, Query(alias="ids")], session: Session = Depends(get_session)):
-    """Delete every backtest in the comma-separated ``ids`` query parameter and return the deleted count.
+    """Permanently delete several backtests in one round-trip — pass their ids as a comma-separated ``ids`` query string.
 
-    Unknown ids are silently skipped (only the count of actual deletions is returned).
-    Returns 400 if ``ids`` is empty, blank, or contains a non-integer segment.
+    Useful for bulk cleanup from a UI's multi-select. Unknown ids are silently skipped;
+    the response only reports how many rows actually went away. 400 if ``ids`` is empty
+    or contains a non-integer segment.
     """
     deleted_count = 0
     backtest_ids_list = []
@@ -509,12 +516,13 @@ async def delete_backtest_batch(ids: Annotated[str, Query(alias="ids")], session
     "/predictions",
     response_model=list[PredictionInfo],
     tags=["Predictions"],
-    summary="List predictions with a configured model",
+    summary="Browse stored forecasts",
 )
 async def get_predictions(session: Session = Depends(get_session)):
-    """Return every prediction whose configured model still exists, as ``PredictionInfo`` rows.
+    """List every prediction whose configured model still exists, so you can pick a forecast to inspect, plot, push back into DHIS2, or delete.
 
-    Predictions whose configured model was deleted are filtered out.
+    Predictions whose configured model has been archived/deleted are filtered out — they
+    can no longer be re-run and would only confuse the listing.
     """
     session_wrapper = SessionWrapper(session=session)
     return [
@@ -526,12 +534,16 @@ async def get_predictions(session: Session = Depends(get_session)):
     "/predictions/{predictionId}",
     response_model=PredictionInfo,
     tags=["Predictions"],
-    summary="Get a prediction",
+    summary="View one forecast's metadata",
 )
 async def get_prediction(
     prediction_id: Annotated[int, Path(alias="predictionId")], session: Session = Depends(get_session)
 ):
-    """Return the ``PredictionInfo`` row for the given id. Returns 404 if unknown."""
+    """Read the identifying information for a single prediction — the model and dataset behind it, when it ran, what periods it covers — without pulling the forecast values themselves.
+
+    Use ``GET /v1/analytics/prediction-entry/{id}`` once you actually need quantiles to
+    plot. 404 if the id is unknown.
+    """
     prediction = session.get(Prediction, prediction_id)
     if prediction is None:
         raise HTTPException(status_code=404, detail="Prediction not found")
@@ -541,12 +553,12 @@ async def get_prediction(
 @router.delete(
     "/predictions/{predictionId}",
     tags=["Predictions"],
-    summary="Delete a prediction",
+    summary="Remove a forecast",
 )
 async def delete_prediction(
     prediction_id: Annotated[int, Path(alias="predictionId")], session: Session = Depends(get_session)
 ):
-    """Delete the prediction row (and its forecasts via cascade). Returns 404 if the id is unknown."""
+    """Permanently delete a prediction and every forecast row it contains. Use this to clean up obsolete or test forecasts from the listing. 404 if the id is unknown."""
     prediction = session.get(Prediction, prediction_id)
     if prediction is None:
         raise HTTPException(status_code=404, detail="Prediction not found")
@@ -563,10 +575,10 @@ async def delete_prediction(
     "/datasets",
     response_model=list[DataSetInfo],
     tags=["Datasets"],
-    summary="List datasets",
+    summary="Browse imported datasets",
 )
 async def get_datasets(session: Session = Depends(get_session)):
-    """Return every dataset as a ``DataSetInfo`` row (metadata only, no observations)."""
+    """List every imported dataset so you can pick one to back a backtest, run a prediction, or inspect its contents — metadata only, no observations inline."""
     datasets = session.exec(select(DataSet)).all()
     return datasets
 
@@ -575,13 +587,14 @@ async def get_datasets(session: Session = Depends(get_session)):
     "/datasets/{datasetId}",
     response_model=DataSetWithObservations,
     tags=["Datasets"],
-    summary="Get a dataset with observations",
+    summary="Inspect a dataset's observations",
 )
 async def get_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
-    """Return the dataset with all its observations embedded.
+    """Load a dataset together with every observation it contains, so you can audit what was imported or re-export it.
 
-    Non-finite observation values are coerced to ``null`` so the response is JSON-safe.
-    Returns 404 if the dataset id is unknown.
+    NaN/inf values are coerced to JSON ``null`` so the response is always parseable.
+    Heavier than the listing — for casual browsing, prefer ``/datasets``. 404 if the id
+    is unknown.
     """
     # dataset = session.exec(select(DataSet).where(DataSet.id == dataset_id)).first()
     dataset = session.get(DataSet, dataset_id)
@@ -596,14 +609,18 @@ async def get_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], sessi
 @router.post(
     "/datasets",
     tags=["Datasets"],
-    summary="Queue a dataset import from observations + geojson",
+    summary="Import a health-only dataset",
 )
 async def create_dataset(
     data: DatasetCreate, datababase_url=Depends(get_database_url), worker_settings=Depends(get_settings)
 ) -> JobResponse:
-    """Queue a harmonize-and-import job for health/population observations with attached polygons.
+    """Import a dataset that carries just disease cases and population (no climate covariates inline), with polygons attached.
 
-    Returns the queued job id; poll ``GET /v1/jobs/{id}`` for status.
+    Climate or other covariates are layered on later by the modelling pipeline.
+    Importing runs in the background; you get a job id and poll ``/v1/jobs/{id}``
+    (or ``/v1/jobs/{id}/database_result`` once finished) for the resulting dataset id.
+    For a dataset that ships its own covariates, use ``POST /v1/analytics/make-dataset``
+    instead.
     """
     health_data = observations_to_dataset(HealthPopulationData, data.observations, fill_missing=True)
     health_data.set_polygons(FeatureCollectionModel.model_validate(data.geojson))
@@ -620,18 +637,18 @@ async def create_dataset(
 @router.post(
     "/datasets/csvFile",
     tags=["Datasets"],
-    summary="Create a dataset from an uploaded CSV + geojson",
+    summary="Import a dataset from a CSV + geojson upload",
 )
 async def create_dataset_csv(
     csv_file: UploadFile = File(...),
     geojson_file: UploadFile = File(...),
     session: Session = Depends(get_session),
 ) -> DataBaseResponse:
-    """Import a CSV of observations and its companion geojson directly (synchronously) into the DB.
+    """Upload a CSV of observations together with the matching geojson polygons (``NAME_1`` keyed) and persist it as a dataset synchronously.
 
-    Unlike ``POST /v1/crud/datasets``, this endpoint inserts the dataset inline and
-    returns the new dataset id immediately - no job is queued. Polygons are keyed by the
-    ``NAME_1`` property.
+    Use this when you have files in hand and don't want to round-trip them through
+    DHIS2 or the JSON import endpoints. Inserts inline — no background job — and
+    returns the new dataset id right away.
     """
     import io
 
@@ -648,13 +665,14 @@ async def create_dataset_csv(
 @router.get(
     "/datasets/{datasetId}/df",
     tags=["Datasets"],
-    summary="Get a dataset as JSON records",
+    summary="Read a dataset as dataframe-style JSON rows",
 )
 async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
-    """Return the dataset as a list of JSON records, one per (location, period) row.
+    """Get a dataset shaped as a list of JSON rows (one row per region and time period), the format pandas / Observable / any tabular tool wants to see.
 
-    Non-finite numeric values are emitted as JSON ``null`` so the response parses cleanly.
-    Returns 404 if the dataset id is unknown.
+    Use this when a UI needs to render the dataset as a table, or when a notebook
+    consumer wants to drop the result into ``pd.DataFrame``. Non-finite values come
+    through as JSON ``null``. 404 if the dataset id is unknown.
     """
     if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
@@ -676,10 +694,14 @@ async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], se
 @router.get(
     "/datasets/{datasetId}/csv",
     tags=["Datasets"],
-    summary="Download a dataset as CSV",
+    summary="Export a dataset as a CSV download",
 )
 async def get_dataset_csv(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
-    """Stream the dataset as a CSV attachment, one row per (location, time_period) tuple. Returns 404 if unknown."""
+    """Download a dataset as a CSV file — one row per region and time period.
+
+    Use this when a user wants to pull the imported data out for use in Excel, R,
+    pandas, or any other offline tool. 404 if the dataset id is unknown.
+    """
     if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
     sw = SessionWrapper(session=session)
@@ -698,10 +720,10 @@ async def get_dataset_csv(dataset_id: Annotated[int, Path(alias="datasetId")], s
 @router.delete(
     "/datasets/{datasetId}",
     tags=["Datasets"],
-    summary="Delete a dataset",
+    summary="Remove an imported dataset",
 )
 async def delete_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
-    """Delete the dataset row and its observations via cascade. Returns 404 if the id is unknown."""
+    """Permanently delete a dataset and every observation in it. Use this to clean up obsolete imports — be aware that backtests and predictions that referenced this dataset will lose their data link. 404 if the id is unknown."""
     # dataset = session.exec(select(DataSet).where(DataSet.id == dataset_id)).first()
     dataset = session.get(DataSet, dataset_id)
     if dataset is None:
@@ -719,14 +741,15 @@ async def delete_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], se
     "/model-templates",
     response_model=list[ModelTemplateRead],
     tags=["Models"],
-    summary="List model templates (and sync live chapkit services)",
+    summary="Browse available model templates",
 )
 async def list_model_templates(session: Session = Depends(get_session)):
-    """Return every model template (including archived) and side-effect a chapkit registry sync.
+    """List every model template that can be configured into a runnable model — including archived ones, so historical references stay resolvable.
 
-    Before returning, live chapkit services from the v2 service registry are upserted by
-    name into the DB and stale chapkit templates are archived. Templates whose live
-    counterpart is currently registered carry ``health_status = "live"``.
+    Acts as the discovery endpoint: this is also where the chapkit v2 service registry
+    gets pulled in, so a template's ``health_status = "live"`` reflects whether the
+    backing chapkit service is currently registered. Stale chapkit templates whose
+    services have disappeared are auto-archived as a side effect.
     """
     live_ids = _sync_live_chapkit_services(session)
     model_templates = session.exec(select(ModelTemplateDB)).all()
@@ -748,10 +771,15 @@ async def list_model_templates(session: Session = Depends(get_session)):
     "/configured-models",
     response_model=list[ModelSpecRead],
     tags=["Models"],
-    summary="List configured models",
+    summary="Browse configured (ready-to-run) models",
 )
 def list_configured_models(session: Session = Depends(get_session)):
-    """Return every configured model as a ``ModelSpecRead`` row (config + template metadata)."""
+    """List every configured model — a template + user-chosen options bundled into something you can actually run.
+
+    Use this to populate model pickers in backtest / prediction creation flows. Each
+    entry carries the configuration values along with template metadata so you can
+    surface "Model X (CRPS-tuned, 12 lags, ERA5)" or similar in a UI.
+    """
     configured_models_read = SessionWrapper(session=session).get_configured_models()
 
     # return
@@ -762,16 +790,16 @@ def list_configured_models(session: Session = Depends(get_session)):
     "/configured-models/{configuredModelId}",
     response_model=ConfiguredModelInfoRead,
     tags=["Models"],
-    summary="Get a configured model with its template",
+    summary="View one configured model with its template",
 )
 @api_experimental
 def get_configured_model_info(
     configured_model_id: Annotated[int, Path(alias="configuredModelId")],
     session: Session = Depends(get_session),
 ):
-    """Return the detail view for a single configured model with the model template eagerly loaded.
+    """Look up a configured model together with the template it came from — the data you need to render a model detail pane (name, configuration values, covariates, version, ...).
 
-    Returns 404 if the id is unknown.
+    404 if the id is unknown.
     """
     configured_model = session.exec(
         select(ConfiguredModelDB)
@@ -787,16 +815,18 @@ def get_configured_model_info(
     "/configured-models",
     response_model=ConfiguredModelDB,
     tags=["Models"],
-    summary="Create a configured model from a template",
+    summary="Configure a template into a runnable model",
 )
 def add_configured_model(
     model_configuration: ModelConfigurationCreate,
     session: Session = Depends(get_session),
 ):
-    """Persist a new configured model bound to an existing model template, inheriting ``uses_chapkit``.
+    """Bind a model template together with user-chosen option values into a new, named configured model — the unit that backtests and predictions actually reference.
 
-    Returns the freshly-inserted ``ConfiguredModelDB`` row. Returns 404 if the referenced
-    model template does not exist.
+    Use this when an operator has filled out the configuration form for a template
+    (lags, precision, extra covariates, ...) and wants to save it. The new row inherits
+    whether the template came from a chapkit service. 404 if the template id is
+    unknown.
     """
     session_wrapper = SessionWrapper(session=session)
     model_template_id = model_configuration.model_template_id
@@ -821,14 +851,15 @@ def add_configured_model(
 @router.delete(
     "/configured-models/{configuredModelId}",
     tags=["Models"],
-    summary="Archive (soft-delete) a configured model",
+    summary="Retire a configured model",
 )
 async def delete_configured_model(
     configured_model_id: Annotated[int, Path(alias="configuredModelId")], session: Session = Depends(get_session)
 ):
-    """Soft-delete the configured model by flipping its ``archived`` flag to ``True``; the row is preserved.
+    """Soft-delete a configured model so it stops showing up in pickers, while keeping the underlying row intact so historical backtests / predictions that reference it still resolve.
 
-    Returns 404 if the id is unknown.
+    The row stays in the database with ``archived=True``; existing references remain
+    valid. 404 if the id is unknown.
     """
     configured_model = session.get(ConfiguredModelDB, configured_model_id)
     if configured_model is None:
@@ -847,15 +878,16 @@ async def delete_configured_model(
     "/prediction-setups",
     response_model=DataBaseResponse,
     tags=["Prediction Setups"],
-    summary="Create a prediction setup from a backtest",
+    summary="Promote a backtest into a reusable prediction config",
 )
 @api_experimental
 async def create_prediction_setup(request: PredictionSetupCreate, session: Session = Depends(get_session)):
-    """Create a reusable ``PredictionSetup`` bound 1-to-1 to a backtest, with an optional cron schedule and quantile targets.
+    """Save a backtest as a prediction setup — a named configuration you can rerun on fresh data, either ad-hoc via ``/run`` or on a cron schedule.
 
-    Returns the new setup id wrapped in a ``DataBaseResponse``. Returns 404 if the
-    referenced backtest is missing, 409 if a setup for that backtest already exists, and
-    422 if the cron expression or quantile targets are invalid.
+    Use this after evaluating a model on historical data and deciding it's good enough
+    to operationalise. A backtest can back at most one setup (1-to-1 link). 404 if the
+    backtest is missing, 409 if it already has a setup, 422 if the cron expression or
+    quantile targets are malformed.
     """
     try:
         setup = prediction_setup_service.create_prediction_setup(
@@ -881,11 +913,16 @@ async def create_prediction_setup(request: PredictionSetupCreate, session: Sessi
     "/prediction-setups",
     response_model=list[PredictionSetupRead],
     tags=["Prediction Setups"],
-    summary="List prediction setups",
+    summary="Browse saved prediction setups",
 )
 @api_experimental
 async def list_prediction_setups(session: Session = Depends(get_session)):
-    """Return every ``PredictionSetup`` as a ``PredictionSetupRead`` row, without nested predictions."""
+    """List every prediction setup so you can manage them, run them ad-hoc, or check which backtests have been promoted into a recurring forecast.
+
+    Lightweight listing: each entry carries the setup's schedule, target backtest, and
+    quantile config, but not the predictions it has produced. Fetch a single setup by
+    id to get those.
+    """
     return prediction_setup_service.list_prediction_setups(session)
 
 
@@ -893,16 +930,16 @@ async def list_prediction_setups(session: Session = Depends(get_session)):
     "/prediction-setups/{predictionSetupId}",
     response_model=PredictionSetupReadWithPredictions,
     tags=["Prediction Setups"],
-    summary="Get a prediction setup with its predictions",
+    summary="View a prediction setup with its forecast history",
 )
 @api_experimental
 async def get_prediction_setup(
     prediction_setup_id: Annotated[int, Path(alias="predictionSetupId")],
     session: Session = Depends(get_session),
 ):
-    """Return the ``PredictionSetup`` with every related prediction (and its dataset metadata) embedded.
+    """Read a setup's configuration alongside every prediction it has produced, so a UI can show "what does this setup do" and "what has it actually forecast" on the same page.
 
-    Returns 404 if the id is unknown.
+    404 if the id is unknown.
     """
     try:
         return prediction_setup_service.get_prediction_setup(session, prediction_setup_id, include_predictions=True)
@@ -914,7 +951,7 @@ async def get_prediction_setup(
     "/prediction-setups/{predictionSetupId}",
     response_model=PredictionSetupRead,
     tags=["Prediction Setups"],
-    summary="Partially update a prediction setup",
+    summary="Tweak a prediction setup's schedule or targets",
 )
 @api_experimental
 async def update_prediction_setup(
@@ -922,10 +959,10 @@ async def update_prediction_setup(
     request: PredictionSetupUpdate,
     session: Session = Depends(get_session),
 ):
-    """Apply the provided fields (cron schedule, enabled flag, quantile targets, ...) and return the refreshed setup.
+    """Adjust a setup without recreating it — pause or resume the schedule, change the cron expression, swap quantile targets, rename it.
 
-    Only fields explicitly set on the request body are updated (``exclude_unset``).
-    Returns 404 if the id is unknown and 422 if the new values fail validation.
+    Only the fields you actually send are touched, so partial updates are safe. 404 if
+    the id is unknown, 422 if the new values are malformed.
     """
     update_data = request.model_dump(exclude_unset=True, by_alias=False)
     try:
@@ -970,19 +1007,20 @@ def _cancel_jobs_for_prediction_setup(prediction_setup_id: int) -> None:
 @router.delete(
     "/prediction-setups/{predictionSetupId}",
     tags=["Prediction Setups"],
-    summary="Delete a prediction setup",
+    summary="Retire a prediction setup",
 )
 @api_experimental
 async def delete_prediction_setup(
     prediction_setup_id: Annotated[int, Path(alias="predictionSetupId")],
     session: Session = Depends(get_session),
 ):
-    """Cancel in-flight jobs tagged with this setup id, clear their Redis metadata, then delete the setup row.
+    """Stop a setup from ever running again — cancels any in-flight jobs it has launched, then removes the setup row.
 
-    Cancelling jobs first prevents a still-running prediction job from writing
-    ``Prediction.prediction_setup_id=<deleted_id>`` and tripping the FK constraint.
-    Returns 404 if the id is unknown and 503 if Redis is unreachable (the FK invariant
-    cannot be guaranteed in that case).
+    Use this when a forecast workflow is being decommissioned. Cancellation of running
+    jobs is essential here: a still-running job would otherwise try to write a
+    foreign-key link to a deleted setup and crash. 404 if the id is unknown; 503 if
+    Redis is unreachable (we can't safely cancel jobs in that case so the delete is
+    refused).
     """
     # Verify existence first so a 404 doesn't waste a Redis sweep, then cancel in-flight
     # jobs BEFORE the DB delete — otherwise a still-running job would try to write
@@ -1000,7 +1038,7 @@ async def delete_prediction_setup(
     "/prediction-setups/{predictionSetupId}/run",
     response_model=JobResponse,
     tags=["Prediction Setups"],
-    summary="Queue a prediction job from a prediction setup",
+    summary="Run a prediction setup against fresh observations",
 )
 @api_experimental
 async def run_prediction_setup(
@@ -1010,12 +1048,13 @@ async def run_prediction_setup(
     database_url: str = Depends(get_database_url),
     worker_settings=Depends(get_settings),
 ):
-    """Validate provided observations, attach polygons, and queue a prediction job using the setup's configured model.
+    """Fire a forecast from a saved setup using observations you ship in the body — the manual equivalent of what the cron schedule does automatically.
 
-    Returns the queued job id; poll ``GET /v1/jobs/{id}`` for status (and filter the
-    jobs list with ``predictionSetupId`` to find jobs tied to this setup). Returns 404
-    if the setup is unknown, 409 if its configured model is archived, 422 if
-    ``provided_data`` is empty, and 500 if the setup has no configured model.
+    Use this when you want to forecast ahead of the schedule (a new data drop arrived,
+    a model investigation, etc.). Returns a job id; track it via ``/v1/jobs/{id}`` or
+    filter the jobs list with ``predictionSetupId`` to see every job this setup has
+    launched. 404 if the setup is unknown, 409 if its configured model has been
+    archived, 422 if ``provided_data`` is empty.
     """
     try:
         setup = prediction_setup_service.get_prediction_setup(session, prediction_setup_id)

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -30,13 +30,14 @@ router = APIRouter(prefix="/visualization", tags=["Visualizations"])
 @router.get(
     "/metric-plots/{backtest_id}",
     response_model=list[VisualizationInfo],
-    summary="List available metric plot types",
+    summary="Discover which metric plots are available",
 )
 def get_avilable_metric_plots(backtest_id: int):
-    """Return every metric-plot visualization registered in the metric-plots registry.
+    """List the metric-plot styles you can render against a backtest's forecasts (line chart of CRPS over time, choropleth of MAE, ...).
 
-    The ``backtest_id`` is accepted for symmetry with the per-plot endpoint but does not
-    filter the result; the list is the same for every backtest.
+    Use this to populate a plot picker in a UI or to find out which
+    ``/metric-plots/{name}/...`` URLs are valid. The result is the same regardless of
+    ``backtest_id`` — the path takes it for symmetry with the render endpoint.
     """
     return [
         VisualizationInfo(id=p["id"], display_name=p["name"], description=p["description"]) for p in list_metric_plots()
@@ -56,13 +57,14 @@ class MetricInfo(DBModel):
 @router.get(
     "/metrics/{backtest_id}",
     response_model=list[MetricInfo],
-    summary="List available metrics for a backtest",
+    summary="Discover which scoring metrics are available",
 )
 def get_available_metrics(backtest_id: int):
-    """Return every metric registered in ``available_metrics`` that can be applied to the given backtest.
+    """List the metrics you can score a backtest with (CRPS, MAE, ...), with a human-friendly name and description for each.
 
-    All metrics support detailed-level visualization. The ``backtest_id`` is accepted for
-    symmetry with the per-metric plot endpoint but does not filter the result.
+    Use this to populate a metric picker in a UI before requesting a specific plot. The
+    result is the same regardless of ``backtest_id`` — the path takes it for symmetry
+    with the render endpoint.
     """
     logger.info(f"Getting available metrics for backtest {backtest_id}")
     logger.info(f"Available metrics: {available_metrics.keys()}")
@@ -83,11 +85,11 @@ def get_available_metrics(backtest_id: int):
 def generate_visualization(
     visualization_name: str, backtest_id: int, metric_id: str, session: Session = Depends(get_session)
 ):
-    """Compute the named metric across the backtest forecasts and render it with the named plot.
+    """Score a backtest with the chosen metric (CRPS, MAE, ...) and render the result as the chosen plot style.
 
-    Returns the plot specification as a JSON response (Vega/Vega-Lite shape, depending on
-    the plot class). Returns 404 if the backtest or visualization is unknown, and 400 if
-    the metric id is not registered.
+    The response is a Vega/Vega-Lite spec you can hand straight to a frontend renderer.
+    404 if the backtest or plot style is unknown; 400 if the metric id is not one of the
+    registered metrics.
     """
     backtest = session.get(Backtest, backtest_id)
     if not backtest:
@@ -117,10 +119,14 @@ class DatasetPlotType(DBModel):
 @router.get(
     "/dataset-plots/",
     response_model=list[DatasetPlotType],
-    summary="List available dataset plot types",
+    summary="Discover which dataset plots are available",
 )
 def list_dataset_plot_types():
-    """Return every dataset-plot visualization registered in the dataset-plots registry."""
+    """List the visualizations you can render against an imported dataset (observation time-series per region, polygon overlays, ...).
+
+    Use this to populate a plot picker before requesting a specific
+    ``/dataset-plots/{name}/{datasetId}`` URL.
+    """
     plots = list_dataset_plots()
     return [
         DatasetPlotType(id=plot["id"], display_name=plot["name"], description=plot["description"]) for plot in plots
@@ -129,13 +135,13 @@ def list_dataset_plot_types():
 
 @router.get(
     "/dataset-plots/{visualization_name}/{dataset_id}",
-    summary="Render a dataset plot",
+    summary="Render a plot of a dataset",
 )
 def generate_data_plots(visualization_name: str, dataset_id: int, session: Session = Depends(get_session)):
-    """Render the named dataset visualization for the given dataset and return the plot specification as JSON.
+    """Render the chosen visualization for a dataset — used to inspect observations before training, spot gaps in the data, or share a quick view of what got imported.
 
-    Returns 404 if the dataset or visualization is unknown; the error message lists the
-    registered visualization ids.
+    The response is a JSON plot spec the frontend can render directly. 404 if the
+    dataset or plot style is unknown; the error message lists the registered styles.
     """
     registry = get_dataset_plots_registry()
     if visualization_name not in registry:
@@ -161,10 +167,14 @@ class BacktestPlotType(DBModel):
 @router.get(
     "/backtest-plots/",
     response_model=list[BacktestPlotType],
-    summary="List available backtest plot types",
+    summary="Discover which backtest plots are available",
 )
 def list_backtest_plot_types():
-    """Return every backtest-plot visualization registered in the backtest-plots registry."""
+    """List the visualizations you can render against a backtest's forecasts (forecast vs. actuals per region, calibration plots, ...).
+
+    Use this to populate a plot picker before requesting a specific
+    ``/backtest-plots/{name}/{backtestId}`` URL.
+    """
     plots = list_backtest_plots()
     return [
         BacktestPlotType(id=plot["id"], display_name=plot["name"], description=plot["description"]) for plot in plots
@@ -173,13 +183,13 @@ def list_backtest_plot_types():
 
 @router.get(
     "/backtest-plots/{visualization_name}/{backtest_id}",
-    summary="Render a backtest plot",
+    summary="Render a forecast plot for a backtest",
 )
 def generate_backtest_plots(visualization_name: str, backtest_id: int, session: Session = Depends(get_session)):
-    """Render the named backtest visualization for the given backtest and return the Vega plot specification as JSON.
+    """Render the chosen visualization for a backtest's forecasts — used to eyeball model performance, find regions where forecasts diverge from actuals, or share an evaluation result.
 
-    Returns 404 if the backtest or visualization is unknown; the error message lists the
-    registered visualization ids.
+    The response is a Vega plot spec the frontend can render directly. 404 if the
+    backtest or plot style is unknown; the error message lists the registered styles.
     """
     registry = get_backtest_plots_registry()
     if visualization_name not in registry:

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -186,10 +186,11 @@ def list_backtest_plot_types():
     summary="Render a forecast plot for a backtest",
 )
 def generate_backtest_plots(visualization_name: str, backtest_id: int, session: Session = Depends(get_session)):
-    """Render the chosen visualization for a backtest's forecasts — used to eyeball model performance, find regions where forecasts diverge from actuals, or share an evaluation result.
+    """Render the chosen visualization for a backtest's forecasts — used to assess model performance, identify regions where forecasts diverge from actuals, or share an evaluation result.
 
-    The response is a Vega plot spec the frontend can render directly. 404 if the
-    backtest or plot style is unknown; the error message lists the registered styles.
+    The response is a Vega plot spec the frontend can render directly. Returns 404 if
+    the backtest or plot style is unknown; the error message lists the registered
+    styles.
     """
     registry = get_backtest_plots_registry()
     if visualization_name not in registry:

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -27,11 +27,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/visualization", tags=["Visualizations"])
 
 
-# List visualizations
-@router.get("/metric-plots/{backtest_id}", response_model=list[VisualizationInfo])
+@router.get(
+    "/metric-plots/{backtest_id}",
+    response_model=list[VisualizationInfo],
+    summary="List available metric plot types",
+)
 def get_avilable_metric_plots(backtest_id: int):
-    """
-    List available visualizations
+    """Return every metric-plot visualization registered in the metric-plots registry.
+
+    The ``backtest_id`` is accepted for symmetry with the per-plot endpoint but does not
+    filter the result; the list is the same for every backtest.
     """
     return [
         VisualizationInfo(id=p["id"], display_name=p["name"], description=p["description"]) for p in list_metric_plots()
@@ -48,12 +53,16 @@ class MetricInfo(DBModel):
     description: str = ""
 
 
-@router.get("/metrics/{backtest_id}", response_model=list[MetricInfo])
+@router.get(
+    "/metrics/{backtest_id}",
+    response_model=list[MetricInfo],
+    summary="List available metrics for a backtest",
+)
 def get_available_metrics(backtest_id: int):
-    """
-    List available metrics for visualization.
+    """Return every metric registered in ``available_metrics`` that can be applied to the given backtest.
 
-    All metrics support detailed level visualization.
+    All metrics support detailed-level visualization. The ``backtest_id`` is accepted for
+    symmetry with the per-metric plot endpoint but does not filter the result.
     """
     logger.info(f"Getting available metrics for backtest {backtest_id}")
     logger.info(f"Available metrics: {available_metrics.keys()}")
@@ -67,10 +76,19 @@ def get_available_metrics(backtest_id: int):
     ]
 
 
-@router.get("/metric-plots/{visualization_name}/{backtest_id}/{metric_id}")
+@router.get(
+    "/metric-plots/{visualization_name}/{backtest_id}/{metric_id}",
+    summary="Render a metric plot for a backtest",
+)
 def generate_visualization(
     visualization_name: str, backtest_id: int, metric_id: str, session: Session = Depends(get_session)
 ):
+    """Compute the named metric across the backtest forecasts and render it with the named plot.
+
+    Returns the plot specification as a JSON response (Vega/Vega-Lite shape, depending on
+    the plot class). Returns 404 if the backtest or visualization is unknown, and 400 if
+    the metric id is not registered.
+    """
     backtest = session.get(Backtest, backtest_id)
     if not backtest:
         raise HTTPException(status_code=404, detail="Backtest not found")
@@ -96,16 +114,29 @@ class DatasetPlotType(DBModel):
     description: str = ""
 
 
-@router.get("/dataset-plots/", response_model=list[DatasetPlotType])
+@router.get(
+    "/dataset-plots/",
+    response_model=list[DatasetPlotType],
+    summary="List available dataset plot types",
+)
 def list_dataset_plot_types():
+    """Return every dataset-plot visualization registered in the dataset-plots registry."""
     plots = list_dataset_plots()
     return [
         DatasetPlotType(id=plot["id"], display_name=plot["name"], description=plot["description"]) for plot in plots
     ]
 
 
-@router.get("/dataset-plots/{visualization_name}/{dataset_id}")
+@router.get(
+    "/dataset-plots/{visualization_name}/{dataset_id}",
+    summary="Render a dataset plot",
+)
 def generate_data_plots(visualization_name: str, dataset_id: int, session: Session = Depends(get_session)):
+    """Render the named dataset visualization for the given dataset and return the plot specification as JSON.
+
+    Returns 404 if the dataset or visualization is unknown; the error message lists the
+    registered visualization ids.
+    """
     registry = get_dataset_plots_registry()
     if visualization_name not in registry:
         available = ", ".join(registry.keys())
@@ -127,16 +158,29 @@ class BacktestPlotType(DBModel):
     description: str = ""
 
 
-@router.get("/backtest-plots/", response_model=list[BacktestPlotType])
+@router.get(
+    "/backtest-plots/",
+    response_model=list[BacktestPlotType],
+    summary="List available backtest plot types",
+)
 def list_backtest_plot_types():
+    """Return every backtest-plot visualization registered in the backtest-plots registry."""
     plots = list_backtest_plots()
     return [
         BacktestPlotType(id=plot["id"], display_name=plot["name"], description=plot["description"]) for plot in plots
     ]
 
 
-@router.get("/backtest-plots/{visualization_name}/{backtest_id}")
+@router.get(
+    "/backtest-plots/{visualization_name}/{backtest_id}",
+    summary="Render a backtest plot",
+)
 def generate_backtest_plots(visualization_name: str, backtest_id: int, session: Session = Depends(get_session)):
+    """Render the named backtest visualization for the given backtest and return the Vega plot specification as JSON.
+
+    Returns 404 if the backtest or visualization is unknown; the error message lists the
+    registered visualization ids.
+    """
     registry = get_backtest_plots_registry()
     if visualization_name not in registry:
         available = ", ".join(registry.keys())

--- a/chap_core/rest_api/v2/routers/services.py
+++ b/chap_core/rest_api/v2/routers/services.py
@@ -22,7 +22,7 @@ router = APIRouter(prefix="/services", tags=["Services"])
 @router.post(
     "/$register",
     response_model=RegistrationResponse,
-    summary="Register a chapkit service with the orchestrator",
+    summary="Onboard a chapkit model service",
 )
 def register_service(
     payload: RegistrationRequest,
@@ -31,10 +31,12 @@ def register_service(
     session: Session = Depends(get_session),
     _: str = Depends(verify_service_key),
 ) -> RegistrationResponse:
-    """Register a new chapkit service and return the absolute ping URL the caller must keep alive.
+    """Announce a chapkit-hosted model service so chap-core can route work to it.
 
-    Eagerly syncs the registered service into the v1 model-templates and configured-models
-    tables so it shows up immediately via the v1 CRUD endpoints. Requires the
+    The orchestrator records the service and returns the absolute ping URL the service
+    must hit periodically to stay live. As a side effect, the service's templates and
+    default configurations are eagerly pulled into the v1 CRUD tables, so backtests and
+    predictions can target it without waiting for the next lazy sync. Requires the
     ``X-Service-Key`` header.
     """
     response = orchestrator.register(payload)
@@ -57,17 +59,19 @@ def register_service(
 @router.put(
     "/{service_id}/$ping",
     response_model=PingResponse,
-    summary="Keep a registered service alive",
+    summary="Send a keepalive heartbeat for a service",
 )
 def ping_service(
     service_id: str,
     orchestrator: Orchestrator = Depends(get_orchestrator),
     _: str = Depends(verify_service_key),
 ) -> PingResponse:
-    """Refresh the registry TTL for a registered service so the orchestrator does not evict it.
+    """Tell the orchestrator the service is still alive so it doesn't get evicted from the registry.
 
-    Requires the ``X-Service-Key`` header. Returns 404 if the service id is unknown to
-    the orchestrator.
+    Called by the chapkit service itself on a timer — typically once a minute. The
+    orchestrator marks the service "live", which is what surfaces as
+    ``health_status = "live"`` on its model templates. Requires the ``X-Service-Key``
+    header; 404 if the service id is unknown.
     """
     try:
         return orchestrator.ping(service_id)
@@ -79,12 +83,12 @@ def ping_service(
     "",
     response_model=ServiceListResponse,
     response_model_exclude_none=True,
-    summary="List registered services",
+    summary="Browse currently live model services",
 )
 def list_services(
     orchestrator: Orchestrator = Depends(get_orchestrator),
 ) -> ServiceListResponse:
-    """Return every service currently registered with the orchestrator and a count."""
+    """List every chapkit model service that's currently registered, so operators can see at a glance what compute is available to route work to."""
     return orchestrator.get_all()
 
 
@@ -92,15 +96,16 @@ def list_services(
     "/{service_id}",
     response_model=ServiceDetail,
     response_model_exclude_none=True,
-    summary="Get a registered service",
+    summary="Inspect one registered service",
 )
 def get_service(
     service_id: str,
     orchestrator: Orchestrator = Depends(get_orchestrator),
 ) -> ServiceDetail:
-    """Return the full detail (info, URL, last ping) for a single registered service.
+    """Look up everything the orchestrator knows about a single service — its declared info, the URL it's reachable at, and when it last pinged.
 
-    Returns 404 if the service id is unknown to the orchestrator.
+    Used to diagnose registration issues or fill a service-detail panel. 404 if the
+    service id is unknown.
     """
     try:
         return orchestrator.get(service_id)
@@ -111,16 +116,18 @@ def get_service(
 @router.delete(
     "/{service_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    summary="Deregister a service",
+    summary="Off-board a model service",
 )
 def deregister_service(
     service_id: str,
     orchestrator: Orchestrator = Depends(get_orchestrator),
     _: str = Depends(verify_service_key),
 ) -> None:
-    """Remove a service from the orchestrator's registry. Requires the ``X-Service-Key`` header.
+    """Remove a service from the registry — used by the service itself on graceful shutdown, or by an operator forcing eviction.
 
-    Returns 204 No Content on success and 404 if the service id is unknown.
+    Templates produced by the service stay in the database (so historical backtests
+    still resolve) but lose their ``health_status = "live"`` marker. Requires the
+    ``X-Service-Key`` header. 204 on success, 404 if the service id is unknown.
     """
     try:
         orchestrator.deregister(service_id)

--- a/chap_core/rest_api/v2/routers/services.py
+++ b/chap_core/rest_api/v2/routers/services.py
@@ -19,7 +19,11 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/services", tags=["Services"])
 
 
-@router.post("/$register", response_model=RegistrationResponse)
+@router.post(
+    "/$register",
+    response_model=RegistrationResponse,
+    summary="Register a chapkit service with the orchestrator",
+)
 def register_service(
     payload: RegistrationRequest,
     request: Request,
@@ -27,7 +31,12 @@ def register_service(
     session: Session = Depends(get_session),
     _: str = Depends(verify_service_key),
 ) -> RegistrationResponse:
-    """Register a new service with the orchestrator."""
+    """Register a new chapkit service and return the absolute ping URL the caller must keep alive.
+
+    Eagerly syncs the registered service into the v1 model-templates and configured-models
+    tables so it shows up immediately via the v1 CRUD endpoints. Requires the
+    ``X-Service-Key`` header.
+    """
     response = orchestrator.register(payload)
     response.ping_url = str(request.base_url).rstrip("/") + response.ping_url
 
@@ -45,46 +54,74 @@ def register_service(
     return response
 
 
-@router.put("/{service_id}/$ping", response_model=PingResponse)
+@router.put(
+    "/{service_id}/$ping",
+    response_model=PingResponse,
+    summary="Keep a registered service alive",
+)
 def ping_service(
     service_id: str,
     orchestrator: Orchestrator = Depends(get_orchestrator),
     _: str = Depends(verify_service_key),
 ) -> PingResponse:
-    """Send a keepalive ping for a registered service."""
+    """Refresh the registry TTL for a registered service so the orchestrator does not evict it.
+
+    Requires the ``X-Service-Key`` header. Returns 404 if the service id is unknown to
+    the orchestrator.
+    """
     try:
         return orchestrator.ping(service_id)
     except ServiceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
 
-@router.get("", response_model=ServiceListResponse, response_model_exclude_none=True)
+@router.get(
+    "",
+    response_model=ServiceListResponse,
+    response_model_exclude_none=True,
+    summary="List registered services",
+)
 def list_services(
     orchestrator: Orchestrator = Depends(get_orchestrator),
 ) -> ServiceListResponse:
-    """List all registered services."""
+    """Return every service currently registered with the orchestrator and a count."""
     return orchestrator.get_all()
 
 
-@router.get("/{service_id}", response_model=ServiceDetail, response_model_exclude_none=True)
+@router.get(
+    "/{service_id}",
+    response_model=ServiceDetail,
+    response_model_exclude_none=True,
+    summary="Get a registered service",
+)
 def get_service(
     service_id: str,
     orchestrator: Orchestrator = Depends(get_orchestrator),
 ) -> ServiceDetail:
-    """Get details of a specific registered service."""
+    """Return the full detail (info, URL, last ping) for a single registered service.
+
+    Returns 404 if the service id is unknown to the orchestrator.
+    """
     try:
         return orchestrator.get(service_id)
     except ServiceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
 
-@router.delete("/{service_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{service_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Deregister a service",
+)
 def deregister_service(
     service_id: str,
     orchestrator: Orchestrator = Depends(get_orchestrator),
     _: str = Depends(verify_service_key),
 ) -> None:
-    """Deregister a service."""
+    """Remove a service from the orchestrator's registry. Requires the ``X-Service-Key`` header.
+
+    Returns 204 No Content on success and 404 if the service id is unknown.
+    """
     try:
         orchestrator.deregister(service_id)
     except ServiceNotFoundError as e:

--- a/chap_core/rest_api/v2/routers/services.py
+++ b/chap_core/rest_api/v2/routers/services.py
@@ -22,7 +22,7 @@ router = APIRouter(prefix="/services", tags=["Services"])
 @router.post(
     "/$register",
     response_model=RegistrationResponse,
-    summary="Onboard a chapkit model service",
+    summary="Onboard a CHAPKit model service",
 )
 def register_service(
     payload: RegistrationRequest,
@@ -31,7 +31,7 @@ def register_service(
     session: Session = Depends(get_session),
     _: str = Depends(verify_service_key),
 ) -> RegistrationResponse:
-    """Announce a chapkit-hosted model service so chap-core can route work to it.
+    """Announce a CHAPKit-hosted model service so CHAP Core can route work to it.
 
     The orchestrator records the service and returns the absolute ping URL the service
     must hit periodically to stay live. As a side effect, the service's templates and
@@ -66,12 +66,12 @@ def ping_service(
     orchestrator: Orchestrator = Depends(get_orchestrator),
     _: str = Depends(verify_service_key),
 ) -> PingResponse:
-    """Tell the orchestrator the service is still alive so it doesn't get evicted from the registry.
+    """Tell the orchestrator the service is still alive so it is not evicted from the registry.
 
-    Called by the chapkit service itself on a timer — typically once a minute. The
+    Called by the CHAPKit service itself on a timer — typically once a minute. The
     orchestrator marks the service "live", which is what surfaces as
     ``health_status = "live"`` on its model templates. Requires the ``X-Service-Key``
-    header; 404 if the service id is unknown.
+    header. Returns 404 if the service id is unknown.
     """
     try:
         return orchestrator.ping(service_id)
@@ -88,7 +88,7 @@ def ping_service(
 def list_services(
     orchestrator: Orchestrator = Depends(get_orchestrator),
 ) -> ServiceListResponse:
-    """List every chapkit model service that's currently registered, so operators can see at a glance what compute is available to route work to."""
+    """List every CHAPKit model service currently registered, so operators can see at a glance what compute is available to route work to."""
     return orchestrator.get_all()
 
 
@@ -102,10 +102,10 @@ def get_service(
     service_id: str,
     orchestrator: Orchestrator = Depends(get_orchestrator),
 ) -> ServiceDetail:
-    """Look up everything the orchestrator knows about a single service — its declared info, the URL it's reachable at, and when it last pinged.
+    """Look up everything the orchestrator knows about a single service — its declared info, the URL it is reachable at, and when it last pinged.
 
-    Used to diagnose registration issues or fill a service-detail panel. 404 if the
-    service id is unknown.
+    Used to diagnose registration issues or populate a service-detail panel. Returns
+    404 if the service id is unknown.
     """
     try:
         return orchestrator.get(service_id)
@@ -127,7 +127,8 @@ def deregister_service(
 
     Templates produced by the service stay in the database (so historical backtests
     still resolve) but lose their ``health_status = "live"`` marker. Requires the
-    ``X-Service-Key`` header. 204 on success, 404 if the service id is unknown.
+    ``X-Service-Key`` header. Returns 204 on success and 404 if the service id is
+    unknown.
     """
     try:
         orchestrator.deregister(service_id)


### PR DESCRIPTION
## Summary

Sweep through every `@router.get/post/put/delete/patch` decorator across **all exposed FastAPI routes** and rewrite the OpenAPI metadata so `/docs` and the spec describe what each endpoint does for the caller — not just the shape of its response. Each route gets an authored `summary=` on the decorator and a docstring used as `description=` by FastAPI.

Also wires `version=` and a top-of-page `description=` into the FastAPI app constructor, and drops the dead `POST /v1/crud/predictions` placeholder (zero callers anywhere; was a permanent 501 misleading external operators reading `/docs`).

## Files touched

- `chap_core/rest_api/app.py` — `version=chap_core.__version__` (was FastAPI default `0.1.0`) and a short top-of-page `description=` lifted from chap.dhis2.org.
- `chap_core/rest_api/v1/routers/visualization.py` (7 endpoints)
- `chap_core/rest_api/v1/routers/analytics.py` (12 endpoints after CMWD removal)
- `chap_core/rest_api/v1/routers/crud.py` (23 endpoints incl. 6 new `/prediction-setups/*` routes; CMWD removed, dead `POST /predictions` dropped)
- `chap_core/rest_api/v1/jobs.py` (8 endpoints)
- `chap_core/rest_api/v2/routers/services.py` (5 endpoints — FastAPI was auto-deriving summaries from function names; replaced with authored copy)
- `chap_core/rest_api/common_routes.py` — already had authored summaries via prior PRs, untouched

## Why docstrings instead of `description=` kwargs

`@api_experimental` (`chap_core/rest_api/experimental.py`) mutates `func.__doc__` to prepend an experimental notice. FastAPI ignores the docstring when `description=` is passed, which would silently nullify that notice. Using docstrings as the description keeps the two mechanisms compatible. The 10 `@api_experimental` endpoints (4 in crud's configured-models section pre-merge, 6 in prediction-setups, 1 in analytics pre-merge) carry only `summary=` on the decorator, with the description in the docstring; verified in OpenAPI that the experimental notice is correctly prepended.

## Notable details

- Async-via-job endpoints (returning `JobResponse` or wrapping a job id in `ImportSummaryResponse`) explicitly state they queue work and point at `GET /v1/jobs/{id}` for status. The `/run` endpoint also notes the `predictionSetupId` query filter on the jobs list.
- Stacked-decorator pairs (`/backtests/{id}/info` + `/backtests/{id}`, and `/actual-cases/{id}` + `/actualCases/{id}`) get distinct summaries so `/docs` differentiates the two operations.
- Endpoint copy is **purpose-focused** (commit `4cea8200`) — each docstring explains when to reach for the endpoint, what it unblocks, and how it fits into a workflow, rather than restating the response shape.

## Round-two changes (post first review)

- Factual fix: `GET /v1/jobs/{id}/logs` no longer claims missing logs surface as 400 — `CeleryJob.get_logs()` falls back to `exception_info` and returns a string, so the 400 branch is effectively unreachable.
- Factual fix: `GET /v1/crud/predictions` no longer claims archived configured models are filtered out — the filter is `configured_model is not None`, which only catches deleted (not archived) rows; soft-archived models still appear.
- `DELETE /v1/jobs/{id}` docstring no longer leaks the Celery `AsyncResult`/PENDING quirk into the user-facing contract; rewritten to describe the actual behavior (cancel before delete).
- Terminology standardised across all routers: **CHAPKit**, **CHAP Core**, **GeoJSON**, "query parameter id" / "path parameter id", "tabular JSON rows".
- Register evened across the rewrite (replaced "Fire", "tweak", "eyeball", "cluttering", "stops eating worker cycles" with neutral phrasing).

## Verification

- `make lint` clean on every commit.
- `tests/integration/rest_api/` (181 tests, 31 skipped) green.
- Final OpenAPI audit: **66 / 66 endpoints carry an authored summary and a non-empty description.** (Was 36 / 66 missing description on 2026-05-22 per the issue.)
- `info.version` in the spec now reads `2.0.0.dev1` (the running chap-core package version) instead of FastAPI's default `0.1.0`.

Closes CLIM-728.