### PR TITLE
feat(openapi): add Field(description=...) to exposed pydantic/SQLModel schemas

### DIFF
--- a/chap_core/api_types.py
+++ b/chap_core/api_types.py
@@ -22,84 +22,129 @@ from chap_core.database.base_tables import DBModel
 
 
 class FeatureModel(_Feature):
-    id: str | None = None  # type: ignore[assignment]
-    properties: dict[str, Any] | None = Field(default_factory=dict)  # type: ignore[assignment]
-    geometry: Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon | None = None  # type: ignore[assignment]
+    """GeoJSON `Feature` carrying one org-unit polygon plus DHIS2-style metadata.
+
+    Loosens upstream `geojson_pydantic.Feature` so `id` may be omitted and
+    `geometry` may be any geometry variant or `None`.
+    """
+
+    id: str | None = Field(default=None, description="External identifier of the org unit (DHIS2 id), if known.")  # type: ignore[assignment]
+    properties: dict[str, Any] | None = Field(
+        default_factory=dict, description="Free-form properties attached to the feature."
+    )  # type: ignore[assignment]
+    geometry: Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon | None = Field(
+        default=None,
+        description="GeoJSON geometry. Any of the standard variants, or `None` if unknown.",
+    )  # type: ignore[assignment]
 
 
 class FeatureCollectionModel(_FeatureCollection):
-    features: list[FeatureModel]  # type: ignore[assignment]
+    """GeoJSON `FeatureCollection` of `FeatureModel`s — the polygon set for a dataset."""
+
+    features: list[FeatureModel] = Field(description="One feature per org unit in the polygon set.")  # type: ignore[assignment]
 
 
 class DataElement(BaseModel):
-    pe: str
-    ou: str
-    value: float | None
+    """Single data point in a v1-format request: a value for one (period, org-unit) pair."""
+
+    pe: str = Field(description="Period identifier (DHIS2-style, e.g. `202403`).")
+    ou: str = Field(description="Org-unit identifier.")
+    value: float | None = Field(description="Observed value; `None` is allowed for known-missing observations.")
 
 
 class DataList(BaseModel):
-    featureId: str
-    dhis2Id: str
-    data: list[DataElement] = Field(..., min_length=1)
+    """Time-series of v1-format `DataElement`s for one feature on one DHIS2 data element."""
+
+    featureId: str = Field(description="Canonical feature identifier (matching a `FeatureType.name`).")
+    dhis2Id: str = Field(description="External DHIS2 data element id the values came from.")
+    data: list[DataElement] = Field(..., min_length=1, description="At least one (period, org-unit, value) row.")
 
 
 class DataElementV2(BaseModel):
-    period: str
-    orgUnit: str
-    value: float | None
+    """Single data point in a v2-format request — same as `DataElement` but with verbose field names."""
+
+    period: str = Field(description="Period identifier (e.g. `202403`).")
+    orgUnit: str = Field(description="Org-unit identifier.")
+    value: float | None = Field(description="Observed value; `None` is allowed for known-missing observations.")
 
 
 class DataListV2(BaseModel):
-    featureId: str
-    dataElement: str
-    data: list[DataElementV2] = Field(..., min_length=1)
+    """Time-series of v2-format `DataElementV2`s for one feature on one data element."""
+
+    featureId: str = Field(description="Canonical feature identifier (matching a `FeatureType.name`).")
+    dataElement: str = Field(description="External data element id the values came from.")
+    data: list[DataElementV2] = Field(..., min_length=1, description="At least one (period, org-unit, value) row.")
 
 
 class RequestV1(BaseModel):
-    orgUnitsGeoJson: FeatureCollectionModel
-    features: list[DataList]
+    """V1 request body: GeoJSON polygons plus a list of feature time-series."""
+
+    orgUnitsGeoJson: FeatureCollectionModel = Field(description="GeoJSON polygon set for the org units in the request.")
+    features: list[DataList] = Field(description="One time-series per (feature, data-element) pair.")
 
 
 class RequestV2(RequestV1):
-    estimator_id: str = "chap_ewars_monthly"
+    """V2 request body: a v1 request plus an explicit estimator id."""
+
+    estimator_id: str = Field(default="chap_ewars_monthly", description="Configured-model name to run.")
 
 
 class PredictionRequest(RequestV2):
-    n_periods: int = 3
-    include_data: bool = False
+    """Prediction request body: a v2 request plus a forecast horizon and a flag to echo back the input data."""
+
+    n_periods: int = Field(default=3, description="Number of periods to forecast.")
+    include_data: bool = Field(
+        default=False, description="When True, the response echoes the request inputs alongside the predictions."
+    )
 
 
 class PredictionEntry(BaseModel):
-    orgUnit: str
-    period: str
-    quantile: float
-    value: float
+    """One quantile-aware predicted value for a (period, org-unit) pair."""
+
+    orgUnit: str = Field(description="Org-unit identifier the prediction is for.")
+    period: str = Field(description="Period the prediction is for.")
+    quantile: float = Field(description="Quantile of the predictive distribution this value represents (0.0 to 1.0).")
+    value: float = Field(description="Predicted value at the given quantile.")
 
 
 class EvaluationEntry(PredictionEntry):
-    splitPeriod: str
+    """Backtest evaluation entry: a prediction plus the split it was produced under."""
+
+    splitPeriod: str = Field(description="Period at which the rolling split was advanced for this prediction.")
 
 
 class BacktestParams(DBModel):
-    n_periods: int = Field(default=3, gt=0)
-    n_splits: int = Field(default=7, gt=0)
-    stride: int = Field(default=1, gt=0)
+    """Shared backtest scheduling parameters used by request models."""
+
+    n_periods: int = Field(default=3, gt=0, description="Number of periods to forecast at each split.")
+    n_splits: int = Field(default=7, gt=0, description="Total number of rolling train/test splits.")
+    stride: int = Field(default=1, gt=0, description="Number of periods to advance between successive splits.")
 
 
 class RunConfig(BaseModel):
     """Configuration for model execution environment."""
 
-    ignore_environment: bool = False
-    debug: bool = False
-    log_file: str | None = None
-    run_directory_type: Literal["latest", "timestamp", "use_existing"] = "timestamp"
-    is_chapkit_model: bool = False
-    track: bool = False
+    ignore_environment: bool = Field(default=False, description="When True, skip the automatic environment setup step.")
+    debug: bool = Field(default=False, description="When True, enable verbose debug logging.")
+    log_file: str | None = Field(default=None, description="Path to write log output to; `None` means stdout only.")
+    run_directory_type: Literal["latest", "timestamp", "use_existing"] = Field(
+        default="timestamp",
+        description="How to name the per-run subdirectory under `runs/`.",
+    )
+    is_chapkit_model: bool = Field(
+        default=False,
+        description="Set to True when the model is served via chapkit (REST) rather than an MLproject directory.",
+    )
+    track: bool = Field(default=False, description="When True, log params/metrics/artifacts to the tracking backend.")
 
 
 class EvaluationResponse(BaseModel):
-    actualCases: DataList
-    predictions: list[EvaluationEntry]
+    """Backtest evaluation response: actual cases plus per-(period, org-unit, quantile) predictions."""
+
+    actualCases: DataList = Field(description="Observed values for the evaluation window, used as the truth signal.")
+    predictions: list[EvaluationEntry] = Field(
+        description="Per-(period, org-unit, quantile) predictions from every split."
+    )
 
     def model_dump(self, **kwargs):
         """Override to handle special types during serialization"""
@@ -127,16 +172,22 @@ class EvaluationResponse(BaseModel):
 
 
 class PeriodObservation(BaseModel):
-    time_period: str
+    """Single observation indexed by its period."""
+
+    time_period: str = Field(description="Period identifier the observation is for.")
 
 
 class EstimatorMode(StrEnum):
+    """How the estimator should be run when training/evaluating a model."""
+
     NORMAL = "normal"
     HPO = "hpo"
     ENSEMBLE = "ensemble"
 
 
 class EstimatorOptions(BaseModel):
