### PR TITLE
ci: refresh outdated GitHub Actions pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci-build-docker-images.yml
+++ b/.github/workflows/ci-build-docker-images.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci-build-docker-images.yml
+++ b/.github/workflows/ci-build-docker-images.yml
@@ -32,10 +32,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build and push Docker image (amd64)
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -73,7 +73,7 @@ jobs:
             GIT_REVISION=${{ github.sha }}
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ matrix.image_name }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ ubuntu-latest ]
         python-version: [ "3.13" ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/ci-lint-code-style.yml
+++ b/.github/workflows/ci-lint-code-style.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
       - name: Set up Python
         run: uv python install 3.13
       - name: Install the project

--- a/.github/workflows/ci-lint-code-style.yml
+++ b/.github/workflows/ci-lint-code-style.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python
         run: uv python install 3.13
       - name: Install the project

--- a/.github/workflows/ci-lint-code-style.yml
+++ b/.github/workflows/ci-lint-code-style.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8
       - name: Set up Python
         run: uv python install 3.13
       - name: Install the project

--- a/.github/workflows/ci-lint-code-style.yml
+++ b/.github/workflows/ci-lint-code-style.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Set up Python

--- a/.github/workflows/ci-test-docs-slow.yml
+++ b/.github/workflows/ci-test-docs-slow.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python
         run: uv python install 3.13
       - name: Install the project

--- a/.github/workflows/ci-test-docs-slow.yml
+++ b/.github/workflows/ci-test-docs-slow.yml
@@ -12,7 +12,7 @@ jobs:
   test-docs-slow:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Set up Python

--- a/.github/workflows/ci-test-docs-slow.yml
+++ b/.github/workflows/ci-test-docs-slow.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
       - name: Set up Python
         run: uv python install 3.13
       - name: Install the project

--- a/.github/workflows/ci-test-docs-slow.yml
+++ b/.github/workflows/ci-test-docs-slow.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8
       - name: Set up Python
         run: uv python install 3.13
       - name: Install the project

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -68,7 +68,7 @@ jobs:
       #     large-packages: false
       #     swap-storage: true
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
       - name: Set up Python ${{ matrix.python-version }}
         run: |
           sudo apt-get install -y libbz2-dev liblzma-dev

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -68,7 +68,7 @@ jobs:
       #     large-packages: false
       #     swap-storage: true
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8
       - name: Set up Python ${{ matrix.python-version }}
         run: |
           sudo apt-get install -y libbz2-dev liblzma-dev

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -68,7 +68,7 @@ jobs:
       #     large-packages: false
       #     swap-storage: true
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python ${{ matrix.python-version }}
         run: |
           sudo apt-get install -y libbz2-dev liblzma-dev

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -37,7 +37,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       #- name: Set up Docker Buildx
       #  uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up environment variables
         run: |
           echo "Service Account Private Key is set"

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           echo "Service Account Private Key is set"
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           echo "Service Account Private Key is set"
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           echo "Service Account Private Key is set"
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python 3.13
         run: uv python install 3.13
       - name: Install the project

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -12,9 +12,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Install uv

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -13,12 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+      - name: Set up Python 3.13
+        run: uv python install 3.13
       - name: Install the project
         run: uv sync --dev
       - name: Build package

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -12,15 +12,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
       - name: Install the project
         run: uv sync --dev
       - name: Build package

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -22,7 +22,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v4.1.1
 

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger chap-site deploy
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.CHAP_SITE_DEPLOY_TOKEN }}
           repository: dhis2-chap/chap-site


### PR DESCRIPTION
## Summary

Bring **every** GitHub Actions pin on this repo up to its current stable major and turn on Dependabot so the same drift doesn't accumulate again. Originally scoped to the `astral-sh/setup-uv` bump; broadened during review to cover all outdated and inconsistent pins, plus a real bug in `push-to-pypi.yml`'s Python pin.

## Changes

- **Enable Dependabot** (`fafbf9a0`) for both `github-actions` and `uv` (Dependabot natively supports uv as of v0.1.0+). Weekly cadence, no grouping yet — easy to tune later if it gets noisy. The repo had no `dependabot.yml` and never has per git history, which is why all the drift cleaned up in this PR went unnoticed.
- **All action pins now reference the current stable major / immutable tag.** Verified each against the upstream releases page:

  | Action | Was | Now | Notes |
  |---|---|---|---|
  | `astral-sh/setup-uv` | mix of older `@v*` tags | `@v8.1.0` | immutable; v8 supply-chain change removed floating `@v8` / `@v8.0` tags |
  | `actions/checkout` | mix of `@v3` / `@v4` / `@v6` | `@v6` | harmonised, latest v6.0.2 |
  | `actions/setup-python` (push-to-pypi only) | `@v3` | dropped | replaced by `uv python install 3.13` (was wrongly pinned to 3.10) |
  | `docker/setup-buildx-action` | `@v3` | `@v4` | |
  | `docker/login-action` | `@v3` | `@v4` | |
  | `docker/build-push-action` | `@v6` | `@v7` | Node 24 runtime + removed env vars we don't set |
  | `actions/attest-build-provenance` | `@v2` | `@v4` | v4 is a thin wrapper around `actions/attest`; existing callers OK |
  | `peter-evans/repository-dispatch` | `@v3` | `@v4` | |
  | `azure/setup-helm` | `@v4` | `@v5` | |

  Three pins were already current and left alone: `peaceiris/actions-gh-pages@v4`, `helm/chart-releaser-action@v1.7.0`, `gabrielfalcao/pyenv-action@v18`.

- **`push-to-pypi.yml` rebuilt**:
  - `0488f9bf` — Python pin was `3.10` while `pyproject.toml` requires `>=3.13,<3.14`. The job only ever succeeded because `astral-sh/setup-uv` + `uv sync --dev` installed a 3.13 interpreter behind the scenes, making the `actions/setup-python` step dead weight. Dropped `actions/setup-python` entirely and use `uv python install 3.13`, matching the pattern every other workflow uses.
  - `e5bcb3c5` — removed a dead `uv python install ${{ matrix.python-version }}` step (no matrix declared; substitution was empty); fixed the misleading step header.

## Note on the master merge

Includes a clean merge of `master` (`d793d9d8`) to pick up #372's alembic-heads guard — otherwise CI would trip on a stale multi-head state that existed when this branch was last synced. No conflicts.

## Verification

- `make check-alembic-heads` → `OK: single head f6a7b8c9d0e1`
- `make lint` clean
- Every `actions/*` pin used in `.github/workflows/` references its current stable major / immutable tag. No follow-up version-bump PR needed.
- `push-to-pypi.yml` now uses a single, correct Python install path (uv-managed 3.13) consistent with the rest of the repo.
- Dependabot config will be picked up by GitHub on merge to `master`; first scheduled run within a week.