### PR TITLE
chore(docs): silence MkDocs 2.0 warning in make docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ coverage: ## run tests with coverage reporting
 	@echo "Coverage report: htmlcov/index.html"
 
 docs: ## generate MkDocs HTML documentation (strict: warnings fail the build)
-	uv run mkdocs build --strict
+	NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict
 	@echo "Docs: site/index.html"
 
 dist: clean ## build source and wheel package


### PR DESCRIPTION
## Summary

mkdocs-material 9.7.2+ prints a multi-line "MkDocs 2.0 incompatibility" notice on every build (we land on 9.7.6 via #381). The upstream opt-out is to set `NO_MKDOCS_2_WARNING=1`.

Setting it in the Makefile target so both local `make docs` and CI (`ci-build-docs.yml`, which calls `make docs`) stop emitting it without each consumer having to remember.

Reference: https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/

## Test plan

- [ ] `make docs` builds without the multi-line MkDocs 2.0 banner
- [ ] `ci-build-docs` CI step passes