+    """Options controlling how the estimator runs (mode + metric)."""
+
     mode: EstimatorMode = Field(
         default=EstimatorMode.NORMAL,
         description=(

--- a/chap_core/database/dataset_tables.py
+++ b/chap_core/database/dataset_tables.py
@@ -13,7 +13,9 @@ from chap_core.database.base_tables import DBModel, PeriodID
 
 
 class FeatureCollectionModel(_FeatureCollection):
-    features: list[Feature]  # type: ignore[assignment]
+    """GeoJSON `FeatureCollection` carrying the polygons for a dataset's org units."""
+
+    features: list[Feature] = Field(description="One feature per org unit in the polygon set.")  # type: ignore[assignment]
 
 
 class PydanticListType(TypeDecorator):
@@ -44,24 +46,34 @@ class PydanticListType(TypeDecorator):
 
 
 class ObservationBase(DBModel):
-    period: PeriodID
-    org_unit: str
-    value: float | None
-    feature_name: str | None
+    """A single observed value for one (period, org unit, feature) triple."""
+
+    period: PeriodID = Field(
+        description="Period the observation belongs to, encoded as an ISO-like string (e.g. `2024-W12`, `202403`)."
+    )
+    org_unit: str = Field(description="Identifier of the org unit (province, district, ...) the observation is from.")
+    value: float | None = Field(description="Observed value. `None` is allowed for known-missing observations.")
+    feature_name: str | None = Field(description="Canonical name of the `FeatureType` this observation is a value for.")
 
 
 class Observation(ObservationBase, table=True):
-    id: int | None = Field(primary_key=True, default=None)
-    dataset_id: int = Field(foreign_key="dataset.id")
+    """Persisted observation row, owned by a parent `DataSet`."""
+
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
+    dataset_id: int = Field(foreign_key="dataset.id", description="Foreign key to the parent `DataSet`.")
     dataset: "DataSet" = Relationship(back_populates="observations")
 
 
 class DataSource(DBModel):
-    covariate: str
-    data_element_id: str
+    """Mapping from a covariate name to the DHIS2 data element id used to source it."""
+
+    covariate: str = Field(description="Canonical covariate name (matching a `FeatureType.name`).")
+    data_element_id: str = Field(description="External identifier of the data element to pull values from.")
 
 
 class DataSetCreateInfo(DBModel):
+    """Metadata fields required when registering a new dataset."""
+
     name: str = Field(description="Name of dataset")
 
     data_sources: list[DataSource] | None = Field(
@@ -73,25 +85,43 @@ class DataSetCreateInfo(DBModel):
 
 
 class DataSetInfo(DataSetCreateInfo):
-    id: int | None = Field(primary_key=True, default=None)
-    covariates: list["str"] = Field(default_factory=list, sa_column=Column(JSON))
-    first_period: PeriodID | None = Field(default=None)
-    last_period: PeriodID | None = Field(default=None)
-    org_units: list["str"] | None = Field(default_factory=list, sa_column=Column(JSON))
-    created: datetime | None = None
+    """Summary view of a dataset — what was created plus what was derived after import."""
 
-    period_type: str | None = None
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
+    covariates: list["str"] = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description="Names of the covariates (features) actually present in the dataset's observations.",
+    )
+    first_period: PeriodID | None = Field(default=None, description="Earliest period present in the observations.")
+    last_period: PeriodID | None = Field(default=None, description="Latest period present in the observations.")
+    org_units: list["str"] | None = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description="Identifiers of every org unit that has at least one observation.",
+    )
+    created: datetime | None = Field(default=None, description="Server-side timestamp when the dataset was registered.")
+
+    period_type: str | None = Field(default=None, description="Granularity of the periods (`month`, `week`, ...).")
 
 
 class DataSetBase(DataSetInfo):
-    geojson: str | None = None
+    """`DataSetInfo` plus the polygon geojson stored alongside the dataset."""
+
+    geojson: str | None = Field(
+        default=None, description="GeoJSON `FeatureCollection` for the dataset's org units, stored as a string."
+    )
 
 
 class DataSet(DataSetBase, table=True):
+    """Persisted dataset row with its child observations."""
+
     observations: list[Observation] = Relationship(back_populates="dataset", cascade_delete=True)
 
 
 class DataSetWithObservations(DataSetBase):
-    id: int
-    observations: list[ObservationBase]
-    created: datetime | None
+    """Read view that bundles a dataset together with its observations."""
+
+    id: int = Field(description="Primary key of the dataset.")
+    observations: list[ObservationBase] = Field(description="Every observation belonging to this dataset.")
+    created: datetime | None = Field(description="Server-side timestamp when the dataset was registered.")

--- a/chap_core/database/feature_tables.py
+++ b/chap_core/database/feature_tables.py
@@ -6,26 +6,60 @@ from chap_core.model_spec import PeriodType
 
 
 class FeatureTypeBase(DBModel):
-    display_name: str
-    description: str
+    """Shared display metadata for a covariate type (rainfall, temperature, ...).
+
+    Used as a mixin by `FeatureType` (the DB-backed row keyed by canonical
+    ``name``) and `FeatureTypeRead` (the API read shape).
+    """
+
+    display_name: str = Field(description="Human-friendly name shown to operators in pickers and plot titles.")
+    description: str = Field(description="Short paragraph explaining what the feature represents.")
 
 
 class FeatureTypeRead(FeatureTypeBase):
-    name: str
+    """A covariate type as returned by the API. Same shape as the DB row."""
+
+    name: str = Field(description="Canonical machine-readable identifier (e.g. `rainfall`, `mean_temperature`).")
 
 
 class FeatureType(FeatureTypeBase, table=True):
-    name: str = Field(primary_key=True)
+    """Catalogue row for one covariate type that models can request as input."""
+
+    name: str = Field(
+        primary_key=True,
+        description="Canonical machine-readable identifier (e.g. `rainfall`, `mean_temperature`).",
+    )
 
 
 class FeatureSource(DBModel, table=True):
-    name: str = Field(primary_key=True)
-    display_name: str
-    feature_type: str = Field(foreign_key="featuretype.name")
-    provider: str
-    supported_period_types: list[PeriodType] = Field(default_factory=list, sa_column=Column(JSON))
+    """A registered provider that can supply data for a specific feature type."""
+
+    name: str = Field(primary_key=True, description="Canonical identifier of the feature source.")
+    display_name: str = Field(description="Human-friendly name shown in source pickers.")
+    feature_type: str = Field(
+        foreign_key="featuretype.name",
+        description="Canonical name of the `FeatureType` this source provides values for.",
+    )
+    provider: str = Field(description="Upstream provider this source pulls from (e.g. `era5`, `dhis2`).")
+    supported_period_types: list[PeriodType] = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description="Period granularities this source can deliver values at.",
+    )
 
 
 class ModelFeatureLink(DBModel, table=True):
-    model_id: int | None = Field(default=None, foreign_key="modelspec.id", primary_key=True)
-    feature_type: str | None = Field(default=None, foreign_key="featuretype.name", primary_key=True)
+    """Join row linking a `ModelSpec` to one of its supported feature types."""
+
+    model_id: int | None = Field(
+        default=None,
+        foreign_key="modelspec.id",
+        primary_key=True,
+        description="Primary-key id of the linked `ModelSpec` row.",
+    )
+    feature_type: str | None = Field(
+        default=None,
+        foreign_key="featuretype.name",
+        primary_key=True,
+        description="Canonical name of the linked `FeatureType` row.",
+    )

--- a/chap_core/database/model_spec_tables.py
+++ b/chap_core/database/model_spec_tables.py
@@ -10,14 +10,18 @@ from chap_core.model_spec import PeriodType
 
 
 class ModelSpecBase(ModelTemplateMetaData, DBModel):
-    """
+    """Legacy base for the older `ModelSpec` table.
+
     Use inheritance here so that it's flat in the database.
     """
 
-    name: str
+    name: str = Field(description="Canonical identifier of the model spec.")
     # supported_period_types: PeriodType = PeriodType.any
-    source_url: str | None = None
-    supported_period_type: PeriodType = PeriodType.any  # ] = [PeriodType.month, PeriodType.week]
+    source_url: str | None = Field(default=None, description="URL where the model's source lives.")
+    supported_period_type: PeriodType = Field(
+        default=PeriodType.any,
+        description="Period granularity the model accepts (`month`, `week`, or `any`).",
+    )
 
     # @field_validator("supported_period_type", mode="before")
     # def wrap_in_list(cls, v):
@@ -27,13 +31,23 @@ class ModelSpecBase(ModelTemplateMetaData, DBModel):
 
 
 class ModelSpecRead(ModelSpecBase):
-    id: int
-    covariates: list[FeatureType]
-    target: FeatureType
-    archived: bool = False
-    uses_chapkit: bool = False
-    user_option_values: dict | None = None
-    additional_continuous_covariates: list[str] = []
+    """API read shape for a legacy `ModelSpec`.
+
+    Carries the joined `covariates` / `target` references plus the
+    archived / chapkit / configuration fields that the current frontend
+    expects when listing available models.
+    """
+
+    id: int = Field(description="Primary key of the underlying `ModelSpec` row.")
+    covariates: list[FeatureType] = Field(description="Covariate feature types this model supports.")
+    target: FeatureType = Field(description="The feature type this model predicts.")
+    archived: bool = Field(default=False, description="When True, the model is hidden from default pickers.")
+    uses_chapkit: bool = Field(default=False, description="When True, the model is served by a chapkit REST endpoint.")
+    user_option_values: dict | None = Field(default=None, description="Configured user-option values, if any.")
+    additional_continuous_covariates: list[str] = Field(
+        default=[],
+        description="Extra continuous covariates passed beyond `covariates`.",
+    )
 
 
 class ModelSpec(ModelSpecBase, table=True):
@@ -42,8 +56,13 @@ class ModelSpec(ModelSpecBase, table=True):
     It is configured through the "configuration" field which is JSON
     """
 
