### PR TITLE
chore(test): sequential make test locally, xdist parallelism in CI

### DIFF
--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -29,4 +29,4 @@ jobs:
         run: uv sync --dev
       - name: Run pytest
         run: |
-          uv run pytest
+          uv run pytest -n auto --dist loadfile

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,10 @@ check-alembic-heads: ## fail if the alembic migration chain has more than one he
 	@echo "Alembic head count..."
 	@uv run python -c "from alembic.config import Config; from alembic.script import ScriptDirectory; heads = ScriptDirectory.from_config(Config('alembic.ini')).get_heads(); assert len(heads) == 1, f'Expected 1 alembic head, found {len(heads)}: {heads}'; print(f'OK: single head {heads[0]}')"
 
-test: ## run tests quickly with minimal output (parallel via pytest-xdist)
+test: ## run tests quickly with minimal output (sequential; snappy startup)
+	uv run pytest -q
+
+test-parallel: ## run tests across all cores via pytest-xdist (faster wall time, slow startup)
 	uv run pytest -q -n auto --dist loadfile
 
 test-docs: ## run fast documentation code block tests


### PR DESCRIPTION
## Summary

`-n auto` (added in #381) spawns one pytest-xdist worker per core, and each worker cold-imports the full `chap_core` stack (pandas, geopandas, gluonts, mlflow, ...) before collection starts. On a 12-core machine that's ~30-60s of silent `bringing up nodes...` that reads as a hang during interactive runs.

Split the concern by who's running it:

- **`make test`** — back to plain `uv run pytest -q`. Snappy startup, what you want when iterating locally.
- **`make test-parallel`** — keeps `-n auto --dist loadfile` for when total wall time matters more than startup latency.
- **CI** (`ci-test-python-install.yml`) — now runs `pytest -n auto --dist loadfile` directly. The bringup cost is amortised against a cold-start runner anyway, and the ~4:30 → ~3:00 wall-time win is real there across the 3-OS matrix.

No change to test behaviour or selection. `pytest-xdist` is already a dev dep pulled in by `uv sync --dev`, so CI has it.

## Test plan

- [ ] CI green (and visibly faster than the previous sequential runs)
- [ ] `make test` starts immediately; `make test-parallel` reproduces the parallel run