### PR TITLE
refactor: add generate_short_id + generate_run_name util helpers

### DIFF
--- a/chap_core/hpo/objective.py
+++ b/chap_core/hpo/objective.py
@@ -1,6 +1,5 @@
 import logging
 from pathlib import Path
-from uuid import uuid4
 
 from chap_core.api_types import BacktestParams
 from chap_core.assessment.evaluation import Evaluation
@@ -8,6 +7,7 @@ from chap_core.assessment.metrics import calculate_metrics
 from chap_core.database.model_templates_and_config_tables import ModelConfiguration
 from chap_core.models.model_template import ModelTemplate
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+from chap_core.util import generate_short_id
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -43,7 +43,7 @@ class Objective:
         model = self.model_template.get_model(configuration)  # type: ignore[arg-type]
         estimator = model()
 
-        run_id = uuid4().hex[:8]  # short unique id like 'a1b2c3d4'
+        run_id = generate_short_id()
 
         model_template_db = ModelTemplateDB(
             id=self.model_template.model_template_config.name,

--- a/chap_core/models/external_web_model.py
+++ b/chap_core/models/external_web_model.py
@@ -1,7 +1,6 @@
 import io
 import logging
 import time
-import uuid
 from pathlib import Path
 
 import pandas as pd
@@ -13,6 +12,7 @@ from chap_core.exceptions import ModelFailedException
 from chap_core.geometry import Polygons
 from chap_core.models.external_model import ExternalModelBase
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+from chap_core.util import generate_short_id
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +159,7 @@ class ExternalWebModel(ExternalModelBase):
             files["config"] = ("config.yaml", config_yaml, "text/yaml")  # type: ignore[assignment]
 
         # Generate unique model name for this training session
-        self._trained_model_name = f"{self._name}_{uuid.uuid4().hex[:8]}"
+        self._trained_model_name = f"{self._name}_{generate_short_id()}"
 
         data = {
             "model_name": self._trained_model_name,

--- a/chap_core/models/utils.py
+++ b/chap_core/models/utils.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -16,7 +15,7 @@ from chap_core.external.model_configuration import ModelTemplateConfigV2
 from chap_core.models.chapkit_service_manager import is_url
 from chap_core.models.external_chapkit_model import ExternalChapkitModelTemplate
 from chap_core.models.model_template import ModelTemplate
-from chap_core.util import generate_short_id
+from chap_core.util import generate_run_name
 
 CHAP_RUNS_DIR = Path(os.getenv("CHAP_RUNS_DIR", "runs/"))
 
@@ -53,9 +52,7 @@ def _get_working_dir(model_path, base_working_dir, run_dir_type, model_name):
             logger.info(f"Removing previous working dir {working_dir}")
             shutil.rmtree(working_dir)
     elif run_dir_type == "timestamp":
-        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        unique_identifier = timestamp + "_" + generate_short_id()
-        # timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S%f")
+        unique_identifier = generate_run_name()
         working_dir = base_working_dir / model_name / unique_identifier
         # check that working dir does not exist
         assert not working_dir.exists(), (

--- a/chap_core/models/utils.py
+++ b/chap_core/models/utils.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import shutil
-import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -17,6 +16,7 @@ from chap_core.external.model_configuration import ModelTemplateConfigV2
 from chap_core.models.chapkit_service_manager import is_url
 from chap_core.models.external_chapkit_model import ExternalChapkitModelTemplate
 from chap_core.models.model_template import ModelTemplate
+from chap_core.util import generate_short_id
 
 CHAP_RUNS_DIR = Path(os.getenv("CHAP_RUNS_DIR", "runs/"))
 
@@ -54,7 +54,7 @@ def _get_working_dir(model_path, base_working_dir, run_dir_type, model_name):
             shutil.rmtree(working_dir)
     elif run_dir_type == "timestamp":
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        unique_identifier = timestamp + "_" + str(uuid.uuid4())[:8]
+        unique_identifier = timestamp + "_" + generate_short_id()
         # timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S%f")
         working_dir = base_working_dir / model_name / unique_identifier
         # check that working dir does not exist

--- a/chap_core/util.py
+++ b/chap_core/util.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import uuid
+from datetime import datetime
 from shutil import which
 
 import numpy as np
@@ -13,6 +14,16 @@ def generate_short_id(length: int = 8) -> str:
     same-second runs don't collide. Keep this the single source of the scheme.
     """
     return uuid.uuid4().hex[:length]
+
+
+def generate_run_name() -> str:
+    """Return a unique run name like ``'2026-05-28_16-04-37_0e5fe728'``.
+
+    A sortable timestamp plus a short random suffix, so runs sort chronologically
+    while concurrent / same-second runs still get distinct directories. Single
+    source of the run-directory naming convention.
+    """
+    return f"{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_{generate_short_id()}"
 
 
 def nan_helper(y):

--- a/chap_core/util.py
+++ b/chap_core/util.py
@@ -1,8 +1,18 @@
 import os
 import subprocess
+import uuid
 from shutil import which
 
 import numpy as np
+
+
+def generate_short_id(length: int = 8) -> str:
+    """Return a short random hex id (default 8 chars), e.g. ``'0e5fe728'``.
+
+    Used as the unique suffix on run/job directory names so that concurrent or
+    same-second runs don't collide. Keep this the single source of the scheme.
+    """
+    return uuid.uuid4().hex[:length]
 
 
 def nan_helper(y):

--- a/tests/hpo/test_objective.py
+++ b/tests/hpo/test_objective.py
@@ -25,10 +25,7 @@ def test_objective_calls_evaluation_create_and_returns_metric(monkeypatch):
         n_periods = 3
         stride = 1
 
-    class FakeUUID:
-        hex = "a1b2c3d4e5f6g7h8"
-
-    monkeypatch.setattr(obj_module, "uuid4", lambda: FakeUUID(), raising=True)
+    monkeypatch.setattr(obj_module, "generate_short_id", lambda: "a1b2c3d4", raising=True)
 
     def fake_create(cls, **kwargs):
         captured["create_kwargs"] = kwargs

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,8 @@
 """Unit tests for chap_core.util helpers."""
 
-from chap_core.util import generate_short_id
+import re
+
+from chap_core.util import generate_run_name, generate_short_id
 
 
 def test_generate_short_id_default_is_8_hex_chars():
@@ -18,3 +20,14 @@ def test_generate_short_id_is_random():
     ids = {generate_short_id() for _ in range(100)}
     # 8 hex chars = 4 bytes; 100 draws colliding is astronomically unlikely.
     assert len(ids) == 100
+
+
+def test_generate_run_name_format():
+    name = generate_run_name()
+    # <YYYY-MM-DD_HH-MM-SS>_<8 hex chars>, e.g. 2026-05-28_16-04-37_0e5fe728
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}_[0-9a-f]{8}", name)
+
+
+def test_generate_run_name_is_unique():
+    # Same-second runs must differ thanks to the random suffix.
+    assert generate_run_name() != generate_run_name()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,20 @@
+"""Unit tests for chap_core.util helpers."""
+
+from chap_core.util import generate_short_id
+
+
+def test_generate_short_id_default_is_8_hex_chars():
+    sid = generate_short_id()
+    assert len(sid) == 8
+    assert all(c in "0123456789abcdef" for c in sid)
+
+
+def test_generate_short_id_respects_length():
+    assert len(generate_short_id(4)) == 4
+    assert len(generate_short_id(12)) == 12
+
+
+def test_generate_short_id_is_random():
+    ids = {generate_short_id() for _ in range(100)}
+    # 8 hex chars = 4 bytes; 100 draws colliding is astronomically unlikely.
+    assert len(ids) == 100


### PR DESCRIPTION
## Summary

Centralize run/job id generation in `chap_core/util.py` so the scheme lives in one place.

**`generate_short_id(length: int = 8)`** — returns a short random hex id (`uuid4().hex[:length]`, e.g. `0e5fe728`). Three sites generated this inline and now call the helper (their `uuid` imports dropped):

- `models/external_web_model.py` — trained web-model names
- `hpo/objective.py` — HPO run ids
- `models/utils.py` — (via `generate_run_name`, below)

**`generate_run_name()`** — returns the `<timestamp>_<short_id>` run-directory name (e.g. `2026-05-28_16-04-37_0e5fe728`): a sortable timestamp plus the random suffix, so runs sort chronologically while same-second runs still get distinct directories. `models/utils.py`'s run-dir creation now uses it (dropping the inline timestamp composition, the now-unused `datetime` import, and an orphaned commented-out line).

Output is byte-identical to before, so existing on-disk names are unaffected.

## Notes

- Kept it uuid-backed deliberately — same bytes as today's run dirs, no naming change.
- `chap_core/explainability/lime.py` (PR #380) has its own inline `<timestamp>_<uuid>` for the explanation output dir; it'll adopt these helpers once both land on master.

## Test plan

- [x] `tests/test_util.py` — `generate_short_id` (length, hex, uniqueness) and `generate_run_name` (format regex, uniqueness)
- [x] Updated the HPO test that monkeypatched the old `uuid4` symbol to patch `generate_short_id`
- [x] `make lint` clean (mypy + pyright)
- [x] full `make test` green (on the first commit; CI re-runs on this push)