-    id: int | None = Field(primary_key=True, default=None)
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
     covariates: list[FeatureType] = Relationship(link_model=ModelFeatureLink)
-    target_name: str = Field(foreign_key="featuretype.name")
+    target_name: str = Field(
+        foreign_key="featuretype.name", description="Canonical name of the predicted `FeatureType`."
+    )
     target: FeatureType = Relationship()
-    configuration: dict | None = Field(sa_column=Column(JSON))
+    configuration: dict | None = Field(
+        sa_column=Column(JSON),
+        description="JSON blob holding the model's configured options.",
+    )

--- a/chap_core/database/model_templates_and_config_tables.py
+++ b/chap_core/database/model_templates_and_config_tables.py
@@ -13,6 +13,13 @@ logger = logging.getLogger(__name__)
 
 
 class AuthorAssessedStatus(Enum):
+    """Author-declared maturity rating of a model template.
+
+    Surfaced to operators in model pickers so users can tell experimental
+    work apart from validated work. The colour scheme mirrors a traffic
+    light from least to most trustworthy.
+    """
+
     gray = "gray"  # Gray: Not intended for use, or deprecated/meant for legacy use only.
     red = "red"  # Red: Highly experimental prototype - not at all validated and only meant for early experimentation
     orange = "orange"  # Orange: Has seen promise on limited data, needs manual configuration and careful evaluation
@@ -21,60 +28,126 @@ class AuthorAssessedStatus(Enum):
 
 
 class ModelTemplateMetaData(SQLModel):
-    display_name: str = "No Display Name yet"
-    description: str = "No Description yet"
-    author_note: str = "No Author note yet"
-    author_assessed_status: AuthorAssessedStatus = AuthorAssessedStatus("red")
-    author: str = "Unknown Author"
-    organization: str | None = None
-    organization_logo_url: str | None = None
-    contact_email: str | None = None
-    citation_info: str | None = None
-    documentation_url: str | None = None
+    """Human-facing metadata for a model template — what the model is, who wrote it, how to cite it."""
+
+    display_name: str = Field(
+        default="No Display Name yet", description="Human-friendly name shown in model pickers and plot titles."
+    )
+    description: str = Field(
+        default="No Description yet", description="Short paragraph explaining what the model does."
+    )
+    author_note: str = Field(
+        default="No Author note yet", description="Free-form note from the author (e.g. caveats, intended use cases)."
+    )
+    author_assessed_status: AuthorAssessedStatus = Field(
+        default=AuthorAssessedStatus("red"),
+        description="Author-declared maturity of the model (gray/red/orange/yellow/green).",
+    )
+    author: str = Field(default="Unknown Author", description="Person or team that authored the model.")
+    organization: str | None = Field(default=None, description="Affiliated organisation, if any.")
+    organization_logo_url: str | None = Field(
+        default=None, description="URL of an organisation logo to render next to the model."
+    )
+    contact_email: str | None = Field(default=None, description="Contact email for the model author / maintainer.")
+    citation_info: str | None = Field(
+        default=None, description="How to cite the model in publications (e.g. DOI, BibTeX)."
+    )
+    documentation_url: str | None = Field(default=None, description="URL to the model's external documentation.")
 
 
 class ModelTemplateInformation(SQLModel):
-    supported_period_type: PeriodType = PeriodType.any
-    user_options: dict | None = Field(default_factory=dict, sa_column=Column(JSON))
-    hpo_search_space: dict | None = Field(default=None, sa_column=Column(JSON))  # rename to hpo_search_space
-    required_covariates: list[str] = Field(default_factory=list, sa_column=Column(JSON))
-    min_prediction_length: int | None = None
-    max_prediction_length: int | None = None
-    target: str = "disease_cases"
-    allow_free_additional_continuous_covariates: bool = False
-    requires_geo: bool = False
+    """Technical capabilities of a model template — what inputs it expects and what it can produce."""
+
+    supported_period_type: PeriodType = Field(
+        default=PeriodType.any, description="Period granularity the template supports (`month`, `week`, or `any`)."
+    )
+    user_options: dict | None = Field(
+        default_factory=dict,
+        sa_column=Column(JSON),
+        description="JSON-schema-like dict describing the user-configurable options the template exposes.",
+    )
+    hpo_search_space: dict | None = Field(
+        default=None,
+        sa_column=Column(JSON),
+        description="Search space used by HPO when training this template in `hpo` mode.",
+    )
+    required_covariates: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description="Covariate names the template must be given to run.",
+    )
+    min_prediction_length: int | None = Field(
+        default=None, description="Minimum forecast horizon (in periods) the template supports."
+    )
+    max_prediction_length: int | None = Field(
+        default=None, description="Maximum forecast horizon (in periods) the template supports."
+    )
+    target: str = Field(default="disease_cases", description="Name of the variable the model predicts.")
+    allow_free_additional_continuous_covariates: bool = Field(
+        default=False,
+        description="When True, callers can attach extra continuous covariates beyond `required_covariates`.",
+    )
+    requires_geo: bool = Field(
+        default=False, description="When True, the template needs a GeoJSON polygon set for spatial features."
+    )
 
 
 class ModelTemplateDB(DBModel, ModelTemplateMetaData, ModelTemplateInformation, table=True):
-    """
-    Just a mixin here to get the model info flat in the database.
-    """
+    """Persisted model-template row. Flat composition of metadata + capability mixins."""
 
-    name: str = Field(unique=True)
-    id: int | None = Field(primary_key=True, default=None)
-    source_url: str | None = None
+    name: str = Field(unique=True, description="Canonical unique identifier of the template.")
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
+    source_url: str | None = Field(
+        default=None, description="URL where the template's source lives (e.g. a GitHub repo)."
+    )
     configured_models: list["ConfiguredModelDB"] = Relationship(back_populates="model_template", cascade_delete=True)
-    version: str | None = None
-    archived: bool = Field(default=False)
-    uses_chapkit: bool = Field(default=False)
+    version: str | None = Field(default=None, description="Template version string, typically a git tag or commit sha.")
+    archived: bool = Field(
+        default=False, description="When True, the template is hidden from default pickers but still resolvable."
+    )
+    uses_chapkit: bool = Field(
+        default=False,
+        description="When True, the template is served by a chapkit REST endpoint rather than an MLproject directory.",
+    )
 
 
 class ModelConfiguration(SQLModel):
+    """A specific choice of user-option values + extra covariates layered on top of a model template."""
+
     model_config = ConfigDict(extra="forbid")  # type: ignore[assignment]
 
-    user_option_values: dict | None = Field(sa_column=Column(JSON), default_factory=dict)
-    additional_continuous_covariates: list[str] = Field(default_factory=list, sa_column=Column(JSON))
+    user_option_values: dict | None = Field(
+        sa_column=Column(JSON),
+        default_factory=dict,
+        description="Values for the user-options declared by the parent `ModelTemplateDB.user_options` schema.",
+    )
+    additional_continuous_covariates: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description="Extra continuous covariates to pass to the model beyond the template's required set.",
+    )
 
 
 class ConfiguredModelDB(ModelConfiguration, DBModel, table=True):
+    """Persisted configured-model row — a `ModelTemplateDB` together with a specific configuration."""
+
     #  unique constraint on name
     # model_config = ConfigDict(protected_namespaces=())
-    name: str = Field(unique=True)
-    id: int | None = Field(primary_key=True, default=None)
-    model_template_id: int = Field(foreign_key="modeltemplatedb.id", ondelete="CASCADE")
+    name: str = Field(
+        unique=True,
+        description="Canonical unique identifier; conventionally `<template_name>` or `<template_name>:<config_stub>`.",
+    )
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
+    model_template_id: int = Field(
+        foreign_key="modeltemplatedb.id",
+        ondelete="CASCADE",
+        description="Foreign key to the parent `ModelTemplateDB`.",
+    )
     model_template: ModelTemplateDB = Relationship(back_populates="configured_models")
