### PR TITLE
perf: defer heavy imports to speed up external-model subprocess startup

### DIFF
--- a/chap_core/adaptors/command_line_interface.py
+++ b/chap_core/adaptors/command_line_interface.py
@@ -3,10 +3,7 @@ import logging
 import yaml
 from cyclopts import App
 
-# from chap_core.models.model_template_interface import ModelConfiguration
-from chap_core.database.model_templates_and_config_tables import ModelConfiguration
 from chap_core.datatypes import create_tsdataclass, remove_field
-from chap_core.external.model_configuration import CommandConfig, EntryPointConfig, RunnerConfig
 from chap_core.model_spec import get_dataclass
 from chap_core.models.model_template_interface import InternalModelTemplate
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
@@ -92,6 +89,8 @@ def generate_template_app(model_template: InternalModelTemplate, name: str = "de
         return dc
 
     def _read_model_config(model_config_path):
+        from chap_core.database.model_templates_and_config_tables import ModelConfiguration
+
         if model_config_path is not None:
             with open(model_config_path) as file:
                 model_config = yaml.safe_load(file)
@@ -143,6 +142,8 @@ def generate_template_app(model_template: InternalModelTemplate, name: str = "de
         """
         Write the model template to a yaml file
         """
+        from chap_core.external.model_configuration import CommandConfig, EntryPointConfig, RunnerConfig
+
         runner_config = RunnerConfig(
             entry_points=EntryPointConfig(
                 train=CommandConfig(

--- a/chap_core/predictor/naive_predictor.py
+++ b/chap_core/predictor/naive_predictor.py
@@ -1,7 +1,6 @@
 import dataclasses
 
 import numpy as np
-from sklearn import linear_model
 
 from chap_core.datatypes import ClimateData, ClimateHealthTimeSeries, HealthData
 from chap_core.spatio_temporal_data.temporal_dataclass import (
@@ -64,6 +63,8 @@ class MultiRegionPoissonModel:
         return np.hstack([lagged_values, season])
 
     def train(self, data: DataSet[ClimateHealthTimeSeries]):
+        from sklearn import linear_model
+
         for location, location_data in data.items():
             X = self._create_feature_matrix(location_data)
             y = location_data.disease_cases[1:]  # type: ignore[index]

--- a/chap_core/spatio_temporal_data/temporal_dataclass.py
+++ b/chap_core/spatio_temporal_data/temporal_dataclass.py
@@ -8,7 +8,6 @@ from typing import IO, Protocol, TypeVar
 
 import numpy as np
 import pandas as pd
-from matplotlib import pyplot as plt
 from pydantic import BaseModel
 
 from ..api_types import FeatureCollectionModel, PeriodObservation
@@ -582,6 +581,8 @@ class DataSet[FeaturesT]:
         return new_dataset
 
     def plot(self):
+        from matplotlib import pyplot as plt
+
         for location, value in self.items():
             df = value.to_pandas()  # type: ignore[attr-defined]
             df.plot(x="time_period", y="disease_cases")
@@ -597,6 +598,7 @@ class DataSet[FeaturesT]:
         return px.line(x=self.period_range.tolist(), y=total)
 
     def to_report(self, pdf_filename: str):
+        from matplotlib import pyplot as plt
         from matplotlib.backends.backend_pdf import PdfPages
 
         with PdfPages(pdf_filename) as pdf:

--- a/tests/predictor/test_multi_region_predictor.py
+++ b/tests/predictor/test_multi_region_predictor.py
@@ -1,4 +1,4 @@
-from chap_core.predictor.naive_predictor import MultiRegionNaivePredictor
+from chap_core.predictor.naive_predictor import MultiRegionNaivePredictor, MultiRegionPoissonModel
 
 import pytest
 
@@ -16,3 +16,12 @@ def test_naive_predictor(full_data):
     for loc, data in predictions.items():  # type: ignore[reportAttributeAccessIssue]
         assert len(data) == 1
     # assert predictions == test_data
+
+
+def test_poisson_model_train(full_data):
+    # Exercises MultiRegionPoissonModel.train, which lazily imports sklearn;
+    # train completing without raising confirms the deferred import resolves.
+    model = MultiRegionPoissonModel()
+    test_start = Month(2012, 7)  # type: ignore[reportArgumentType]
+    train_data, _ = train_test_split(full_data, test_start)
+    model.train(train_data)

--- a/tests/test_command_line_interface_adaptor.py
+++ b/tests/test_command_line_interface_adaptor.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import numpy as np
 import pytest
 from pydantic import BaseModel
@@ -87,3 +90,16 @@ def test_generate_template_app(dumped_weekly_data_paths, tmp_path, model_config_
 def test_generate_template_app_yaml(model_config_path):
     *_, write_yaml = generate_template_app(DummyModelTemplate())
     write_yaml()
+
+
+def test_command_line_interface_import_is_lean():
+    # Every external-model predict subprocess imports this module, so sklearn and
+    # matplotlib are deferred to keep startup fast. Run in a fresh interpreter
+    # because the test process has already imported them transitively.
+    code = (
+        "import sys, chap_core.adaptors.command_line_interface; "
+        "heavy = [m for m in ('sklearn', 'matplotlib') if m in sys.modules]; "
+        "assert not heavy, heavy"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

External-model predict subprocesses (`python main.py predict …`) import `chap_core.adaptors.command_line_interface`, which eagerly pulled in **sklearn** (~720ms) and **matplotlib** (~160ms) through the predictor and `DataSet` import chains. Neither is needed on the predict path, but the cold import dominated per-call startup — and `chap explain-lime` pays that cost once per LIME perturbation (dozens-to-hundreds of times per run).

This defers the imports into the functions that actually use them:

- `from sklearn import linear_model` → `MultiRegionPoissonModel.train` (`naive_predictor.py`)
- `from matplotlib import pyplot as plt` → the two `DataSet` plotting methods (`temporal_dataclass.py`)
- `ModelConfiguration` and `CommandConfig`/`EntryPointConfig`/`RunnerConfig` → the template-only functions (`command_line_interface.py`)

No behaviour change — same imports, just relocated. The win lands wherever current chap_core is imported (the `chap` CLI, eval orchestration, and any external-model env built on current chap_core).

## Result

`import chap_core.adaptors.command_line_interface` (measured with `python -X importtime`):

| | total self-import |
|---|---|
| before | ~1320 ms |
| after | ~500 ms (-62%) |

sklearn and matplotlib no longer load on import.

## Tests

- `test_command_line_interface_import_is_lean` — fresh-interpreter lock-in: importing the adaptor pulls in neither `sklearn` nor `matplotlib`.
- `test_poisson_model_train` — exercises `MultiRegionPoissonModel.train` so the now-deferred sklearn import is covered.
- Full suite green (962 passed), `make lint` clean.

## Notes / follow-ups (out of scope here)

- In the AR/flax model subprocess, matplotlib is also imported by `ch_modelling`'s flax model (a separate repo), and flax/jax is irreducible on the predict path — so the bigger per-call lever remains a persistent "serve" mode rather than import hygiene.
- sqlmodel still loads via `datatypes → api_types → database.base_tables` (~84ms); deferring it touches foundational code, left out to keep this PR surgical.

## Test plan

- [x] `make lint`
- [x] `make test` (962 passed)
- [x] before/after `-X importtime` measurement