### PR TITLE
fix(runners): wrap MlFlowTrainPredictRunner.predict() failures as ModelFailedException

### DIFF
--- a/chap_core/runners/mlflow_runner.py
+++ b/chap_core/runners/mlflow_runner.py
@@ -64,11 +64,20 @@ class MlFlowTrainPredictRunner(TrainPredictRunner):
             "model_config": str(self.model_configuration_filename) if self.model_configuration_filename else None,
         }
         params.update({key: val for key, val in extra_params.items() if key in self.extra_params and val is not None})
-        return mlflow.projects.run(
-            str(self.model_path),
-            entry_point="predict",
-            parameters=params,
-        )
+        try:
+            return mlflow.projects.run(
+                str(self.model_path),
+                entry_point="predict",
+                parameters=params,
+            )
+        except ShellCommandException as e:
+            logger.error(
+                "Error running mlflow project, might be due to missing pyenv (See: https://github.com/pyenv/pyenv#installation)"
+            )
+            raise ModelFailedException(str(e)) from e
+        except mlflow.exceptions.ExecutionException as e:
+            logger.error("Execution of model failed for some reason. Check the logs for more information")
+            raise ModelFailedException(str(e)) from e
 
     def report(self, model_file_name, historic_data, output_file, polygons_file_name=None):
         logging.debug(f"Running report with output to {output_file}")

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -354,6 +354,18 @@ def test_mlflow_runner_report_wraps_execution_errors(tmp_path):
             runner.report("model", "historic.csv", "out.pdf")
 
 
+def test_mlflow_runner_predict_wraps_execution_errors(tmp_path):
+    # predict() must convert mlflow execution failures into ModelFailedException
+    # (like train()/report() do) so callers — e.g. explainability's per-location
+    # fallback — can catch them instead of a raw mlflow ExecutionException.
+    import mlflow.exceptions
+
+    runner = MlFlowTrainPredictRunner(model_path=tmp_path)
+    with patch("mlflow.projects.run", side_effect=mlflow.exceptions.ExecutionException("boom")):
+        with pytest.raises(ModelFailedException):
+            runner.predict("model", "historic.csv", "future.csv", "out.csv")
+
+
 def test_runner_selection_with_conda_env(tmp_path):
     """Test that get_train_predict_runner_from_model_template_config returns CondaTrainPredictRunner when conda_env is set"""
     config = ModelTemplateConfigV2(


### PR DESCRIPTION
## Summary

`MlFlowTrainPredictRunner` has three methods that call `mlflow.projects.run(...)`: `train()`, `predict()`, and `report()`. `train()` and `report()` wrap that call in a `try/except` that converts `ShellCommandException` and `mlflow.exceptions.ExecutionException` into the project's own `ModelFailedException`. **`predict()` did not** — it called `mlflow.projects.run(...)` raw, so a failed prediction propagated a raw `mlflow.exceptions.ExecutionException`.

This change makes `predict()` consistent with its siblings.

## Why

Callers that catch `ModelFailedException` couldn't recover from a failed prediction. The concrete case: the explainability pipeline (`produce_lime_dataset`) batches perturbations into synthetic pseudo-locations and calls `model.predict(...)`; location-sensitive models fail on those, and there's a designed `except ModelFailedException` fallback that retries each perturbation individually with the *real* location name. Because `predict()` raised a raw `ExecutionException`, that fallback never triggered and `explain-lime` crashed against real mlflow models.

This is a standalone runner fix split out from the explainability work (PR #380), which stays scoped to its own module.

## Changes

- `chap_core/runners/mlflow_runner.py` — wrap `predict()`'s `mlflow.projects.run(...)` in the same `try/except (ShellCommandException, mlflow.exceptions.ExecutionException)` → `raise ModelFailedException(...)` used by `train()` and `report()`. No new imports.
- `tests/runners/test_runners.py` — add `test_mlflow_runner_predict_wraps_execution_errors`, mirroring the existing `test_mlflow_runner_report_wraps_execution_errors`.

No behaviour change beyond the exception *type* raised on failure.

## Test plan

- [x] `uv run pytest tests/runners/test_runners.py` — 24 passed (new test included; verified it fails without the fix).
- [x] `make lint` clean.
- [x] `make test` — 943 passed, 114 skipped (same as master).

## Not in scope

- The Docker runner (`docker_runner.py`, used by EWARS) raises `AssertionError` on failure rather than `ModelFailedException` — analogous but separate.
- Switching the `explain-lime` documented example to a real model — a follow-up once this lands and the end-to-end path is verified.