-    archived: bool = Field(default=False)
-    uses_chapkit: bool = Field(default=False)
+    archived: bool = Field(default=False, description="When True, the configured model is hidden from default pickers.")
+    uses_chapkit: bool = Field(
+        default=False, description="Inherited from the template; True for chapkit-hosted models."
+    )
 
     @property
     def display_name(self) -> str:

--- a/chap_core/database/tables.py
+++ b/chap_core/database/tables.py
@@ -15,34 +15,62 @@ from chap_core.database.model_templates_and_config_tables import ConfiguredModel
 
 
 class BacktestBase(DBModel):
-    dataset_id: int = Field(foreign_key="dataset.id")
-    model_id: str
-    name: str | None = None
-    created: datetime.datetime | None = None
-    model_template_version: str | None = (
-        None  # This is the version of the model template in the moment the backtest was created (version at model template object can change later)
+    """Shared fields for every backtest shape (DB row, create request, read view)."""
+
+    dataset_id: int = Field(
+        foreign_key="dataset.id", description="Foreign key to the `DataSet` the backtest evaluates against."
+    )
+    model_id: str = Field(description="Name of the configured model that was backtested.")
+    name: str | None = Field(default=None, description="Optional human-friendly name for the backtest.")
+    created: datetime.datetime | None = Field(
+        default=None, description="Server-side timestamp when the backtest row was created."
+    )
+    model_template_version: str | None = Field(
+        default=None,
+        description="Snapshot of the parent template's version at backtest-creation time (may differ from current template version).",
     )
 
 
 class DataSetMeta(DataSetInfo):
-    id: int
+    """Slim dataset summary embedded inside other read views (e.g. `BacktestRead`)."""
+
+    id: int = Field(description="Primary key of the dataset.")
     # created: datetime.datetime
     # covariates: List[str]
 
 
 class _BacktestRead(BacktestBase):
-    id: int
-    org_units: list[str] = Field(default_factory=list, sa_column=Column(JSON))
-    split_periods: list[PeriodID] = Field(default_factory=list, sa_column=Column(JSON))
+    """Internal base class for `Backtest` / `BacktestRead` carrying the JSON-stored org_units + split_periods."""
+
+    id: int = Field(description="Primary key of the backtest.")
+    org_units: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description="Identifiers of every org unit the backtest scored predictions over.",
+    )
+    split_periods: list[PeriodID] = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description="Periods at which the rolling backtest's train/test split was advanced.",
+    )
 
 
 class Backtest(_BacktestRead, table=True):
-    id: int | None = Field(primary_key=True, default=None)  # type: ignore[assignment]
+    """Persisted backtest row. Owns its forecasts, metrics, and (optionally) a `PredictionSetup`."""
+
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")  # type: ignore[assignment]
     dataset: DataSet = Relationship()
     forecasts: list["BacktestForecast"] = Relationship(back_populates="backtest", cascade_delete=True)
     metrics: list["BacktestMetric"] = Relationship(back_populates="backtest", cascade_delete=True)
-    aggregate_metrics: dict[str, float] = Field(default_factory=dict, sa_column=Column(JSON))
-    model_db_id: int = Field(foreign_key="configuredmodeldb.id")
+    aggregate_metrics: dict[str, float] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON),
+        description="Map of metric id to aggregated score across all splits / org units.",
+    )
+    model_db_id: int = Field(
+        foreign_key="configuredmodeldb.id",
+        description="Foreign key to the `ConfiguredModelDB` row used to run the backtest.",
+    )
     configured_model: Optional["ConfiguredModelDB"] = Relationship()
     prediction_setup: Optional["PredictionSetup"] = Relationship(
         back_populates="backtest",
@@ -60,125 +88,228 @@ class Backtest(_BacktestRead, table=True):
 
 
 class ConfiguredModelRead(ModelConfiguration, DBModel):
-    name: str
-    id: int
-    model_template: ModelTemplateDB
+    """API read shape for a `ConfiguredModelDB` plus its parent template."""
+
+    name: str = Field(description="Canonical name of the configured model.")
+    id: int = Field(description="Primary key of the configured model.")
+    model_template: ModelTemplateDB = Field(description="Parent template the configuration extends.")
 
 
 class QuantileTarget(DBModel):
-    quantile: str
-    data_element_id: str
+    """A `(quantile, data_element_id)` pair declaring where to push a quantile of the predictive distribution.
+
+    Used inside `PredictionSetup.quantile_targets` to tell the scheduled run
+    which DHIS2 data element receives which quantile (e.g. median → element
+    A, 90th-percentile → element B).
+    """
+
+    quantile: str = Field(
+        description="Quantile as a numeric string (`'0.5'` for median, `'0.9'` for the 90th percentile, ...)."
+    )
+    data_element_id: str = Field(description="External data element id the quantile value is pushed to.")
 
 
 class PredictionSetup(DBModel, table=True):
-    id: int | None = Field(primary_key=True, default=None)
-    name: str
-    created: datetime.datetime | None = None
-    backtest_id: int = Field(foreign_key="backtest.id", unique=True)
+    """Persisted prediction-setup row: a recurring forecast schedule attached to a backtest."""
+
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
+    name: str = Field(description="Human-friendly name for the setup.")
+    created: datetime.datetime | None = Field(
+        default=None, description="Server-side timestamp when the setup was created."
+    )
+    backtest_id: int = Field(
+        foreign_key="backtest.id",
+        unique=True,
+        description="Foreign key to the parent `Backtest` (one-to-one).",
+    )
     backtest: "Backtest" = Relationship(back_populates="prediction_setup")
-    configured_model_id: int = Field(foreign_key="configuredmodeldb.id")
+    configured_model_id: int = Field(
+        foreign_key="configuredmodeldb.id",
+        description="Foreign key to the configured model the setup will run.",
+    )
     configured_model: "ConfiguredModelDB" = Relationship()
-    start_period: PeriodID | None = None
-    org_units: list[str] = Field(default_factory=list, sa_column=Column(JSON))
+    start_period: PeriodID | None = Field(
+        default=None, description="Period the recurring run starts forecasting from; `None` means run-time default."
+    )
+    org_units: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description="Identifiers of the org units the setup forecasts for.",
+    )
     covariate_sources: list[DataSource] = Field(
         default_factory=list,
         sa_column=Column(PydanticListType(DataSource)),
+        description="Mapping of covariate names to data element ids used to source the inputs.",
     )
-    period_type: str | None = None
-    schedule_cron_expression: str | None = None
-    schedule_enabled: bool = Field(default=False)
+    period_type: str | None = Field(
+        default=None, description="Granularity of the forecast periods (`month`, `week`, ...)."
+    )
+    schedule_cron_expression: str | None = Field(
+        default=None,
+        description="Standard cron expression for when the setup runs; `None` means manual-only.",
+    )
+    schedule_enabled: bool = Field(
+        default=False, description="When True, the scheduler executes the setup at every cron tick."
+    )
     quantile_targets: list[QuantileTarget] = Field(
         default_factory=list,
         sa_column=Column(PydanticListType(QuantileTarget)),
+        description="Where to push each quantile of the predictive distribution.",
     )
     predictions: list["Prediction"] = Relationship(back_populates="prediction_setup")
 
 
 class PredictionSetupRead(DBModel):
-    id: int
-    name: str
-    created: datetime.datetime | None
-    backtest_id: int
-    configured_model: ConfiguredModelRead
-    start_period: PeriodID | None
-    org_units: list[str]
-    covariate_sources: list[DataSource]
-    period_type: str | None
-    schedule_cron_expression: str | None
-    schedule_enabled: bool
-    quantile_targets: list[QuantileTarget]
+    """API read shape for a `PredictionSetup`. Same fields as the DB row but with the configured-model joined."""
+
+    id: int = Field(description="Primary key of the setup.")
+    name: str = Field(description="Human-friendly name for the setup.")
+    created: datetime.datetime | None = Field(description="Server-side timestamp when the setup was created.")
+    backtest_id: int = Field(description="Foreign key to the parent `Backtest`.")
+    configured_model: ConfiguredModelRead = Field(description="Configured model the setup will run.")
+    start_period: PeriodID | None = Field(
+        description="Period the recurring run starts forecasting from; `None` means run-time default."
+    )
+    org_units: list[str] = Field(description="Identifiers of the org units the setup forecasts for.")
+    covariate_sources: list[DataSource] = Field(
+        description="Mapping of covariate names to data element ids used to source the inputs."
+    )
+    period_type: str | None = Field(description="Granularity of the forecast periods (`month`, `week`, ...).")
+    schedule_cron_expression: str | None = Field(
+        description="Standard cron expression for when the setup runs; `None` means manual-only."
+    )
+    schedule_enabled: bool = Field(description="When True, the scheduler executes the setup at every cron tick.")
+    quantile_targets: list[QuantileTarget] = Field(
+        description="Where to push each quantile of the predictive distribution."
+    )
 
 
 OldBacktestRead = _BacktestRead
 
 
 class BacktestRead(_BacktestRead):
