### PR TITLE
fix(alembic): linearize migration chain and add single-head guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint: ## check and fix code style with ruff, run type checking
 	@echo "Type checking (pyright)..."
 	uv run pyright
 
-check: ## non-mutating lint + type checks (used in CI)
+check: check-alembic-heads ## non-mutating lint + type checks (used in CI)
 	@echo "Ruff check..."
 	uv run ruff check
 	@echo "Ruff format check..."
@@ -46,6 +46,10 @@ check: ## non-mutating lint + type checks (used in CI)
 	uv run mypy
 	@echo "Type checking (pyright)..."
 	uv run pyright
+
+check-alembic-heads: ## fail if the alembic migration chain has more than one head
+	@echo "Alembic head count..."
+	@uv run python -c "from alembic.config import Config; from alembic.script import ScriptDirectory; heads = ScriptDirectory.from_config(Config('alembic.ini')).get_heads(); assert len(heads) == 1, f'Expected 1 alembic head, found {len(heads)}: {heads}'; print(f'OK: single head {heads[0]}')"
 
 test: ## run tests quickly with minimal output
 	uv run pytest -q

--- a/alembic/versions/e5f6a7b8c9d0_add_prediction_setup.py
+++ b/alembic/versions/e5f6a7b8c9d0_add_prediction_setup.py
@@ -5,8 +5,8 @@ foreign key column on prediction. The legacy
 configured_model_with_data_source_id column on prediction is left in place
 for now; it will be migrated and dropped in a later revision.
 
-Revision ID: d4e5f6a7b8c9
-Revises: c3d4e5f6a7b8
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
 Create Date: 2026-05-19
 
 """
@@ -17,8 +17,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "d4e5f6a7b8c9"
-down_revision: Union[str, Sequence[str], None] = "c3d4e5f6a7b8"
+revision: str = "e5f6a7b8c9d0"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/f6a7b8c9d0e1_drop_configured_model_with_data_source.py
+++ b/alembic/versions/f6a7b8c9d0e1_drop_configured_model_with_data_source.py
@@ -2,10 +2,10 @@
 
 Removes the configured_model_with_data_source_id foreign key column on
 prediction and drops the configuredmodelwithdatasource table. The
-PredictionSetup table introduced in d4e5f6a7b8c9 replaces it.
+PredictionSetup table introduced in e5f6a7b8c9d0 replaces it.
 
-Revision ID: e5f6a7b8c9d0
-Revises: d4e5f6a7b8c9
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
 Create Date: 2026-05-19
 
 """
@@ -16,8 +16,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "e5f6a7b8c9d0"
-down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+revision: str = "f6a7b8c9d0e1"
+down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

`tests/test_alembic_migrations.py` started failing on master because PRs #354 and #366 each added a migration parented on `c3d4e5f6a7b8` and both picked the same revision id `d4e5f6a7b8c9`. Two heads, one duplicate id, four broken tests.

## Fix

Renumber PR #354's two migrations to chain on top of PR #366's `drop_debugentry`:

- `add_prediction_setup`: `d4e5f6a7b8c9` → `e5f6a7b8c9d0`, parent `c3d4e5f6a7b8` → `d4e5f6a7b8c9`
- `drop_configured_model_with_data_source`: `e5f6a7b8c9d0` → `f6a7b8c9d0e1`, parent `d4e5f6a7b8c9` → `e5f6a7b8c9d0`

Single linear chain, single head `f6a7b8c9d0e1`. No schema changes; only revision IDs and `down_revision` pointers move.

## Guard

Adds `make check-alembic-heads` (and wires it in as a prerequisite of `make check`) that uses the alembic Python API to fail fast if the migration chain has more than one head. CI already runs `make check`, so this catches the same situation in future PRs without any workflow file changes. Verified by faking the broken state locally - the guard reports "Expected 1 alembic head, found 3" and exits non-zero.

## Why this slipped past CI originally

GitHub Actions checks out the PR-merged-into-base state at PR time, not the eventual master state. PR #366 ran green against `master @ c3d4e5f6a7b8`, merged → master HEAD became `d4e5f6a7b8c9`. PR #354 then merged green from a CI run that was also based on `c3d4e5f6a7b8` and never saw #366's `d4e5f6a7b8c9` migration. The guard prevents the same race from breaking master again - once the second-to-land PR is rebased onto the first, `make check` fails locally and in CI.

## Verification

- `uv run alembic heads` → single head `f6a7b8c9d0e1`
- `uv run alembic history` → linear chain
- `uv run pytest tests/test_alembic_migrations.py --run-slow` → 4 / 4 pass against a real PostgreSQL container
- `make check-alembic-heads` → OK
- Faked broken state to confirm the guard fails with the expected message