-    dataset: DataSetMeta
-    aggregate_metrics: dict[str, float]
-    configured_model: ConfiguredModelRead | None
-    prediction_setup_id: int | None = None
+    """API read shape for a `Backtest`. Same fields as the DB row plus the joined dataset / model / setup links."""
+
+    dataset: DataSetMeta = Field(description="Slim dataset summary the backtest evaluated against.")
+    aggregate_metrics: dict[str, float] = Field(
+        description="Map of metric id to aggregated score across all splits / org units."
+    )
+    configured_model: ConfiguredModelRead | None = Field(
+        description="Configured model used for the backtest, joined for convenience."
+    )
+    prediction_setup_id: int | None = Field(
+        default=None, description="Id of the attached `PredictionSetup`, if one exists."
+    )
 
 
 class ForecastBase(DBModel):
-    period: PeriodID
-    org_unit: str
-    values: list[float] = Field(default_factory=list, sa_type=JSON)
+    """Shared shape for a single (period, org_unit) forecast carrying its sample values."""
+
+    period: PeriodID = Field(description="Period the forecast is for.")
+    org_unit: str = Field(description="Identifier of the org unit the forecast is for.")
+    values: list[float] = Field(
+        default_factory=list,
+        sa_type=JSON,
+        description="Posterior sample values for this (period, org_unit). Quantiles are derived from these at read time.",
+    )
 
     def get_quantiles(self, quantiles: list[float]) -> np.ndarray:
         return np.quantile(self.values, quantiles).astype(float)
 
 
-class ForecastRead(ForecastBase): ...
+class ForecastRead(ForecastBase):
+    """API read shape for a forecast — currently identical to `ForecastBase`."""
 
 
 class PredictionBase(DBModel):
-    dataset_id: int = Field(foreign_key="dataset.id")
-    model_id: str
-    n_periods: int
-    name: str
-    created: datetime.datetime
-    meta_data: dict = Field(default_factory=dict, sa_column=Column(JSON))
-    org_units: list[str] = Field(default_factory=list, sa_column=Column(JSON))
+    """Shared fields for every prediction shape (DB row, read view, ...)."""
+
+    dataset_id: int = Field(
+        foreign_key="dataset.id", description="Foreign key to the `DataSet` the prediction was run against."
+    )
+    model_id: str = Field(description="Name of the configured model that produced the prediction.")
+    n_periods: int = Field(description="Number of periods the model was asked to forecast.")
+    name: str = Field(description="Human-friendly name for the prediction run.")
+    created: datetime.datetime = Field(description="Server-side timestamp when the prediction row was created.")
+    meta_data: dict = Field(
+        default_factory=dict,
+        sa_column=Column(JSON),
+        description="Free-form metadata bag attached to the prediction (e.g. provenance, scheduler context).",
+    )
+    org_units: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description="Identifiers of the org units the prediction was run for.",
+    )
 
 
 class Prediction(PredictionBase, table=True):
-    id: int | None = Field(primary_key=True, default=None)
+    """Persisted prediction row. Owns its per-period forecasts and optionally belongs to a `PredictionSetup`."""
+
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
     forecasts: list["PredictionSamplesEntry"] = Relationship(back_populates="prediction", cascade_delete=True)
     dataset: DataSet = Relationship()
-    model_db_id: int = Field(foreign_key="configuredmodeldb.id")
+    model_db_id: int = Field(
+        foreign_key="configuredmodeldb.id",
+        description="Foreign key to the `ConfiguredModelDB` row used to run the prediction.",
+    )
     configured_model: Optional["ConfiguredModelDB"] = Relationship()
-    prediction_setup_id: int | None = Field(default=None, foreign_key="predictionsetup.id", nullable=True)
+    prediction_setup_id: int | None = Field(
+        default=None,
+        foreign_key="predictionsetup.id",
+        nullable=True,
+        description="Foreign key to the `PredictionSetup` that triggered the run, if any.",
+    )
     prediction_setup: Optional["PredictionSetup"] = Relationship(back_populates="predictions")
 
 
 class PredictionInfo(PredictionBase):
-    id: int
-    configured_model: ConfiguredModelDB | None
-    dataset: DataSetMeta
+    """Summary read view for a prediction — fields + joined dataset/model, no per-period forecasts."""
+
+    id: int = Field(description="Primary key of the prediction.")
+    configured_model: ConfiguredModelDB | None = Field(
+        description="Configured model used for the prediction, joined for convenience."
+    )
+    dataset: DataSetMeta = Field(description="Slim dataset summary the prediction was run against.")
 
 
 # PredictionInfo = PredictionBase.get_read_class()
 
 
 class PredictionRead(PredictionInfo):
-    forecasts: list[ForecastRead]
+    """Full prediction read view: summary fields plus every per-period forecast."""
+
+    forecasts: list[ForecastRead] = Field(description="Per-(period, org_unit) forecast rows for this prediction.")
 
 
 class PredictionSetupReadWithPredictions(PredictionSetupRead):
-    predictions: list[PredictionInfo] = []
+    """`PredictionSetupRead` augmented with the list of predictions the setup has produced so far."""
+
+    predictions: list[PredictionInfo] = Field(
+        default=[],
+        description="Predictions produced by this setup so far, summary view only.",
+    )
 
 
 class PredictionSamplesEntry(ForecastBase, table=True):
-    id: int | None = Field(primary_key=True, default=None)
-    prediction_id: int = Field(foreign_key="prediction.id")
+    """Persisted forecast row that belongs to a `Prediction` (not a backtest)."""
+
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
+    prediction_id: int = Field(foreign_key="prediction.id", description="Foreign key to the owning `Prediction`.")
     prediction: "Prediction" = Relationship(back_populates="forecasts")
 
 
 class BacktestForecast(ForecastBase, table=True):
-    id: int | None = Field(primary_key=True, default=None)
-    backtest_id: int = Field(foreign_key="backtest.id")
-    last_train_period: PeriodID
-    last_seen_period: PeriodID
+    """Persisted forecast row that belongs to a `Backtest` — adds train/seen-period context."""
+
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
+    backtest_id: int = Field(foreign_key="backtest.id", description="Foreign key to the owning `Backtest`.")
+    last_train_period: PeriodID = Field(
+        description="Most recent period included in the training window for this forecast."
+    )
+    last_seen_period: PeriodID = Field(
+        description="Most recent period whose actuals were visible when this forecast was generated."
+    )
     backtest: Backtest = Relationship(back_populates="forecasts")
 
 
@@ -189,14 +320,24 @@ class BacktestMetric(DBModel, table=True):
     Can be removed when no references left to this class.
     """
 
-    id: int | None = Field(primary_key=True, default=None)
-    backtest_id: int = Field(foreign_key="backtest.id")
-    metric_id: str
-    period: PeriodID  # Should this be optional and be null for aggregate metrics?
-    org_unit: str  # Should this be optional and be null for aggregate metrics?
-    last_train_period: PeriodID
-    last_seen_period: PeriodID
-    value: float
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")
+    backtest_id: int = Field(foreign_key="backtest.id", description="Foreign key to the owning `Backtest`.")
+    metric_id: str = Field(description="Canonical metric identifier (e.g. `crps`, `mae`).")
+    period: PeriodID = Field(
+        description="Period this metric value applies to (currently always populated; aggregates handled elsewhere)."
+    )
+    # Should this be optional and be null for aggregate metrics?
+    org_unit: str = Field(
+        description="Org unit this metric value applies to (currently always populated; aggregates handled elsewhere)."
+    )
+    # Should this be optional and be null for aggregate metrics?
+    last_train_period: PeriodID = Field(
+        description="Most recent period included in the training window for this score."
+    )
+    last_seen_period: PeriodID = Field(
+        description="Most recent period whose actuals were visible when this score was computed."
+    )
+    value: float = Field(description="Computed metric value.")
     backtest: Backtest = Relationship(back_populates="metrics")
 
 

--- a/chap_core/model_spec.py
+++ b/chap_core/model_spec.py
@@ -17,6 +17,11 @@ _non_feature_names = {
 
 
 class PeriodType(Enum):
+    """Granularity at which a model accepts inputs and emits forecasts.
+
+    `any` means the model handles whatever the dataset's `period_type` is.
+    """
+
     week = "week"
     month = "month"
     any = "any"

--- a/chap_core/plotting/evaluation_plot.py
+++ b/chap_core/plotting/evaluation_plot.py
@@ -1,4 +1,5 @@
 import altair as alt
+from sqlmodel import Field
 
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metric_plots import MetricPlotBase
@@ -8,9 +9,11 @@ from chap_core.database.tables import Backtest
 
 
 class VisualizationInfo(DBModel):
-    id: str
-    display_name: str
-    description: str
+    """Catalogue entry for one available metric visualisation (returned by `/v1/visualization/metrics/{backtest_id}` and similar)."""
+
+    id: str = Field(description="Canonical plot identifier used in URLs.")
+    display_name: str = Field(description="Human-friendly plot name shown in pickers.")
+    description: str = Field(description="Short paragraph explaining what the plot shows.")
 
 
 def make_plot_from_backtest_object(

--- a/chap_core/rest_api/celery_tasks.py
+++ b/chap_core/rest_api/celery_tasks.py
@@ -12,7 +12,7 @@ from celery import Celery, Task, shared_task
 from celery.result import AsyncResult
 from celery.utils.log import get_task_logger
 from dotenv import find_dotenv, load_dotenv
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
@@ -48,14 +48,20 @@ logger.setLevel(logging.INFO)
 
 # Send database url in function queue call. Have a dict in module of database url to engines. Look up engine in dict
 class JobDescription(BaseModel):
-    id: str
-    type: str
-    name: str
-    status: str
-    start_time: str | None
-    end_time: str | None
-    result: str | None
-    prediction_setup_id: int | None = None
+    """Public job metadata surfaced by the `/v1/jobs` endpoints — what the UI shows in a job list."""
+
+    id: str = Field(description="Identifier of the job (matches the underlying Celery task id).")
+    type: str = Field(
+        description="Canonical job-type string from `JobType` (e.g. `create_backtest`, `create_prediction`)."
+    )
+    name: str = Field(description="Human-friendly name for the job, set by the caller at enqueue time.")
+    status: str = Field(description="Current job status (`PENDING`, `STARTED`, `SUCCESS`, `FAILURE`, ...).")
+    start_time: str | None = Field(description="ISO timestamp when the job started running; `None` while still queued.")
+    end_time: str | None = Field(description="ISO timestamp when the job completed; `None` while still running.")
+    result: str | None = Field(description="Result blob produced by the job (JSON string) or error message on failure.")
+    prediction_setup_id: int | None = Field(
+        default=None, description="`PredictionSetup.id` this job belongs to, when applicable."
+    )
 
 
 def read_environment_variables():

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -12,107 +12,155 @@ from chap_core.database.tables import BacktestBase, BacktestForecast, BacktestMe
 
 
 class PredictionBase(BaseModel):
-    orgUnit: str
-    dataElement: str
-    period: str
+    """Shared identifying triple for a single predicted value (org unit + period + which element)."""
+
+    orgUnit: str = Field(description="Org-unit identifier the value is for.")
+    dataElement: str = Field(description="External data element id the value belongs to.")
+    period: str = Field(description="Period the value is for.")
 
 
 class PredictionResponse(PredictionBase):
-    value: float
+    """`PredictionBase` plus a single scalar value (used for non-sample-based predictions)."""
+
+    value: float = Field(description="Predicted value.")
 
 
 class PredictionSamplResponse(PredictionBase):
-    values: list[float]
+    """`PredictionBase` plus the posterior sample values (caller derives quantiles client-side)."""
+
+    values: list[float] = Field(description="Posterior sample values for this (org-unit, period, element).")
 
 
 class FullPredictionResponse(BaseModel):
-    diseaseId: str
-    dataValues: list[PredictionResponse]
+    """Aggregate response carrying every predicted value for one disease."""
+
+    diseaseId: str = Field(description="Identifier of the disease the predictions are for.")
+    dataValues: list[PredictionResponse] = Field(description="One row per (org-unit, period, element).")
 
 
 class FetchRequest(DBModel):
-    feature_name: str
-    data_source_name: str
+    """Tell the server which feature to fetch from which data source when materialising a dataset."""
+
+    feature_name: str = Field(description="Canonical feature name (matching a `FeatureType.name`).")
+    data_source_name: str = Field(description="Canonical name of the source to pull from.")
 
 
 class DatasetMakeRequest(DataSetCreateInfo):
-    geojson: FeatureCollectionModel
-    provided_data: list[ObservationBase]
-    data_to_be_fetched: list[FetchRequest]
+    """Request body for building a dataset: metadata + polygons + observations (provided or fetched)."""
+
+    geojson: FeatureCollectionModel = Field(description="GeoJSON polygon set for the dataset's org units.")
+    provided_data: list[ObservationBase] = Field(description="Observations the caller is supplying directly.")
+    data_to_be_fetched: list[FetchRequest] = Field(
+        description="Features whose observations the server should fetch from a registered source."
+    )
 
 
 class JobResponse(BaseModel):
-    id: str
+    """Response returned from any endpoint that enqueues background work."""
+
+    id: str = Field(description="Identifier of the queued job; use it to poll status via the jobs endpoints.")
 
 
 class PredictionParams(DBModel):
-    model_id: str
-    n_periods: int = Field(default=3, gt=0)
+    """Shared prediction-side parameters embedded in request models."""
+
+    model_id: str = Field(description="Canonical name of the configured model to run.")
+    n_periods: int = Field(default=3, gt=0, description="Number of future periods to forecast.")
 
 
 class ValidationError(DBModel):
-    reason: str
-    org_unit: str
-    feature_name: str
-    time_periods: list[str]
+    """One row of structured validation feedback returned from CSV/JSON dataset imports."""
+
+    reason: str = Field(description="Human-readable reason the row was rejected.")
+    org_unit: str = Field(description="Org-unit identifier the rejected row referred to.")
+    feature_name: str = Field(description="Canonical feature name the rejected row referred to.")
+    time_periods: list[str] = Field(description="Affected periods (may be a single period or a range).")
 
 
 class ImportSummaryResponse(DBModel):
-    id: str | None
-    imported_count: int
-    rejected: list[ValidationError]
+    """Result of a dataset import: how many rows landed, how many were rejected, and why."""
+
+    id: str | None = Field(
+        description="Identifier of the imported dataset; `None` if the import was rejected outright."
+    )
+    imported_count: int = Field(description="Number of observations that were successfully imported.")
+    rejected: list[ValidationError] = Field(description="One row per rejected observation, with the reason.")
 
 
 class BacktestCreate(BacktestBase):
+    """Request body for creating a backtest row directly (DB-level — typically the long path goes via `MakeBacktestRequest`)."""
+
     # Accept either the configured-model integer primary key or its string
     # name. The underlying DB column (`BacktestBase.model_id`) is a string,
     # but the `POST /v1/crud/backtests/` handler resolves an `int` to the
     # corresponding name before persisting so the column stays consistent.
     # See `chap_core.rest_api.v1.routers.crud.create_backtest` for the
     # resolution path.
-    model_id: int | str  # type: ignore[assignment]
+    model_id: int | str = Field(  # type: ignore[assignment]
+        description="Configured model to backtest: either the integer primary key or the canonical string name.",
+    )
 
 
 class BacktestFull(BacktestRead):
-    metrics: list[BacktestMetric]
-    forecasts: list[BacktestForecast]
+    """Full backtest read view: `BacktestRead` plus every per-(period, org-unit) metric and forecast."""
+
+    metrics: list[BacktestMetric] = Field(description="Per-(period, org-unit) metric values for this backtest.")
+    forecasts: list[BacktestForecast] = Field(description="Per-(period, org-unit) forecast rows for this backtest.")
 
 
 class BacktestDomain(DBModel):
-    org_units: list[str]
-    split_periods: list[str]
+    """The set of org units + split periods a backtest covers — used by the UI to filter visualisations."""
+
+    org_units: list[str] = Field(description="Identifiers of every org unit the backtest scored predictions over.")
+    split_periods: list[str] = Field(
+        description="Periods at which the rolling backtest's train/test split was advanced."
+    )
 
 
 class ChapDataSource(DBModel):
-    name: str
-    display_name: str
-    supported_features: list[str]
-    description: str
-    dataset: str
+    """Catalogue entry describing one registered data source (chap-side metadata, not the DB-table row)."""
+
+    name: str = Field(description="Canonical identifier of the source.")
+    display_name: str = Field(description="Human-friendly name shown in source pickers.")
+    supported_features: list[str] = Field(description="Canonical feature names this source can deliver.")
+    description: str = Field(description="Short paragraph describing what this source provides.")
+    dataset: str = Field(description="Canonical name of the upstream dataset this source pulls from.")
 
 
 class MakePredictionRequest(DatasetMakeRequest, PredictionParams):
-    meta_data: dict = {}
+    """Long-path request for kicking off a prediction: combines dataset construction + model parameters."""
+
+    meta_data: dict = Field(
+        default={}, description="Free-form metadata bag stored alongside the resulting prediction row."
+    )
 
 
 class MakeBacktestRequest(BacktestParams):
-    name: str
-    model_id: str
-    dataset_id: int
+    """Request to backtest an already-imported dataset against a configured model."""
+
+    name: str = Field(description="Human-friendly name for the resulting backtest row.")
+    model_id: str = Field(description="Canonical name of the configured model to backtest.")
+    dataset_id: int = Field(description="Foreign key to the dataset the backtest evaluates against.")
 
 
 class MakeBacktestWithDataRequest(DatasetMakeRequest, BacktestParams):
-    name: str
-    model_id: str
+    """Long-path request: build the dataset, then immediately backtest the configured model against it."""
+
+    name: str = Field(description="Human-friendly name for the resulting backtest row.")
+    model_id: str = Field(description="Canonical name of the configured model to backtest.")
 
 
 class DataBaseResponse(DBModel):
-    id: int
+    """Generic response that just echoes the created row's primary key."""
+
+    id: int = Field(description="Primary key of the row that was created or affected.")
 
 
 class DatasetCreate(DataSetCreateInfo):
-    observations: list[ObservationBase]
-    geojson: FeatureCollectionModel
+    """Request body for creating a dataset directly from a fully-materialised observation list + polygons."""
+
+    observations: list[ObservationBase] = Field(description="Every observation that should land in the new dataset.")
+    geojson: FeatureCollectionModel = Field(description="GeoJSON polygon set for the dataset's org units.")
 
 
 class ModelTemplateRead(DBModel, ModelTemplateInformation, ModelTemplateMetaData):
@@ -121,14 +169,20 @@ class ModelTemplateRead(DBModel, ModelTemplateInformation, ModelTemplateMetaData
     It is used to return the model template in a readable format.
     """
 
-    name: str
-    id: int
-    user_options: dict | None = None
-    required_covariates: list[str] = []
-    version: str | None = None
-    archived: bool = False
-    health_status: str | None = None
-    uses_chapkit: bool = False
+    name: str = Field(description="Canonical unique identifier of the template.")
+    id: int = Field(description="Primary key of the template.")
+    user_options: dict | None = Field(
+        default=None, description="JSON-schema-like dict describing the template's user-configurable options."
+    )
+    required_covariates: list[str] = Field(default=[], description="Covariate names the template must be given to run.")
+    version: str | None = Field(default=None, description="Template version string, typically a git tag or commit sha.")
+    archived: bool = Field(default=False, description="When True, the template is hidden from default pickers.")
+    health_status: str | None = Field(
+        default=None, description="Reported health status of the template, used by chapkit-hosted models."
+    )
+    uses_chapkit: bool = Field(
+        default=False, description="When True, the template is served by a chapkit REST endpoint."
+    )
 
 
 class ConfiguredModelInfoRead(DBModel):
@@ -140,61 +194,98 @@ class ConfiguredModelInfoRead(DBModel):
     to the chosen values without stitching together multiple list calls.
     """
 
-    id: int
-    name: str
-    display_name: str
-    model_template_id: int
-    user_option_values: dict | None = None
-    additional_continuous_covariates: list[str] = []
-    archived: bool = False
-    uses_chapkit: bool = False
-    model_template: ModelTemplateRead
+    id: int = Field(description="Primary key of the configured model.")
+    name: str = Field(description="Canonical name of the configured model.")
+    display_name: str = Field(
+        description="Human-friendly name stitched from the template name and (optionally) a configuration stub."
+    )
+    model_template_id: int = Field(description="Foreign key to the parent `ModelTemplateDB`.")
+    user_option_values: dict | None = Field(
+        default=None, description="Configured values for the template's user-options."
+    )
+    additional_continuous_covariates: list[str] = Field(
+        default=[], description="Extra continuous covariates passed beyond the template's required set."
+    )
+    archived: bool = Field(default=False, description="When True, the configured model is hidden from default pickers.")
+    uses_chapkit: bool = Field(
+        default=False, description="Inherited from the template; True for chapkit-hosted models."
+    )
+    model_template: ModelTemplateRead = Field(description="Parent template the configuration extends.")
 
 
 class ModelConfigurationCreate(DBModel):
-    name: str
-    model_template_id: int
-    user_option_values: dict = Field(default_factory=dict)
-    additional_continuous_covariates: list[str] = []
+    """Request body for adding a new configured model on top of a template."""
+
+    name: str = Field(
+        description="Canonical name for the new configured model; conventionally `<template_name>:<config_stub>`."
+    )
+    model_template_id: int = Field(description="Foreign key to the parent `ModelTemplateDB`.")
+    user_option_values: dict = Field(
+        default_factory=dict, description="Values for the user-options declared by the parent template."
+    )
+    additional_continuous_covariates: list[str] = Field(
+        default=[], description="Extra continuous covariates beyond the template's required set."
+    )
 
 
 class PredictionCreate(DBModel):
-    dataset_id: int
-    estimator_id: str
-    n_periods: int
+    """Request body for creating a prediction row directly (DB-level)."""
+
+    dataset_id: int = Field(description="Foreign key to the dataset the prediction was run against.")
+    estimator_id: str = Field(description="Canonical name of the configured model used to produce the prediction.")
+    n_periods: int = Field(description="Number of periods the model was asked to forecast.")
 
 
 class BacktestUpdate(DBModel):
-    name: str | None = None
+    """Partial-update body for an existing backtest. Currently only the human-friendly name is mutable."""
+
+    name: str | None = Field(default=None, description="New human-friendly name; `None` leaves it unchanged.")
 
 
 class PredictionSetupCreate(DBModel):
-    backtest_id: int
-    name: str
-    schedule_cron_expression: str | None = None
-    schedule_enabled: bool = False
-    quantile_targets: list[QuantileTarget] = Field(default_factory=list)
+    """Request body for creating a recurring prediction setup attached to a backtest."""
+
+    backtest_id: int = Field(description="Foreign key to the parent `Backtest` the setup will run forward in time.")
+    name: str = Field(description="Human-friendly name for the setup.")
+    schedule_cron_expression: str | None = Field(
+        default=None, description="Standard cron expression for when to run; `None` means manual-only."
+    )
+    schedule_enabled: bool = Field(
+        default=False, description="When True, the scheduler executes the setup at every cron tick."
+    )
+    quantile_targets: list[QuantileTarget] = Field(
+        default_factory=list,
+        description="Where to push each quantile of the predictive distribution.",
+    )
 
 
 class PredictionSetupUpdate(DBModel):
+    """Partial-update body for an existing prediction setup. Rejects unknown fields with HTTP 422."""
+
     # Reject unknown fields so clients trying to update immutable fields
     # (backtestId, configuredModelId, etc.) get a clear 422 instead of a silent no-op.
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="forbid")  # type: ignore[assignment]
 
-    name: str | None = None
-    schedule_cron_expression: str | None = None
-    schedule_enabled: bool | None = None
-    quantile_targets: list[QuantileTarget] | None = None
+    name: str | None = Field(default=None, description="New human-friendly name; `None` leaves it unchanged.")
+    schedule_cron_expression: str | None = Field(
+        default=None, description="New cron expression; `None` leaves it unchanged."
+    )
+    schedule_enabled: bool | None = Field(default=None, description="New enabled flag; `None` leaves it unchanged.")
+    quantile_targets: list[QuantileTarget] | None = Field(
+        default=None, description="New full quantile-targets list; `None` leaves it unchanged."
+    )
 
 
 class RunPredictionSetupRequest(DBModel):
+    """Request body for a one-shot run of a prediction setup. Rejects unknown fields with HTTP 422."""
+
     # Reject unknown fields so legacy clients still sending dataSources /
     # dataToBeFetched / configuredModelWithDataSourceId fail loud instead of
     # having those fields silently dropped.
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="forbid")  # type: ignore[assignment]
 
-    name: str
-    geojson: FeatureCollectionModel
-    provided_data: list[ObservationBase]
-    type: str | None = None
-    n_periods: int = Field(default=3, gt=0)
+    name: str = Field(description="Human-friendly name for the one-shot prediction run.")
+    geojson: FeatureCollectionModel = Field(description="GeoJSON polygon set for the org units in the run.")
+    provided_data: list[ObservationBase] = Field(description="Observations supplied directly by the caller.")
+    type: str | None = Field(default=None, description="Free-form run-type marker stored alongside the prediction.")
+    n_periods: int = Field(default=3, gt=0, description="Number of future periods to forecast.")

--- a/chap_core/rest_api/services/schemas.py
+++ b/chap_core/rest_api/services/schemas.py
@@ -37,24 +37,32 @@ class PeriodType(StrEnum):
 class ModelMetadata(BaseModel):
     """Metadata about the ML model author and documentation."""
 
-    author: str | None = None
-    author_note: str | None = None
-    author_assessed_status: AssessedStatus | None = None
-    contact_email: EmailStr | None = None
-    organization: str | None = None
-    organization_logo_url: HttpUrl | None = None
-    citation_info: str | None = None
-    repository_url: HttpUrl | None = None
-    documentation_url: HttpUrl | None = None
+    author: str | None = Field(default=None, description="Person or team that authored the model.")
+    author_note: str | None = Field(
+        default=None, description="Free-form note from the author (caveats, intended use, ...)."
+    )
+    author_assessed_status: AssessedStatus | None = Field(
+        default=None, description="Author-declared maturity rating (gray/red/orange/yellow/green)."
+    )
+    contact_email: EmailStr | None = Field(default=None, description="Contact email for the model author / maintainer.")
+    organization: str | None = Field(default=None, description="Affiliated organisation, if any.")
+    organization_logo_url: HttpUrl | None = Field(
+        default=None, description="URL of an organisation logo to render next to the model."
+    )
+    citation_info: str | None = Field(
+        default=None, description="How to cite the model in publications (DOI, BibTeX, ...)."
+    )
+    repository_url: HttpUrl | None = Field(default=None, description="URL to the model's source code repository.")
+    documentation_url: HttpUrl | None = Field(default=None, description="URL to the model's external documentation.")
 
 
 class ServiceInfo(BaseModel):
     """Base service information metadata."""
 
     id: str = Field(description="Unique service identifier (slug format)")
-    display_name: str
-    version: str = "1.0.0"
-    description: str | None = None
+    display_name: str = Field(description="Human-friendly service name shown to operators.")
+    version: str = Field(default="1.0.0", description="Service version string.")
+    description: str | None = Field(default=None, description="Short paragraph describing what the service does.")
 
     @field_validator("id")
     @classmethod
@@ -71,13 +79,27 @@ class ServiceInfo(BaseModel):
 class MLServiceInfo(ServiceInfo):
     """ML service information extending base ServiceInfo with model-specific fields."""
 
-    model_metadata: ModelMetadata
-    period_type: PeriodType
-    min_prediction_periods: int = 0
-    max_prediction_periods: int = 100
-    allow_free_additional_continuous_covariates: bool = False
-    required_covariates: list[str] = Field(default_factory=list)
-    requires_geo: bool = False
+    model_metadata: ModelMetadata = Field(
+        description="Author / documentation metadata for the model the service hosts."
+    )
+    period_type: PeriodType = Field(description="Period granularity the model accepts (`weekly` or `monthly`).")
+    min_prediction_periods: int = Field(
+        default=0, description="Minimum forecast horizon (in periods) the model supports."
+    )
+    max_prediction_periods: int = Field(
+        default=100, description="Maximum forecast horizon (in periods) the model supports."
+    )
+    allow_free_additional_continuous_covariates: bool = Field(
+        default=False,
+        description="When True, callers can attach extra continuous covariates beyond `required_covariates`.",
+    )
+    required_covariates: list[str] = Field(
+        default_factory=list,
+        description="Covariate names the model must be given to run.",
+    )
+    requires_geo: bool = Field(
+        default=False, description="When True, the model needs a GeoJSON polygon set for spatial features."
+    )
 
 
 class RegistrationRequest(BaseModel):

--- a/chap_core/rest_api/v1/jobs.py
+++ b/chap_core/rest_api/v1/jobs.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlmodel import Session
 
 from chap_core.database.tables import Backtest, BacktestRead, Prediction, PredictionInfo
@@ -209,7 +209,9 @@ def get_evaluation_result(
 
 
 class DataBaseResponse(BaseModel):
-    id: int
+    """Generic job-result payload that just echoes the created row's primary key."""
+
+    id: int = Field(description="Primary key of the row the job created or affected.")
 
 
 @router.get(

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlmodel import Session
+from sqlmodel import Field, Session
 from starlette.responses import JSONResponse
 
 from chap_core.assessment.backtest_plots import (
@@ -45,13 +45,17 @@ def get_avilable_metric_plots(backtest_id: int):
 
 
 class VisualizationParams(DBModel):
-    metric_id: int
+    """Inputs for requesting a metric-aware backtest plot."""
+
+    metric_id: int = Field(description="Primary key of the metric to score against.")
 
 
 class MetricInfo(DBModel):
-    id: str
-    display_name: str
-    description: str = ""
+    """Catalogue entry for one scoring metric (CRPS, MAE, ...)."""
+
+    id: str = Field(description="Canonical metric identifier used in URLs and request bodies.")
+    display_name: str = Field(description="Human-friendly metric name shown in pickers.")
+    description: str = Field(default="", description="Short paragraph explaining what the metric measures.")
 
 
 @router.get(
@@ -111,9 +115,11 @@ def generate_visualization(
 
 
 class DatasetPlotType(DBModel):
-    id: str
-    display_name: str
-    description: str = ""
+    """Catalogue entry for one dataset-level plot style (observation time-series, polygon overlay, ...)."""
+
+    id: str = Field(description="Canonical plot identifier used in URLs.")
+    display_name: str = Field(description="Human-friendly plot name shown in pickers.")
+    description: str = Field(default="", description="Short paragraph explaining what the plot shows.")
 
 
 @router.get(
@@ -159,9 +165,11 @@ def generate_data_plots(visualization_name: str, dataset_id: int, session: Sessi
 
 
 class BacktestPlotType(DBModel):
-    id: str
-    display_name: str
-    description: str = ""
+    """Catalogue entry for one backtest-level plot style (per-metric, per-org-unit, ...)."""
+
+    id: str = Field(description="Canonical plot identifier used in URLs.")
+    display_name: str = Field(description="Human-friendly plot name shown in pickers.")
+    description: str = Field(default="", description="Short paragraph explaining what the plot shows.")
 
 
 @router.get(


### PR DESCRIPTION
## Summary

Sweep through every pydantic / SQLModel class that surfaces under `components.schemas` in the OpenAPI spec and add a short, operator-facing description — `Field(description=...)` on properties, class docstrings on the schemas themselves.

Closes [CLIM-729](https://dhis2.atlassian.net/browse/CLIM-729).

## Coverage

| | Before | After |
|---|---|---|
| Schemas with description | 21 / 73 | **69 / 74** |
| Properties with description | 53 / 398 | **366 / 396** |

The 5 remaining schemas (and 30 properties) without descriptions are all third-party leakage we don't own:

- `HTTPValidationError` + `ValidationError` (FastAPI / pydantic)
- `Position2D` / `Position3D` and the geometry types (geojson_pydantic)
- `Body_create_dataset_csv_v1_crud_datasets_csvFile_post` (FastAPI auto-generated multipart body)

## Files touched

Description-only edits, no behaviour change:

- `chap_core/api_types.py`
- `chap_core/database/dataset_tables.py`, `feature_tables.py`, `model_spec_tables.py`, `model_templates_and_config_tables.py`, `tables.py`
- `chap_core/model_spec.py`
- `chap_core/plotting/evaluation_plot.py`
- `chap_core/rest_api/celery_tasks.py`, `data_models.py`, `services/schemas.py`
- `chap_core/rest_api/v1/jobs.py`, `v1/routers/visualization.py`

## Verification

- `make lint` clean.
- `make test`: 936 passed, 114 skipped — same as master.
- OpenAPI spec re-counted (numbers in table above).

## Test plan

- [ ] CI green
- [ ] Spot-check `/docs` renders the new copy for a couple of schemas (request, read, error)

## See also

- Sibling: CLIM-728 (endpoint-level summary / description) — separate PR.

[CLIM-729]: https://dhis2.atlassian.net/browse/CLIM-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