### PR TITLE
refactor(database): extract DataSetManager with filterable observation reads

### DIFF
--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -19,7 +19,6 @@ from ..external.model_configuration import ModelTemplateConfigV2
 from ..models import ModelTemplate
 from ..models.configured_model import ConfiguredModel
 from ..models.external_chapkit_model import ExternalChapkitModelTemplate
-from .dataset_manager import DataSetManager
 from .model_spec_tables import ModelSpecRead
 from .model_templates_and_config_tables import ConfiguredModelDB, ModelConfiguration, ModelTemplateDB
 from .tables import Backtest, Prediction, PredictionSamplesEntry
@@ -442,11 +441,6 @@ class SessionWrapper:
         self.session.add(prediction)
         self.session.commit()
         return prediction.id
-
-    @property
-    def datasets(self) -> DataSetManager:
-        """Dataset data-access operations. Use this for all dataset reads/writes."""
-        return DataSetManager(self.session)
 
 
 def _run_alembic_migrations(engine):

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -19,9 +19,7 @@ from ..external.model_configuration import ModelTemplateConfigV2
 from ..models import ModelTemplate
 from ..models.configured_model import ConfiguredModel
 from ..models.external_chapkit_model import ExternalChapkitModelTemplate
-from ..spatio_temporal_data.temporal_dataclass import DataSet as _DataSet
 from .dataset_manager import DataSetManager
-from .dataset_tables import DataSet, DataSetCreateInfo
 from .model_spec_tables import ModelSpecRead
 from .model_templates_and_config_tables import ConfiguredModelDB, ModelConfiguration, ModelTemplateDB
 from .tables import Backtest, Prediction, PredictionSamplesEntry
@@ -447,34 +445,8 @@ class SessionWrapper:
 
     @property
     def datasets(self) -> DataSetManager:
-        """Dataset data-access operations."""
+        """Dataset data-access operations. Use this for all dataset reads/writes."""
         return DataSetManager(self.session)
-
-    def add_dataset_from_csv(self, name: str, csv_path: Path, geojson_path: Path | None = None):
-        return self.datasets.add_dataset_from_csv(name, csv_path, geojson_path)
-
-    def add_dataset(self, dataset_info: DataSetCreateInfo, orig_dataset: _DataSet, polygons):
-        return self.datasets.add_dataset(dataset_info, orig_dataset, polygons)
-
-    def get_dataset(
-        self,
-        dataset_id: int,
-        dataclass: type | None = None,
-        *,
-        period_range: tuple[str, str] | None = None,
-        org_units: list[str] | None = None,
-        feature_names: list[str] | None = None,
-    ) -> _DataSet:
-        return self.datasets.get_dataset(
-            dataset_id,
-            dataclass,
-            period_range=period_range,
-            org_units=org_units,
-            feature_names=feature_names,
-        )
-
-    def get_dataset_by_name(self, dataset_name: str) -> DataSet | None:
-        return self.datasets.get_dataset_by_name(dataset_name)
 
 
 def _run_alembic_migrations(engine):

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -1,6 +1,4 @@
-import dataclasses
 import datetime
-import json
 import logging
 
 # CHeck if CHAP_DATABASE_URL is set in the environment
@@ -14,19 +12,16 @@ import sqlalchemy
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, SQLModel, create_engine, select
 
-from chap_core.datatypes import FullData, create_tsdataclass
-from chap_core.geometry import Polygons
 from chap_core.log_config import is_debug_mode
 from chap_core.predictor.naive_estimator import NaiveEstimator
-from chap_core.time_period import Month, Week
 
 from ..external.model_configuration import ModelTemplateConfigV2
 from ..models import ModelTemplate
 from ..models.configured_model import ConfiguredModel
 from ..models.external_chapkit_model import ExternalChapkitModelTemplate
-from ..spatio_temporal_data.converters import observations_to_dataset
 from ..spatio_temporal_data.temporal_dataclass import DataSet as _DataSet
-from .dataset_tables import DataSet, DataSetCreateInfo, DataSetInfo, Observation
+from .dataset_manager import DataSetManager
+from .dataset_tables import DataSet, DataSetCreateInfo
 from .model_spec_tables import ModelSpecRead
 from .model_templates_and_config_tables import ConfiguredModelDB, ModelConfiguration, ModelTemplateDB
 from .tables import Backtest, Prediction, PredictionSamplesEntry
@@ -450,88 +445,36 @@ class SessionWrapper:
         self.session.commit()
         return prediction.id
 
-    def add_dataset_from_csv(self, name: str, csv_path: Path, geojson_path: Path | None = None):
-        dataset = _DataSet.from_csv(csv_path, dataclass=FullData)
-        geojson_content = open(geojson_path).read() if geojson_path else None
-        features = None
-        if geojson_content is not None:
-            features = Polygons.from_geojson(json.loads(geojson_content), id_property="NAME_1").feature_collection()
-            features = features.model_dump_json()
+    @property
+    def datasets(self) -> DataSetManager:
+        """Dataset data-access operations."""
+        return DataSetManager(self.session)
 
-        return self.add_dataset(DataSetCreateInfo(name=name), dataset, features)
+    def add_dataset_from_csv(self, name: str, csv_path: Path, geojson_path: Path | None = None):
+        return self.datasets.add_dataset_from_csv(name, csv_path, geojson_path)
 
     def add_dataset(self, dataset_info: DataSetCreateInfo, orig_dataset: _DataSet, polygons):
-        """
-        Add a dataset to the database. The dataset is provided as a spatio-temporal dataclass.
-        The polygons should be provided as a geojson feature collection.
-        The dataset_info should contain information about the dataset, such as its name and data sources.
-        The function sets some derived fields in the dataset_info, such as the first and last time period and the covariates.
-        The function returns the id of the newly created dataset.
-        """
-        logger.info(
-            f"Adding dataset {dataset_info.name} with {len(list(orig_dataset.locations()))} locations and {len(orig_dataset.period_range)} time periods"
+        return self.datasets.add_dataset(dataset_info, orig_dataset, polygons)
+
+    def get_dataset(
+        self,
+        dataset_id: int,
+        dataclass: type | None = None,
+        *,
+        period_range: tuple[str, str] | None = None,
+        org_units: list[str] | None = None,
+        feature_names: list[str] | None = None,
+    ) -> _DataSet:
+        return self.datasets.get_dataset(
+            dataset_id,
+            dataclass,
+            period_range=period_range,
+            org_units=org_units,
+            feature_names=feature_names,
         )
-        field_names = [
-            field.name
-            for field in dataclasses.fields(next(iter(orig_dataset.values())))
-            if field.name not in ["time_period", "location"]
-        ]
-        logger.info(f"Field names in dataset: {field_names}")
-        if isinstance(orig_dataset.period_range[0], Month):
-            period_type = "month"
-        else:
-            assert isinstance(orig_dataset.period_range[0], Week), orig_dataset.period_range[0]
-            period_type = "week"
-        full_info = DataSetInfo(
-            first_period=orig_dataset.period_range[0].id,
-            last_period=orig_dataset.period_range[-1].id,
-            covariates=field_names,
-            created=datetime.datetime.now(),
-            org_units=list(orig_dataset.locations()),
-            period_type=period_type,
-            **dataset_info.model_dump(),
-        )
-        dataset = DataSet(geojson=polygons, **full_info.model_dump())
-
-        for location, data in orig_dataset.items():
-            field_names = [
-                field.name for field in dataclasses.fields(data) if field.name not in ["time_period", "location"]
-            ]
-            for row in data:
-                for field in field_names:
-                    observation = Observation(
-                        period=row.time_period.id,
-                        org_unit=location,
-                        value=float(getattr(row, field)),
-                        feature_name=field,
-                    )
-                    dataset.observations.append(observation)
-
-        self.session.add(dataset)
-        self.session.commit()
-        assert self.session.exec(select(Observation).where(Observation.dataset_id == dataset.id)).first() is not None
-        return dataset.id
-
-    def get_dataset(self, dataset_id: int, dataclass: type | None = None) -> _DataSet:
-        dataset = self.session.get(DataSet, dataset_id)
-        if dataset is None:
-            raise ValueError(f"Dataset with id {dataset_id} not found")
-        if dataclass is None:
-            logger.info(f"Getting dataset with covariates: {dataset.covariates} and name: {dataset.name}")
-            field_names = dataset.covariates
-            dataclass = create_tsdataclass(field_names)
-        observations = dataset.observations
-        new_dataset = observations_to_dataset(dataclass, observations)
-
-        if dataset.geojson:
-            logger.info(f"Loading polygons from geojson for dataset id {dataset_id}")
-            new_dataset.set_polygons(Polygons.from_geojson(json.loads(dataset.geojson), id_property="district").data)
-
-        return cast("_DataSet", new_dataset)
 
     def get_dataset_by_name(self, dataset_name: str) -> DataSet | None:
-        dataset = self.session.exec(select(DataSet).where(DataSet.name == dataset_name)).first()
-        return dataset
+        return self.datasets.get_dataset_by_name(dataset_name)
 
 
 def _run_alembic_migrations(engine):

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -58,6 +58,9 @@ class SessionWrapper:
     This is a wrapper around data access operations.
     This class handles cases when putting things in/out of db requires
     more than just adding/getting a row, e.g. transforming data etc.
+
+    Dataset reads/writes are not here: use ``DataSetManager(session)``
+    (``chap_core.database.dataset_manager``) for those.
     """
 
     def __init__(self, local_engine=None, session=None):

--- a/chap_core/database/dataset_manager.py
+++ b/chap_core/database/dataset_manager.py
@@ -1,7 +1,8 @@
 """Data-access operations for datasets and their observations.
 
 Extracted from ``SessionWrapper`` so dataset reads/writes live in one place.
-``SessionWrapper`` keeps thin delegating methods for backwards compatibility.
+Construct ``DataSetManager(session)`` directly; ``SessionWrapper`` no longer
+exposes dataset methods.
 """
 
 import dataclasses

--- a/chap_core/database/dataset_manager.py
+++ b/chap_core/database/dataset_manager.py
@@ -52,7 +52,7 @@ class DataSetManager(DbManager[DataSet]):
 
     model = DataSet
 
-    def add_dataset_from_csv(self, name: str, csv_path: Path, geojson_path: Path | None = None):
+    def save_dataset_from_csv(self, name: str, csv_path: Path, geojson_path: Path | None = None):
         dataset = _DataSet.from_csv(csv_path, dataclass=FullData)
         geojson_content = open(geojson_path).read() if geojson_path else None
         features = None
@@ -60,9 +60,9 @@ class DataSetManager(DbManager[DataSet]):
             features = Polygons.from_geojson(json.loads(geojson_content), id_property="NAME_1").feature_collection()
             features = features.model_dump_json()
 
-        return self.add_dataset(DataSetCreateInfo(name=name), dataset, features)
+        return self.save_dataset(DataSetCreateInfo(name=name), dataset, features)
 
-    def add_dataset(self, dataset_info: DataSetCreateInfo, orig_dataset: _DataSet, polygons):
+    def save_dataset(self, dataset_info: DataSetCreateInfo, orig_dataset: _DataSet, polygons):
         """
         Add a dataset to the database. The dataset is provided as a spatio-temporal dataclass.
         The polygons should be provided as a geojson feature collection.
@@ -109,11 +109,11 @@ class DataSetManager(DbManager[DataSet]):
                     )
                     dataset.observations.append(observation)
 
-        self.add(dataset)
+        self.save(dataset)
         assert self.session.exec(select(Observation).where(Observation.dataset_id == dataset.id)).first() is not None
         return dataset.id
 
-    def get_observations(
+    def observations(
         self,
         dataset_id: int,
         *,
@@ -124,7 +124,7 @@ class DataSetManager(DbManager[DataSet]):
     ) -> list[Observation]:
         """Read raw observations for a dataset, optionally filtered.
 
-        Unlike :meth:`get_dataset` this does not build a ``_DataSet`` domain object,
+        Unlike :meth:`to_dataset` this does not build a ``_DataSet`` domain object,
         so the selected periods do not need to be consecutive (an explicit, possibly
         non-contiguous ``periods`` list is allowed). Returns an empty list if the
         dataset does not exist or nothing matches the filters.
@@ -138,7 +138,7 @@ class DataSetManager(DbManager[DataSet]):
         )
         return list(self.session.exec(expr).all())
 
-    def get_dataset(
+    def to_dataset(
         self,
         dataset_id: int,
         dataclass: type | None = None,
@@ -147,15 +147,15 @@ class DataSetManager(DbManager[DataSet]):
         org_units: list[str] | None = None,
         feature_names: list[str] | None = None,
     ) -> _DataSet:
-        """Load a dataset as a ``_DataSet`` domain object, optionally filtered.
+        """Build a dataset as a ``_DataSet`` domain object, optionally filtered.
 
         The filters are restricted to ones that keep each location's series
         consecutive (``period_range``, ``org_units``, ``feature_names``); use
-        :meth:`get_observations` for arbitrary period subsets. When ``feature_names``
+        :meth:`observations` for arbitrary period subsets. When ``feature_names``
         is given and ``dataclass`` is inferred, the inferred dataclass is narrowed to
         the requested features.
         """
-        dataset = self.get(dataset_id)
+        dataset = self.find_by_id(dataset_id)
         if dataset is None:
             raise ValueError(f"Dataset with id {dataset_id} not found")
         if dataclass is None:
@@ -182,6 +182,6 @@ class DataSetManager(DbManager[DataSet]):
 
         return cast("_DataSet", new_dataset)
 
-    def get_dataset_by_name(self, dataset_name: str) -> DataSet | None:
+    def find_by_name(self, dataset_name: str) -> DataSet | None:
         dataset = self.session.exec(select(DataSet).where(DataSet.name == dataset_name)).first()
         return dataset

--- a/chap_core/database/dataset_manager.py
+++ b/chap_core/database/dataset_manager.py
@@ -1,0 +1,189 @@
+"""Data-access operations for datasets and their observations.
+
+Extracted from ``SessionWrapper`` so dataset reads/writes live in one place.
+``SessionWrapper`` keeps thin delegating methods for backwards compatibility.
+"""
+
+import dataclasses
+import datetime
+import json
+import logging
+from pathlib import Path
+from typing import cast
+
+from sqlmodel import select
+
+from chap_core.datatypes import FullData, create_tsdataclass
+from chap_core.geometry import Polygons
+from chap_core.time_period import Month, Week
+
+from ..spatio_temporal_data.converters import observations_to_dataset
+from ..spatio_temporal_data.temporal_dataclass import DataSet as _DataSet
+from .dataset_tables import DataSet, DataSetCreateInfo, DataSetInfo, Observation
+from .manager import DbManager
+
+logger = logging.getLogger(__name__)
+
+
+def _filtered_observation_query(
+    dataset_id: int,
+    *,
+    periods: list[str] | None = None,
+    period_range: tuple[str, str] | None = None,
+    org_units: list[str] | None = None,
+    feature_names: list[str] | None = None,
+):
+    """Build a ``select(Observation)`` query for one dataset with optional filters."""
+    expr = select(Observation).where(Observation.dataset_id == dataset_id)
+    if periods is not None:
+        expr = expr.where(Observation.period.in_(periods))  # type: ignore[attr-defined]
+    if period_range is not None:
+        start, end = period_range
+        expr = expr.where(Observation.period >= start).where(Observation.period <= end)
+    if org_units is not None:
+        expr = expr.where(Observation.org_unit.in_(org_units))  # type: ignore[attr-defined]
+    if feature_names is not None:
+        expr = expr.where(Observation.feature_name.in_(feature_names))  # type: ignore[union-attr]
+    return expr
+
+
+class DataSetManager(DbManager[DataSet]):
+    """Dataset data-access operations, backed by a SQLModel ``Session``."""
+
+    model = DataSet
+
+    def add_dataset_from_csv(self, name: str, csv_path: Path, geojson_path: Path | None = None):
+        dataset = _DataSet.from_csv(csv_path, dataclass=FullData)
+        geojson_content = open(geojson_path).read() if geojson_path else None
+        features = None
+        if geojson_content is not None:
+            features = Polygons.from_geojson(json.loads(geojson_content), id_property="NAME_1").feature_collection()
+            features = features.model_dump_json()
+
+        return self.add_dataset(DataSetCreateInfo(name=name), dataset, features)
+
+    def add_dataset(self, dataset_info: DataSetCreateInfo, orig_dataset: _DataSet, polygons):
+        """
+        Add a dataset to the database. The dataset is provided as a spatio-temporal dataclass.
+        The polygons should be provided as a geojson feature collection.
+        The dataset_info should contain information about the dataset, such as its name and data sources.
+        The function sets some derived fields in the dataset_info, such as the first and last time period and the covariates.
+        The function returns the id of the newly created dataset.
+        """
+        logger.info(
+            f"Adding dataset {dataset_info.name} with {len(list(orig_dataset.locations()))} locations and {len(orig_dataset.period_range)} time periods"
+        )
+        field_names = [
+            field.name
+            for field in dataclasses.fields(next(iter(orig_dataset.values())))
+            if field.name not in ["time_period", "location"]
+        ]
+        logger.info(f"Field names in dataset: {field_names}")
+        if isinstance(orig_dataset.period_range[0], Month):
+            period_type = "month"
+        else:
+            assert isinstance(orig_dataset.period_range[0], Week), orig_dataset.period_range[0]
+            period_type = "week"
+        full_info = DataSetInfo(
+            first_period=orig_dataset.period_range[0].id,
+            last_period=orig_dataset.period_range[-1].id,
+            covariates=field_names,
+            created=datetime.datetime.now(),
+            org_units=list(orig_dataset.locations()),
+            period_type=period_type,
+            **dataset_info.model_dump(),
+        )
+        dataset = DataSet(geojson=polygons, **full_info.model_dump())
+
+        for location, data in orig_dataset.items():
+            field_names = [
+                field.name for field in dataclasses.fields(data) if field.name not in ["time_period", "location"]
+            ]
+            for row in data:
+                for field in field_names:
+                    observation = Observation(
+                        period=row.time_period.id,
+                        org_unit=location,
+                        value=float(getattr(row, field)),
+                        feature_name=field,
+                    )
+                    dataset.observations.append(observation)
+
+        self.session.add(dataset)
+        self.session.commit()
+        assert self.session.exec(select(Observation).where(Observation.dataset_id == dataset.id)).first() is not None
+        return dataset.id
+
+    def get_observations(
+        self,
+        dataset_id: int,
+        *,
+        periods: list[str] | None = None,
+        period_range: tuple[str, str] | None = None,
+        org_units: list[str] | None = None,
+        feature_names: list[str] | None = None,
+    ) -> list[Observation]:
+        """Read raw observations for a dataset, optionally filtered.
+
+        Unlike :meth:`get_dataset` this does not build a ``_DataSet`` domain object,
+        so the selected periods do not need to be consecutive (an explicit, possibly
+        non-contiguous ``periods`` list is allowed).
+        """
+        if self.get(dataset_id) is None:
+            raise ValueError(f"Dataset with id {dataset_id} not found")
+        expr = _filtered_observation_query(
+            dataset_id,
+            periods=periods,
+            period_range=period_range,
+            org_units=org_units,
+            feature_names=feature_names,
+        )
+        return list(self.session.exec(expr).all())
+
+    def get_dataset(
+        self,
+        dataset_id: int,
+        dataclass: type | None = None,
+        *,
+        period_range: tuple[str, str] | None = None,
+        org_units: list[str] | None = None,
+        feature_names: list[str] | None = None,
+    ) -> _DataSet:
+        """Load a dataset as a ``_DataSet`` domain object, optionally filtered.
+
+        The filters are restricted to ones that keep each location's series
+        consecutive (``period_range``, ``org_units``, ``feature_names``); use
+        :meth:`get_observations` for arbitrary period subsets. When ``feature_names``
+        is given and ``dataclass`` is inferred, the inferred dataclass is narrowed to
+        the requested features.
+        """
+        dataset = self.get(dataset_id)
+        if dataset is None:
+            raise ValueError(f"Dataset with id {dataset_id} not found")
+        if dataclass is None:
+            logger.info(f"Getting dataset with covariates: {dataset.covariates} and name: {dataset.name}")
+            field_names = dataset.covariates
+            if feature_names is not None:
+                requested = set(feature_names)
+                field_names = [name for name in field_names if name in requested]
+            dataclass = create_tsdataclass(field_names)
+        expr = _filtered_observation_query(
+            dataset_id,
+            period_range=period_range,
+            org_units=org_units,
+            feature_names=feature_names,
+        )
+        observations = list(self.session.exec(expr).all())
+        if not observations:
+            raise ValueError(f"No observations found for dataset {dataset_id} matching the given filters")
+        new_dataset = observations_to_dataset(dataclass, observations)
+
+        if dataset.geojson:
+            logger.info(f"Loading polygons from geojson for dataset id {dataset_id}")
+            new_dataset.set_polygons(Polygons.from_geojson(json.loads(dataset.geojson), id_property="district").data)
+
+        return cast("_DataSet", new_dataset)
+
+    def get_dataset_by_name(self, dataset_name: str) -> DataSet | None:
+        dataset = self.session.exec(select(DataSet).where(DataSet.name == dataset_name)).first()
+        return dataset

--- a/chap_core/database/dataset_manager.py
+++ b/chap_core/database/dataset_manager.py
@@ -109,8 +109,7 @@ class DataSetManager(DbManager[DataSet]):
                     )
                     dataset.observations.append(observation)
 
-        self.session.add(dataset)
-        self.session.commit()
+        self.add(dataset)
         assert self.session.exec(select(Observation).where(Observation.dataset_id == dataset.id)).first() is not None
         return dataset.id
 
@@ -127,10 +126,9 @@ class DataSetManager(DbManager[DataSet]):
 
         Unlike :meth:`get_dataset` this does not build a ``_DataSet`` domain object,
         so the selected periods do not need to be consecutive (an explicit, possibly
-        non-contiguous ``periods`` list is allowed).
+        non-contiguous ``periods`` list is allowed). Returns an empty list if the
+        dataset does not exist or nothing matches the filters.
         """
-        if self.get(dataset_id) is None:
-            raise ValueError(f"Dataset with id {dataset_id} not found")
         expr = _filtered_observation_query(
             dataset_id,
             periods=periods,

--- a/chap_core/database/datasets_seed.py
+++ b/chap_core/database/datasets_seed.py
@@ -1,16 +1,17 @@
 from pathlib import Path
 
+from chap_core.database.dataset_manager import DataSetManager
+
 
 def seed_example_datasets(session_wrapper):
     base_path = Path(__file__).parent.parent.parent / "example_data"
 
-    datasets = {"example_data1": {"data": base_path / "v0/training_data.csv", "geojson": None}}
+    datasets: list[tuple[str, Path, Path | None]] = [
+        ("example_data1", base_path / "v0/training_data.csv", None),
+    ]
 
-    for name, paths in datasets.items():
-        if not session_wrapper.datasets.get_dataset_by_name(name):
+    manager = DataSetManager(session_wrapper.session)
+    for name, data_path, geojson_path in datasets:
+        if not manager.find_by_name(name):
             print(f"Seeding dataset: {name}")
-            session_wrapper.datasets.add_dataset_from_csv(
-                name,
-                paths["data"],
-                paths["geojson"],
-            )
+            manager.save_dataset_from_csv(name, data_path, geojson_path)

--- a/chap_core/database/datasets_seed.py
+++ b/chap_core/database/datasets_seed.py
@@ -7,9 +7,9 @@ def seed_example_datasets(session_wrapper):
     datasets = {"example_data1": {"data": base_path / "v0/training_data.csv", "geojson": None}}
 
     for name, paths in datasets.items():
-        if not session_wrapper.get_dataset_by_name(name):
+        if not session_wrapper.datasets.get_dataset_by_name(name):
             print(f"Seeding dataset: {name}")
-            session_wrapper.add_dataset_from_csv(
+            session_wrapper.datasets.add_dataset_from_csv(
                 name,
                 paths["data"],
                 paths["geojson"],

--- a/chap_core/database/manager.py
+++ b/chap_core/database/manager.py
@@ -1,0 +1,25 @@
+"""Base class for database data-access managers.
+
+A manager wraps a SQLModel ``Session`` and the table model it operates on, so
+entity-specific data-access code (e.g. :class:`DataSetManager`) can share common
+lookups and be typed against its model. Apply the same pattern for other tables.
+"""
+
+from sqlmodel import Session, SQLModel, select
+
+
+class DbManager[ModelT: SQLModel]:
+    """Data-access manager bound to a single table ``model`` and a ``Session``."""
+
+    model: type[ModelT]
+
+    def __init__(self, session: Session):
+        self.session = session
+
+    def get(self, item_id: int) -> ModelT | None:
+        """Return the row with this primary key, or ``None`` if it does not exist."""
+        return self.session.get(self.model, item_id)
+
+    def list_all(self) -> list[ModelT]:
+        """Return every row for this manager's model."""
+        return list(self.session.exec(select(self.model)).all())

--- a/chap_core/database/manager.py
+++ b/chap_core/database/manager.py
@@ -23,3 +23,16 @@ class DbManager[ModelT: SQLModel]:
     def list_all(self) -> list[ModelT]:
         """Return every row for this manager's model."""
         return list(self.session.exec(select(self.model)).all())
+
+    def add(self, obj: ModelT) -> ModelT:
+        """Persist a row and return the committed instance."""
+        self.session.add(obj)
+        self.session.commit()
+        return obj
+
+    def delete(self, item_id: int) -> None:
+        """Delete the row with this primary key, if it exists."""
+        obj = self.get(item_id)
+        if obj is not None:
+            self.session.delete(obj)
+            self.session.commit()

--- a/chap_core/database/manager.py
+++ b/chap_core/database/manager.py
@@ -2,7 +2,10 @@
 
 A manager wraps a SQLModel ``Session`` and the table model it operates on, so
 entity-specific data-access code (e.g. :class:`DataSetManager`) can share common
-lookups and be typed against its model. Apply the same pattern for other tables.
+lookups and be typed against its model. Method names mirror the servicekit manager
+interface (``save`` / ``find_by_id`` / ``find_all`` / ``delete_by_id``) so chap-core's
+sync data-access reads consistently with the rest of the stack. Apply the same
+pattern for other tables.
 """
 
 from sqlmodel import Session, SQLModel, select
@@ -16,23 +19,23 @@ class DbManager[ModelT: SQLModel]:
     def __init__(self, session: Session):
         self.session = session
 
-    def get(self, item_id: int) -> ModelT | None:
+    def find_by_id(self, item_id: int) -> ModelT | None:
         """Return the row with this primary key, or ``None`` if it does not exist."""
         return self.session.get(self.model, item_id)
 
-    def list_all(self) -> list[ModelT]:
+    def find_all(self) -> list[ModelT]:
         """Return every row for this manager's model."""
         return list(self.session.exec(select(self.model)).all())
 
-    def add(self, obj: ModelT) -> ModelT:
+    def save(self, obj: ModelT) -> ModelT:
         """Persist a row and return the committed instance."""
         self.session.add(obj)
         self.session.commit()
         return obj
 
-    def delete(self, item_id: int) -> None:
+    def delete_by_id(self, item_id: int) -> None:
         """Delete the row with this primary key, if it exists."""
-        obj = self.get(item_id)
+        obj = self.find_by_id(item_id)
         if obj is not None:
             self.session.delete(obj)
             self.session.commit()

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -14,6 +14,7 @@ from chap_core.assessment.prediction_evaluator import backtest as _backtest
 from chap_core.climate_predictor import QuickForecastFetcher
 from chap_core.data import DataSet as InMemoryDataSet
 from chap_core.database.database import SessionWrapper
+from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import DataSetCreateInfo
 from chap_core.datatypes import HealthPopulationData, create_tsdataclass
 from chap_core.log_config import get_status_logger
@@ -82,7 +83,7 @@ def run_backtest(
     assert session is not None, "session is required"
     status_logger.info(f"Starting backtest for model '{info.model_id}' on dataset ID {info.dataset_id}")
 
-    dataset = session.datasets.get_dataset(info.dataset_id)
+    dataset = DataSetManager(session.session).to_dataset(info.dataset_id)
 
     configured_model = session.get_configured_model_by_id_or_name(info.model_id)
     # Normalise back to the name string so any downstream code that still
@@ -154,7 +155,7 @@ def run_prediction(
     # NOTE: model_id arg from the user is actually the model's unique name identifier
     status_logger.info(f"Starting prediction for model '{model_id}' on dataset ID {dataset_id}")
 
-    dataset = session.datasets.get_dataset(int(dataset_id))
+    dataset = DataSetManager(session.session).to_dataset(int(dataset_id))
     if n_periods is None:
         n_periods = _get_n_periods(dataset)
 
@@ -181,7 +182,7 @@ def harmonize_and_add_health_dataset(
     status_logger.info(f"Processing and adding dataset '{name}'")
     dataset_obj = InMemoryDataSet.from_dict(health_dataset, HealthPopulationData)  # type: ignore[arg-type]
     dataset = harmonize_health_dataset(dataset_obj, usecwd_for_credentials=False, worker_config=worker_config)
-    db_id: int = session.datasets.add_dataset(
+    db_id: int = DataSetManager(session.session).save_dataset(
         DataSetCreateInfo(name=name), dataset, polygons=dataset_obj.polygons.model_dump_json()
     )
     status_logger.info(f"Dataset '{name}' added successfully with ID {db_id}")
@@ -207,7 +208,9 @@ def harmonize_and_add_dataset(
     else:
         full_dataset = dataset_obj
     info = DataSetCreateInfo(name=name, type=ds_type)
-    db_id: int = session.datasets.add_dataset(info, full_dataset, polygons=dataset_obj.polygons.model_dump_json())
+    db_id: int = DataSetManager(session.session).save_dataset(
+        info, full_dataset, polygons=dataset_obj.polygons.model_dump_json()
+    )
     status_logger.info(f"Dataset '{name}' added successfully with ID {db_id}")
     return db_id
 
@@ -235,7 +238,7 @@ def predict_pipeline_from_composite_dataset(
     ds = InMemoryDataSet.from_dict(health_dataset, create_tsdataclass(provided_field_names))
     # dataset_info = DataSetCreateInfo.model_validate(dataset_create_info)
 
-    dataset_id = session.datasets.add_dataset(
+    dataset_id = DataSetManager(session.session).save_dataset(
         dataset_info=dataset_create_info, orig_dataset=ds, polygons=ds.polygons.model_dump_json()
     )
 
@@ -262,7 +265,7 @@ def run_backtest_from_dataset(
     worker_config=WorkerConfig(),
 ) -> int:
     ds = InMemoryDataSet.from_dict(provided_data_model_dump, create_tsdataclass(feature_names))
-    dataset_id = session.datasets.add_dataset(
+    dataset_id = DataSetManager(session.session).save_dataset(
         dataset_info=dataset_info, orig_dataset=ds, polygons=ds.polygons.model_dump_json()
     )
     backtest_create_info = BacktestCreate(name=backtest_name, dataset_id=dataset_id, model_id=model_id)

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -82,7 +82,7 @@ def run_backtest(
     assert session is not None, "session is required"
     status_logger.info(f"Starting backtest for model '{info.model_id}' on dataset ID {info.dataset_id}")
 
-    dataset = session.get_dataset(info.dataset_id)
+    dataset = session.datasets.get_dataset(info.dataset_id)
 
     configured_model = session.get_configured_model_by_id_or_name(info.model_id)
     # Normalise back to the name string so any downstream code that still
@@ -154,7 +154,7 @@ def run_prediction(
     # NOTE: model_id arg from the user is actually the model's unique name identifier
     status_logger.info(f"Starting prediction for model '{model_id}' on dataset ID {dataset_id}")
 
-    dataset = session.get_dataset(int(dataset_id))
+    dataset = session.datasets.get_dataset(int(dataset_id))
     if n_periods is None:
         n_periods = _get_n_periods(dataset)
 
@@ -181,7 +181,7 @@ def harmonize_and_add_health_dataset(
     status_logger.info(f"Processing and adding dataset '{name}'")
     dataset_obj = InMemoryDataSet.from_dict(health_dataset, HealthPopulationData)  # type: ignore[arg-type]
     dataset = harmonize_health_dataset(dataset_obj, usecwd_for_credentials=False, worker_config=worker_config)
-    db_id: int = session.add_dataset(
+    db_id: int = session.datasets.add_dataset(
         DataSetCreateInfo(name=name), dataset, polygons=dataset_obj.polygons.model_dump_json()
     )
     status_logger.info(f"Dataset '{name}' added successfully with ID {db_id}")
@@ -207,7 +207,7 @@ def harmonize_and_add_dataset(
     else:
         full_dataset = dataset_obj
     info = DataSetCreateInfo(name=name, type=ds_type)
-    db_id: int = session.add_dataset(info, full_dataset, polygons=dataset_obj.polygons.model_dump_json())
+    db_id: int = session.datasets.add_dataset(info, full_dataset, polygons=dataset_obj.polygons.model_dump_json())
     status_logger.info(f"Dataset '{name}' added successfully with ID {db_id}")
     return db_id
 
@@ -235,7 +235,7 @@ def predict_pipeline_from_composite_dataset(
     ds = InMemoryDataSet.from_dict(health_dataset, create_tsdataclass(provided_field_names))
     # dataset_info = DataSetCreateInfo.model_validate(dataset_create_info)
 
-    dataset_id = session.add_dataset(
+    dataset_id = session.datasets.add_dataset(
         dataset_info=dataset_create_info, orig_dataset=ds, polygons=ds.polygons.model_dump_json()
     )
 
@@ -262,7 +262,9 @@ def run_backtest_from_dataset(
     worker_config=WorkerConfig(),
 ) -> int:
     ds = InMemoryDataSet.from_dict(provided_data_model_dump, create_tsdataclass(feature_names))
-    dataset_id = session.add_dataset(dataset_info=dataset_info, orig_dataset=ds, polygons=ds.polygons.model_dump_json())
+    dataset_id = session.datasets.add_dataset(
+        dataset_info=dataset_info, orig_dataset=ds, polygons=ds.polygons.model_dump_json()
+    )
     backtest_create_info = BacktestCreate(name=backtest_name, dataset_id=dataset_id, model_id=model_id)
     if ds.frequency == "W" and backtest_params.stride < 4:
         logging.warning("Setting stride to 4 since its weekly data")

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -16,8 +16,9 @@ from chap_core.api_types import (
     PredictionEntry,
 )
 from chap_core.assessment.dataset_splitting import train_test_generator
+from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import DataSet as DataSetTable
-from chap_core.database.dataset_tables import DataSetCreateInfo, Observation
+from chap_core.database.dataset_tables import DataSetCreateInfo
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
 from chap_core.database.tables import Backtest, BacktestForecast, Prediction
 from chap_core.datatypes import create_tsdataclass
@@ -515,11 +516,11 @@ async def get_actual_cases(
         dataset_id = backtest.dataset_id
     else:
         dataset_id = backtest_id
-    expr = select(Observation).where(Observation.dataset_id == dataset_id)
-    if org_units is not None and not return_summed:
-        org_units_set = set(org_units)
-        expr = expr.where(Observation.org_unit.in_(org_units_set))  # type: ignore[attr-defined]
-    observations = session.exec(expr).all()
+    observations = DataSetManager(session).get_observations(
+        dataset_id,
+        org_units=None if return_summed else org_units,
+        feature_names=["disease_cases"],
+    )
     logger.info(f"Observations: {observations}")
     data_list = [
         DataElement(
@@ -530,7 +531,6 @@ async def get_actual_cases(
             else None,
         )
         for observation in observations
-        if observation.feature_name == "disease_cases"
     ]
     if return_summed:
         # sum over all regions

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -516,7 +516,7 @@ async def get_actual_cases(
         dataset_id = backtest.dataset_id
     else:
         dataset_id = backtest_id
-    observations = DataSetManager(session).get_observations(
+    observations = DataSetManager(session).observations(
         dataset_id,
         org_units=None if return_summed else org_units,
         feature_names=["disease_cases"],

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -662,7 +662,7 @@ async def create_dataset_csv(
     dataset = InMemoryDataSet.from_csv(io.BytesIO(csv_content), dataclass=FullData)
     geo_json_content = await geojson_file.read()
     features = Polygons.from_geojson(json.loads(geo_json_content), id_property="NAME_1").feature_collection()
-    dataset_id = DataSetManager(session).add_dataset(
+    dataset_id = DataSetManager(session).save_dataset(
         DataSetCreateInfo(name="csv_file"), dataset, features.model_dump_json()
     )
     return DataBaseResponse(id=dataset_id)
@@ -682,7 +682,7 @@ async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], se
     """
     if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    in_memory_dataset = DataSetManager(session).get_dataset(dataset_id)
+    in_memory_dataset = DataSetManager(session).to_dataset(dataset_id)
     df = in_memory_dataset.to_pandas()
     # Convert time_period column to strings for proper serialization
     df["time_period"] = df["time_period"].astype(str)
@@ -709,7 +709,7 @@ async def get_dataset_csv(dataset_id: Annotated[int, Path(alias="datasetId")], s
     """
     if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    in_memory_dataset = DataSetManager(session).get_dataset(dataset_id)
+    in_memory_dataset = DataSetManager(session).to_dataset(dataset_id)
     df = in_memory_dataset.to_pandas()
     df["time_period"] = df["time_period"].astype(str)
 
@@ -731,7 +731,7 @@ async def delete_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], se
     # dataset = session.exec(select(DataSet).where(DataSet.id == dataset_id)).first()
     if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    DataSetManager(session).delete(dataset_id)
+    DataSetManager(session).delete_by_id(dataset_id)
     return {"message": "deleted"}
 
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -31,6 +31,7 @@ from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metrics import compute_all_detailed_metrics
 from chap_core.data import DataSet as InMemoryDataSet
 from chap_core.database.database import SessionWrapper
+from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import (
     DataSet,
     DataSetCreateInfo,
@@ -661,7 +662,7 @@ async def create_dataset_csv(
     dataset = InMemoryDataSet.from_csv(io.BytesIO(csv_content), dataclass=FullData)
     geo_json_content = await geojson_file.read()
     features = Polygons.from_geojson(json.loads(geo_json_content), id_property="NAME_1").feature_collection()
-    dataset_id = SessionWrapper(session=session).add_dataset(
+    dataset_id = DataSetManager(session).add_dataset(
         DataSetCreateInfo(name="csv_file"), dataset, features.model_dump_json()
     )
     return DataBaseResponse(id=dataset_id)
@@ -681,8 +682,7 @@ async def get_dataset_df(dataset_id: Annotated[int, Path(alias="datasetId")], se
     """
     if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    sw = SessionWrapper(session=session)
-    in_memory_dataset = sw.get_dataset(dataset_id)
+    in_memory_dataset = DataSetManager(session).get_dataset(dataset_id)
     df = in_memory_dataset.to_pandas()
     # Convert time_period column to strings for proper serialization
     df["time_period"] = df["time_period"].astype(str)
@@ -709,8 +709,7 @@ async def get_dataset_csv(dataset_id: Annotated[int, Path(alias="datasetId")], s
     """
     if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    sw = SessionWrapper(session=session)
-    in_memory_dataset = sw.get_dataset(dataset_id)
+    in_memory_dataset = DataSetManager(session).get_dataset(dataset_id)
     df = in_memory_dataset.to_pandas()
     df["time_period"] = df["time_period"].astype(str)
 
@@ -730,11 +729,9 @@ async def get_dataset_csv(dataset_id: Annotated[int, Path(alias="datasetId")], s
 async def delete_dataset(dataset_id: Annotated[int, Path(alias="datasetId")], session: Session = Depends(get_session)):
     """Permanently delete a dataset and every observation in it. Use this to clean up obsolete imports — be aware that backtests and predictions that referenced this dataset will lose their data link. 404 if the id is unknown."""
     # dataset = session.exec(select(DataSet).where(DataSet.id == dataset_id)).first()
-    dataset = session.get(DataSet, dataset_id)
-    if dataset is None:
+    if session.get(DataSet, dataset_id) is None:
         raise HTTPException(status_code=404, detail="Dataset not found")
-    session.delete(dataset)
-    session.commit()
+    DataSetManager(session).delete(dataset_id)
     return {"message": "deleted"}
 
 

--- a/chap_core/spatio_temporal_data/converters.py
+++ b/chap_core/spatio_temporal_data/converters.py
@@ -8,6 +8,21 @@ from chap_core.datatypes import create_tsdataclass
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet as _DataSet
 
 
+def observations_to_dataframe(observations) -> pd.DataFrame:
+    """Flatten Observation rows into a long DataFrame.
+
+    Columns: ``[location, time_period, feature_name, value]``. Unlike
+    :func:`observations_to_dataset` this does not pivot or build a domain object,
+    so it works for arbitrary (possibly non-contiguous) period subsets.
+    """
+    columns = ["location", "time_period", "feature_name", "value"]
+    obs_dicts = [obs.model_dump() for obs in observations]
+    if not obs_dicts:
+        return pd.DataFrame(columns=columns)
+    dataframe = pd.DataFrame(obs_dicts).rename(columns={"org_unit": "location", "period": "time_period"})
+    return dataframe[columns]
+
+
 def observations_to_dataset(dataclass, observations, fill_missing=False):
     obs_dicts = [obs.model_dump() for obs in observations]
     dataframe = pd.DataFrame(obs_dicts).rename(columns={"org_unit": "location", "period": "time_period"})

--- a/docs/contributor/architecture_diagrams.md
+++ b/docs/contributor/architecture_diagrams.md
@@ -217,11 +217,6 @@ classDiagram
         +values: list~float~
     }
 
-    class DebugEntry {
-        +timestamp: datetime
-        +payload: dict
-    }
-
     DBModel <|-- DataSet
     DBModel <|-- Observation
     DBModel <|-- ModelTemplateDB
@@ -231,7 +226,6 @@ classDiagram
     DBModel <|-- BacktestMetric
     DBModel <|-- Prediction
     DBModel <|-- PredictionSamplesEntry
-    DBModel <|-- DebugEntry
 
     DataSet "1" --> "*" Observation : observations
     ModelTemplateDB "1" --> "*" ConfiguredModelDB : configurations

--- a/docs/contributor/rest_api_and_database.md
+++ b/docs/contributor/rest_api_and_database.md
@@ -162,7 +162,6 @@ The tables are spread across several files:
 | `tables.py` | `Backtest`, `Prediction`, `BacktestForecast`, `PredictionSamplesEntry`, `BacktestMetric` | Evaluation and prediction results |
 | `model_templates_and_config_tables.py` | `ModelTemplateDB`, `ConfiguredModelDB` | Model definitions and configurations |
 | `model_spec_tables.py` | `ModelSpecRead` | Read model for backwards-compatible API responses |
-| `debug.py` | `DebugEntry` | Debug/diagnostic entries |
 
 ### Key relationships
 
@@ -327,4 +326,3 @@ shortcut to apply this to all GET endpoints.
 | `database/dataset_tables.py` | DataSet, Observation tables |
 | `database/model_templates_and_config_tables.py` | ModelTemplateDB, ConfiguredModelDB |
 | `database/model_spec_tables.py` | ModelSpecRead (backwards-compatible read model) |
-| `database/debug.py` | DebugEntry table |

--- a/docs/contributor/rest_api_and_database.md
+++ b/docs/contributor/rest_api_and_database.md
@@ -139,9 +139,10 @@ There are two session patterns used in the codebase:
    plain `sqlmodel.Session`. Used by most REST endpoints.
 
 2. **SessionWrapper** -- a context manager that wraps a `Session` and adds higher-level
-   data access methods (adding datasets, model templates, configured models, etc.).
+   data access methods (model templates, configured models, backtests, predictions, etc.).
    Used by the Celery worker (`celery_run_with_session`) and by some REST endpoints that
-   need complex operations.
+   need complex operations. Dataset reads/writes are not here -- use
+   `DataSetManager(session)` (`database/dataset_manager.py`) for those.
 
 ### Database tables
 
@@ -281,8 +282,10 @@ shortcut to apply this to all GET endpoints.
 3. Add the endpoint function to the appropriate router file.
 4. If the operation is long-running, queue it as a Celery task via `worker.queue_db()`
    and return a `JobResponse`.
-5. For new database operations, add methods to `SessionWrapper` or work with
-   the `Session` directly in the endpoint.
+5. For new database operations, add methods to the relevant manager
+   (`DataSetManager` for datasets, or a new `DbManager` subclass following
+   `database/manager.py`), to `SessionWrapper`, or work with the `Session`
+   directly in the endpoint.
 
 
 ## How to add a new database table
@@ -317,6 +320,8 @@ shortcut to apply this to all GET endpoints.
 | `rest_api/db_worker_functions.py` | Business logic for async Celery jobs |
 | `rest_api/worker_functions.py` | WorkerConfig and related utilities |
 | `database/database.py` | Engine creation, SessionWrapper, migrations |
+| `database/manager.py` | `DbManager[ModelT]` generic data-access base |
+| `database/dataset_manager.py` | `DataSetManager` dataset reads/writes + filtering |
 | `database/base_tables.py` | DBModel base class with camelCase config |
 | `database/tables.py` | Backtest, Prediction, forecast tables |
 | `database/dataset_tables.py` | DataSet, Observation tables |

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -95,7 +95,7 @@ def test_visualization_endpoints_404_on_missing_ids(clean_engine, dependency_ove
 @pytest.mark.skip(reason="not in use")
 def test_backtest_flow(celery_session_worker, clean_engine, dependency_overrides, weekly_full_data, do_filter):
     with SessionWrapper(clean_engine) as session:
-        dataset_id = session.add_dataset("full_data", weekly_full_data, "polygons", dataset_type="evaluation")
+        dataset_id = session.datasets.add_dataset("full_data", weekly_full_data, "polygons", dataset_type="evaluation")
     response = client.post("/v1/crud/backtests", json={"datasetId": dataset_id, "modelId": "naive_model"})
     assert response.status_code == 200, response.json()
     job_id = response.json()["id"]

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -12,7 +12,7 @@ from sqlmodel import Session, select
 from chap_core.api_types import DataList, EvaluationEntry, PredictionEntry
 from chap_core.database.database import SessionWrapper
 from chap_core.database.dataset_manager import DataSetManager
-from chap_core.database.dataset_tables import DataSet, DataSetWithObservations, ObservationBase
+from chap_core.database.dataset_tables import DataSet, DataSetCreateInfo, DataSetWithObservations, ObservationBase
 from chap_core.database.model_spec_tables import ModelSpecRead
 from chap_core.database.tables import (
     Backtest,
@@ -97,7 +97,7 @@ def test_visualization_endpoints_404_on_missing_ids(clean_engine, dependency_ove
 def test_backtest_flow(celery_session_worker, clean_engine, dependency_overrides, weekly_full_data, do_filter):
     with SessionWrapper(clean_engine) as session:
         dataset_id = DataSetManager(session.session).save_dataset(
-            "full_data", weekly_full_data, "polygons", dataset_type="evaluation"
+            DataSetCreateInfo(name="full_data", type="evaluation"), weekly_full_data, "polygons"
         )
     response = client.post("/v1/crud/backtests", json={"datasetId": dataset_id, "modelId": "naive_model"})
     assert response.status_code == 200, response.json()

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, select
 
 from chap_core.api_types import DataList, EvaluationEntry, PredictionEntry
 from chap_core.database.database import SessionWrapper
+from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import DataSet, DataSetWithObservations, ObservationBase
 from chap_core.database.model_spec_tables import ModelSpecRead
 from chap_core.database.tables import (
@@ -95,7 +96,9 @@ def test_visualization_endpoints_404_on_missing_ids(clean_engine, dependency_ove
 @pytest.mark.skip(reason="not in use")
 def test_backtest_flow(celery_session_worker, clean_engine, dependency_overrides, weekly_full_data, do_filter):
     with SessionWrapper(clean_engine) as session:
-        dataset_id = session.datasets.add_dataset("full_data", weekly_full_data, "polygons", dataset_type="evaluation")
+        dataset_id = DataSetManager(session.session).save_dataset(
+            "full_data", weekly_full_data, "polygons", dataset_type="evaluation"
+        )
     response = client.post("/v1/crud/backtests", json={"datasetId": dataset_id, "modelId": "naive_model"})
     assert response.status_code == 200, response.json()
     job_id = response.json()["id"]

--- a/tests/integration/test_chapkit_e2e.py
+++ b/tests/integration/test_chapkit_e2e.py
@@ -169,7 +169,7 @@ def test_chapkit_backtest_via_worker_function(chapkit_service):
         session.add_configured_model(template_id, ModelConfiguration(), uses_chapkit=True)
 
         # Add dataset from example CSV
-        dataset_id = session.add_dataset_from_csv("vietnam_test", EXAMPLE_CSV, EXAMPLE_GEOJSON)
+        dataset_id = session.datasets.add_dataset_from_csv("vietnam_test", EXAMPLE_CSV, EXAMPLE_GEOJSON)
 
         # Run backtest directly (bypasses Celery)
         backtest_id = run_backtest(

--- a/tests/integration/test_chapkit_e2e.py
+++ b/tests/integration/test_chapkit_e2e.py
@@ -19,6 +19,7 @@ from sqlmodel import SQLModel
 
 import chap_core.database.tables  # noqa: F401 - register all table models
 from chap_core.database.database import SessionWrapper
+from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.model_templates_and_config_tables import ModelConfiguration
 from chap_core.database.tables import Backtest
 from chap_core.models.external_chapkit_model import ml_service_info_to_model_template_config
@@ -169,7 +170,7 @@ def test_chapkit_backtest_via_worker_function(chapkit_service):
         session.add_configured_model(template_id, ModelConfiguration(), uses_chapkit=True)
 
         # Add dataset from example CSV
-        dataset_id = session.datasets.add_dataset_from_csv("vietnam_test", EXAMPLE_CSV, EXAMPLE_GEOJSON)
+        dataset_id = DataSetManager(session.session).save_dataset_from_csv("vietnam_test", EXAMPLE_CSV, EXAMPLE_GEOJSON)
 
         # Run backtest directly (bypasses Celery)
         backtest_id = run_backtest(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -52,15 +52,15 @@ def engine():
 @pytest.fixture
 def engine_with_dataset(engine, weekly_full_data):
     with SessionWrapper(engine) as session:
-        session.add_dataset("full_data", weekly_full_data, None)
+        session.datasets.add_dataset("full_data", weekly_full_data, None)
     return engine
 
 
 def test_dataset_roundrip(health_population_data, engine):
     info = DataSetCreateInfo(name="health_population")
     with SessionWrapper(engine) as session:
-        dataset_id = session.add_dataset(info, health_population_data, None)
-        dataset = session.get_dataset(dataset_id, HealthPopulationData)
+        dataset_id = session.datasets.add_dataset(info, health_population_data, None)
+        dataset = session.datasets.get_dataset(dataset_id, HealthPopulationData)
         assert_dataset_equal(dataset, health_population_data)
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5,6 +5,7 @@ from sqlalchemy import create_engine
 from sqlmodel import Session, SQLModel, select
 
 from chap_core.database.database import SessionWrapper
+from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import DataSet, DataSetCreateInfo
 from chap_core.database.datasets_seed import seed_example_datasets
 from chap_core.database.model_template_seed import (
@@ -52,15 +53,15 @@ def engine():
 @pytest.fixture
 def engine_with_dataset(engine, weekly_full_data):
     with SessionWrapper(engine) as session:
-        session.datasets.add_dataset("full_data", weekly_full_data, None)
+        DataSetManager(session.session).save_dataset("full_data", weekly_full_data, None)
     return engine
 
 
 def test_dataset_roundrip(health_population_data, engine):
     info = DataSetCreateInfo(name="health_population")
     with SessionWrapper(engine) as session:
-        dataset_id = session.datasets.add_dataset(info, health_population_data, None)
-        dataset = session.datasets.get_dataset(dataset_id, HealthPopulationData)
+        dataset_id = DataSetManager(session.session).save_dataset(info, health_population_data, None)
+        dataset = DataSetManager(session.session).to_dataset(dataset_id, HealthPopulationData)
         assert_dataset_equal(dataset, health_population_data)
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -53,7 +53,7 @@ def engine():
 @pytest.fixture
 def engine_with_dataset(engine, weekly_full_data):
     with SessionWrapper(engine) as session:
-        DataSetManager(session.session).save_dataset("full_data", weekly_full_data, None)
+        DataSetManager(session.session).save_dataset(DataSetCreateInfo(name="full_data"), weekly_full_data, None)
     return engine
 
 

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -22,7 +22,7 @@ def engine():
 @pytest.fixture
 def dataset_id(engine, health_population_data):
     with SessionWrapper(engine) as session:
-        return session.add_dataset(DataSetCreateInfo(name="health_population"), health_population_data, None)
+        return session.datasets.add_dataset(DataSetCreateInfo(name="health_population"), health_population_data, None)
 
 
 def _sorted_periods(observations):
@@ -85,10 +85,9 @@ def test_get_observations_empty_match_returns_empty(engine, dataset_id):
     assert filtered == []
 
 
-def test_get_observations_unknown_dataset_raises(engine):
+def test_get_observations_unknown_dataset_returns_empty(engine):
     with SessionWrapper(engine) as session:
-        with pytest.raises(ValueError, match="not found"):
-            session.datasets.get_observations(999999)
+        assert session.datasets.get_observations(999999) == []
 
 
 def test_observations_to_dataframe_shape(engine, dataset_id):
@@ -108,7 +107,7 @@ def test_observations_to_dataframe_empty():
 
 def test_get_dataset_feature_subset_narrows_dataclass(engine, dataset_id):
     with SessionWrapper(engine) as session:
-        dataset = session.get_dataset(dataset_id, feature_names=["disease_cases"])
+        dataset = session.datasets.get_dataset(dataset_id, feature_names=["disease_cases"])
         _, data = next(iter(dataset.items()))
     field_names = {field.name for field in dataclasses.fields(data)}
     assert "disease_cases" in field_names
@@ -118,12 +117,12 @@ def test_get_dataset_feature_subset_narrows_dataclass(engine, dataset_id):
 def test_get_dataset_empty_filter_raises(engine, dataset_id):
     with SessionWrapper(engine) as session:
         with pytest.raises(ValueError, match="No observations"):
-            session.get_dataset(dataset_id, org_units=["does-not-exist"])
+            session.datasets.get_dataset(dataset_id, org_units=["does-not-exist"])
 
 
 def test_get_dataset_org_unit_filter_roundtrips(engine, dataset_id):
     with SessionWrapper(engine) as session:
         org_unit = sorted({obs.org_unit for obs in session.datasets.get_observations(dataset_id)})[0]
-        dataset = session.get_dataset(dataset_id, org_units=[org_unit])
+        dataset = session.datasets.get_dataset(dataset_id, org_units=[org_unit])
         locations = list(dataset.locations())
     assert locations == [org_unit]

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -1,6 +1,7 @@
 """Tests for DataSetManager observation filtering and the flat-frame converter."""
 
 import dataclasses
+from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine
@@ -9,6 +10,8 @@ from sqlmodel import Session, SQLModel
 from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import DataSetCreateInfo
 from chap_core.spatio_temporal_data.converters import observations_to_dataframe
+
+EXAMPLE_DATA = Path(__file__).parent.parent / "example_data"
 
 
 @pytest.fixture
@@ -60,6 +63,28 @@ def test_observations_filters_by_period_range(manager, dataset_id):
     assert periods[-1] not in returned
 
 
+def test_observations_period_range_no_match_returns_empty(manager, dataset_id):
+    assert manager.observations(dataset_id, period_range=("1800-01", "1800-12")) == []
+
+
+def test_observations_periods_non_contiguous_list(manager, dataset_id):
+    periods = _sorted_periods(manager.observations(dataset_id))
+    assert len(periods) >= 3
+    wanted = [periods[0], periods[2]]  # deliberately skip periods[1] -> a gap
+    filtered = manager.observations(dataset_id, periods=wanted)
+    assert {obs.period for obs in filtered} == set(wanted)
+
+
+def test_observations_period_range_composes_with_org_unit(manager, dataset_id):
+    periods = _sorted_periods(manager.observations(dataset_id))
+    assert len(periods) >= 4
+    start, end = periods[1], periods[-2]
+    org_unit = sorted({obs.org_unit for obs in manager.observations(dataset_id)})[0]
+    filtered = manager.observations(dataset_id, period_range=(start, end), org_units=[org_unit])
+    assert filtered
+    assert all(obs.org_unit == org_unit and start <= obs.period <= end for obs in filtered)
+
+
 def test_observations_filters_by_org_units(manager, dataset_id):
     org_units = sorted({obs.org_unit for obs in manager.observations(dataset_id)})
     wanted = org_units[:1]
@@ -95,6 +120,20 @@ def test_observations_to_dataframe_shape(manager, dataset_id):
     assert len(df) == len(observations)
 
 
+def test_find_by_id_returns_row_or_none(manager, dataset_id):
+    row = manager.find_by_id(dataset_id)
+    assert row is not None and row.id == dataset_id
+    assert manager.find_by_id(999999) is None
+
+
+def test_find_all_and_delete_by_id(manager, dataset_id):
+    assert [d.id for d in manager.find_all()] == [dataset_id]
+    manager.delete_by_id(dataset_id)
+    assert manager.find_all() == []
+    assert manager.find_by_id(dataset_id) is None
+    assert manager.observations(dataset_id) == []  # observations cascade-deleted with the dataset
+
+
 def test_observations_to_dataframe_empty():
     df = observations_to_dataframe([])
     assert list(df.columns) == ["location", "time_period", "feature_name", "value"]
@@ -114,7 +153,55 @@ def test_to_dataset_empty_filter_raises(manager, dataset_id):
         manager.to_dataset(dataset_id, org_units=["does-not-exist"])
 
 
+def test_to_dataset_unknown_id_raises(manager):
+    with pytest.raises(ValueError, match="not found"):
+        manager.to_dataset(999999)
+
+
+def test_find_by_name_returns_row_or_none(manager, dataset_id):
+    row = manager.find_by_name("health_population")
+    assert row is not None and row.id == dataset_id
+    assert manager.find_by_name("does-not-exist") is None
+
+
 def test_to_dataset_org_unit_filter_roundtrips(manager, dataset_id):
     org_unit = sorted({obs.org_unit for obs in manager.observations(dataset_id)})[0]
     dataset = manager.to_dataset(dataset_id, org_units=[org_unit])
     assert list(dataset.locations()) == [org_unit]
+
+
+def test_to_dataset_period_range_windows_the_series(manager, dataset_id):
+    all_periods = _sorted_periods(manager.observations(dataset_id))
+    assert len(all_periods) >= 4
+    start, end = all_periods[1], all_periods[-2]
+    expected = [p for p in all_periods if start <= p <= end]
+    windowed = manager.to_dataset(dataset_id, period_range=(start, end))
+    full = manager.to_dataset(dataset_id)
+    # the window drops the first and last period and keeps a consecutive run in between
+    assert len(windowed.period_range) == len(expected)
+    assert len(windowed.period_range) < len(full.period_range)
+
+
+def test_to_dataset_period_range_and_org_unit_compose(manager, dataset_id):
+    all_periods = _sorted_periods(manager.observations(dataset_id))
+    assert len(all_periods) >= 4
+    start, end = all_periods[1], all_periods[-2]
+    org_unit = sorted({obs.org_unit for obs in manager.observations(dataset_id)})[0]
+    dataset = manager.to_dataset(dataset_id, period_range=(start, end), org_units=[org_unit])
+    assert list(dataset.locations()) == [org_unit]
+    assert len(dataset.period_range) == len([p for p in all_periods if start <= p <= end])
+
+
+def test_save_dataset_from_csv_with_geojson_loads_polygons(manager):
+    dataset_id = manager.save_dataset_from_csv(
+        "vietnam", EXAMPLE_DATA / "vietnam_monthly.csv", EXAMPLE_DATA / "vietnam_monthly.geojson"
+    )
+    dataset = manager.to_dataset(dataset_id)
+    assert len(list(dataset.locations())) > 0
+    assert dataset.polygons is not None
+    assert manager.find_by_name("vietnam").period_type == "month"
+
+
+def test_save_dataset_from_csv_weekly_sets_period_type(manager):
+    manager.save_dataset_from_csv("nicaragua", EXAMPLE_DATA / "nicaragua_weekly_data.csv")
+    assert manager.find_by_name("nicaragua").period_type == "week"

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -1,0 +1,129 @@
+"""Tests for DataSetManager observation filtering and SessionWrapper delegation."""
+
+import dataclasses
+
+import pytest
+from sqlalchemy import create_engine
+from sqlmodel import SQLModel
+
+from chap_core.database.database import SessionWrapper
+from chap_core.database.dataset_tables import DataSetCreateInfo
+from chap_core.datatypes import HealthPopulationData
+from chap_core.spatio_temporal_data.converters import observations_to_dataframe
+
+
+@pytest.fixture
+def engine():
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def dataset_id(engine, health_population_data):
+    with SessionWrapper(engine) as session:
+        return session.add_dataset(DataSetCreateInfo(name="health_population"), health_population_data, None)
+
+
+def _sorted_periods(observations):
+    return sorted({obs.period for obs in observations})
+
+
+def test_get_observations_no_filter_returns_all(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        observations = session.datasets.get_observations(dataset_id)
+    assert len(observations) > 0
+    assert {obs.feature_name for obs in observations} == {"disease_cases", "population"}
+
+
+def test_get_observations_filters_by_period_list(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        all_obs = session.datasets.get_observations(dataset_id)
+        periods = _sorted_periods(all_obs)
+        wanted = periods[:2]
+        filtered = session.datasets.get_observations(dataset_id, periods=wanted)
+    assert {obs.period for obs in filtered} == set(wanted)
+
+
+def test_get_observations_filters_by_period_range(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        periods = _sorted_periods(session.datasets.get_observations(dataset_id))
+        assert len(periods) >= 4
+        start, end = periods[1], periods[-2]
+        filtered = session.datasets.get_observations(dataset_id, period_range=(start, end))
+    returned = {obs.period for obs in filtered}
+    assert returned == {p for p in periods if start <= p <= end}
+    assert periods[0] not in returned
+    assert periods[-1] not in returned
+
+
+def test_get_observations_filters_by_org_units(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        org_units = sorted({obs.org_unit for obs in session.datasets.get_observations(dataset_id)})
+        wanted = org_units[:1]
+        filtered = session.datasets.get_observations(dataset_id, org_units=wanted)
+    assert {obs.org_unit for obs in filtered} == set(wanted)
+
+
+def test_get_observations_filters_by_feature_names(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        filtered = session.datasets.get_observations(dataset_id, feature_names=["disease_cases"])
+    assert {obs.feature_name for obs in filtered} == {"disease_cases"}
+
+
+def test_get_observations_filters_compose(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        org_unit = sorted({obs.org_unit for obs in session.datasets.get_observations(dataset_id)})[0]
+        filtered = session.datasets.get_observations(dataset_id, org_units=[org_unit], feature_names=["disease_cases"])
+    assert all(obs.org_unit == org_unit and obs.feature_name == "disease_cases" for obs in filtered)
+    assert len(filtered) > 0
+
+
+def test_get_observations_empty_match_returns_empty(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        filtered = session.datasets.get_observations(dataset_id, periods=["1899-01"])
+    assert filtered == []
+
+
+def test_get_observations_unknown_dataset_raises(engine):
+    with SessionWrapper(engine) as session:
+        with pytest.raises(ValueError, match="not found"):
+            session.datasets.get_observations(999999)
+
+
+def test_observations_to_dataframe_shape(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        observations = session.datasets.get_observations(dataset_id, feature_names=["disease_cases"])
+        df = observations_to_dataframe(observations)
+    assert list(df.columns) == ["location", "time_period", "feature_name", "value"]
+    assert (df["feature_name"] == "disease_cases").all()
+    assert len(df) == len(observations)
+
+
+def test_observations_to_dataframe_empty():
+    df = observations_to_dataframe([])
+    assert list(df.columns) == ["location", "time_period", "feature_name", "value"]
+    assert df.empty
+
+
+def test_get_dataset_feature_subset_narrows_dataclass(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        dataset = session.get_dataset(dataset_id, feature_names=["disease_cases"])
+        _, data = next(iter(dataset.items()))
+    field_names = {field.name for field in dataclasses.fields(data)}
+    assert "disease_cases" in field_names
+    assert "population" not in field_names
+
+
+def test_get_dataset_empty_filter_raises(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        with pytest.raises(ValueError, match="No observations"):
+            session.get_dataset(dataset_id, org_units=["does-not-exist"])
+
+
+def test_get_dataset_org_unit_filter_roundtrips(engine, dataset_id):
+    with SessionWrapper(engine) as session:
+        org_unit = sorted({obs.org_unit for obs in session.datasets.get_observations(dataset_id)})[0]
+        dataset = session.get_dataset(dataset_id, org_units=[org_unit])
+        locations = list(dataset.locations())
+    assert locations == [org_unit]

--- a/tests/test_dataset_manager.py
+++ b/tests/test_dataset_manager.py
@@ -1,14 +1,13 @@
-"""Tests for DataSetManager observation filtering and SessionWrapper delegation."""
+"""Tests for DataSetManager observation filtering and the flat-frame converter."""
 
 import dataclasses
 
 import pytest
 from sqlalchemy import create_engine
-from sqlmodel import SQLModel
+from sqlmodel import Session, SQLModel
 
-from chap_core.database.database import SessionWrapper
+from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import DataSetCreateInfo
-from chap_core.datatypes import HealthPopulationData
 from chap_core.spatio_temporal_data.converters import observations_to_dataframe
 
 
@@ -21,79 +20,76 @@ def engine():
 
 @pytest.fixture
 def dataset_id(engine, health_population_data):
-    with SessionWrapper(engine) as session:
-        return session.datasets.add_dataset(DataSetCreateInfo(name="health_population"), health_population_data, None)
+    with Session(engine) as session:
+        return DataSetManager(session).save_dataset(
+            DataSetCreateInfo(name="health_population"), health_population_data, None
+        )
+
+
+@pytest.fixture
+def manager(engine):
+    with Session(engine) as session:
+        yield DataSetManager(session)
 
 
 def _sorted_periods(observations):
     return sorted({obs.period for obs in observations})
 
 
-def test_get_observations_no_filter_returns_all(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        observations = session.datasets.get_observations(dataset_id)
+def test_observations_no_filter_returns_all(manager, dataset_id):
+    observations = manager.observations(dataset_id)
     assert len(observations) > 0
     assert {obs.feature_name for obs in observations} == {"disease_cases", "population"}
 
 
-def test_get_observations_filters_by_period_list(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        all_obs = session.datasets.get_observations(dataset_id)
-        periods = _sorted_periods(all_obs)
-        wanted = periods[:2]
-        filtered = session.datasets.get_observations(dataset_id, periods=wanted)
+def test_observations_filters_by_period_list(manager, dataset_id):
+    periods = _sorted_periods(manager.observations(dataset_id))
+    wanted = periods[:2]
+    filtered = manager.observations(dataset_id, periods=wanted)
     assert {obs.period for obs in filtered} == set(wanted)
 
 
-def test_get_observations_filters_by_period_range(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        periods = _sorted_periods(session.datasets.get_observations(dataset_id))
-        assert len(periods) >= 4
-        start, end = periods[1], periods[-2]
-        filtered = session.datasets.get_observations(dataset_id, period_range=(start, end))
+def test_observations_filters_by_period_range(manager, dataset_id):
+    periods = _sorted_periods(manager.observations(dataset_id))
+    assert len(periods) >= 4
+    start, end = periods[1], periods[-2]
+    filtered = manager.observations(dataset_id, period_range=(start, end))
     returned = {obs.period for obs in filtered}
     assert returned == {p for p in periods if start <= p <= end}
     assert periods[0] not in returned
     assert periods[-1] not in returned
 
 
-def test_get_observations_filters_by_org_units(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        org_units = sorted({obs.org_unit for obs in session.datasets.get_observations(dataset_id)})
-        wanted = org_units[:1]
-        filtered = session.datasets.get_observations(dataset_id, org_units=wanted)
+def test_observations_filters_by_org_units(manager, dataset_id):
+    org_units = sorted({obs.org_unit for obs in manager.observations(dataset_id)})
+    wanted = org_units[:1]
+    filtered = manager.observations(dataset_id, org_units=wanted)
     assert {obs.org_unit for obs in filtered} == set(wanted)
 
 
-def test_get_observations_filters_by_feature_names(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        filtered = session.datasets.get_observations(dataset_id, feature_names=["disease_cases"])
+def test_observations_filters_by_feature_names(manager, dataset_id):
+    filtered = manager.observations(dataset_id, feature_names=["disease_cases"])
     assert {obs.feature_name for obs in filtered} == {"disease_cases"}
 
 
-def test_get_observations_filters_compose(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        org_unit = sorted({obs.org_unit for obs in session.datasets.get_observations(dataset_id)})[0]
-        filtered = session.datasets.get_observations(dataset_id, org_units=[org_unit], feature_names=["disease_cases"])
+def test_observations_filters_compose(manager, dataset_id):
+    org_unit = sorted({obs.org_unit for obs in manager.observations(dataset_id)})[0]
+    filtered = manager.observations(dataset_id, org_units=[org_unit], feature_names=["disease_cases"])
     assert all(obs.org_unit == org_unit and obs.feature_name == "disease_cases" for obs in filtered)
     assert len(filtered) > 0
 
 
-def test_get_observations_empty_match_returns_empty(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        filtered = session.datasets.get_observations(dataset_id, periods=["1899-01"])
-    assert filtered == []
+def test_observations_empty_match_returns_empty(manager, dataset_id):
+    assert manager.observations(dataset_id, periods=["1899-01"]) == []
 
 
-def test_get_observations_unknown_dataset_returns_empty(engine):
-    with SessionWrapper(engine) as session:
-        assert session.datasets.get_observations(999999) == []
+def test_observations_unknown_dataset_returns_empty(manager):
+    assert manager.observations(999999) == []
 
 
-def test_observations_to_dataframe_shape(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        observations = session.datasets.get_observations(dataset_id, feature_names=["disease_cases"])
-        df = observations_to_dataframe(observations)
+def test_observations_to_dataframe_shape(manager, dataset_id):
+    observations = manager.observations(dataset_id, feature_names=["disease_cases"])
+    df = observations_to_dataframe(observations)
     assert list(df.columns) == ["location", "time_period", "feature_name", "value"]
     assert (df["feature_name"] == "disease_cases").all()
     assert len(df) == len(observations)
@@ -105,24 +101,20 @@ def test_observations_to_dataframe_empty():
     assert df.empty
 
 
-def test_get_dataset_feature_subset_narrows_dataclass(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        dataset = session.datasets.get_dataset(dataset_id, feature_names=["disease_cases"])
-        _, data = next(iter(dataset.items()))
+def test_to_dataset_feature_subset_narrows_dataclass(manager, dataset_id):
+    dataset = manager.to_dataset(dataset_id, feature_names=["disease_cases"])
+    _, data = next(iter(dataset.items()))
     field_names = {field.name for field in dataclasses.fields(data)}
     assert "disease_cases" in field_names
     assert "population" not in field_names
 
 
-def test_get_dataset_empty_filter_raises(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        with pytest.raises(ValueError, match="No observations"):
-            session.datasets.get_dataset(dataset_id, org_units=["does-not-exist"])
+def test_to_dataset_empty_filter_raises(manager, dataset_id):
+    with pytest.raises(ValueError, match="No observations"):
+        manager.to_dataset(dataset_id, org_units=["does-not-exist"])
 
 
-def test_get_dataset_org_unit_filter_roundtrips(engine, dataset_id):
-    with SessionWrapper(engine) as session:
-        org_unit = sorted({obs.org_unit for obs in session.datasets.get_observations(dataset_id)})[0]
-        dataset = session.datasets.get_dataset(dataset_id, org_units=[org_unit])
-        locations = list(dataset.locations())
-    assert locations == [org_unit]
+def test_to_dataset_org_unit_filter_roundtrips(manager, dataset_id):
+    org_unit = sorted({obs.org_unit for obs in manager.observations(dataset_id)})[0]
+    dataset = manager.to_dataset(dataset_id, org_units=[org_unit])
+    assert list(dataset.locations()) == [org_unit]


### PR DESCRIPTION
## What

Foundation PR for CLIM-637 (pluggable threshold endpoint). Splits dataset data-access out of the catch-all `SessionWrapper` into a dedicated `DataSetManager`, adds the ability to control how much of a dataset is read (instead of always loading everything), and routes all dataset access through the manager.

## Manager layer

- `chap_core/database/manager.py`: generic `DbManager[ModelT: SQLModel]` base whose method names mirror servicekit's manager interface — `find_by_id`, `find_all`, `save`, `delete_by_id` — so chap-core's sync data-access reads consistently with the rest of the stack. (servicekit itself is async / AsyncSession; chap-core is sync, so we mirror the naming rather than subclass it.)
- `chap_core/database/dataset_manager.py`: `DataSetManager(DbManager[DataSet])` owns dataset reads/writes (moved from `SessionWrapper`) plus filtering:
  - `to_dataset(id, *, period_range, org_units, feature_names)` -> `_DataSet` domain object; contiguous-safe filters; narrows the inferred dataclass to the requested feature subset; clear error on empty selection.
  - `observations(id, *, periods, period_range, org_units, feature_names)` -> raw `Observation` rows; handles arbitrary / non-contiguous period subsets; `[]` for unknown/empty.
  - `save_dataset(info, _DataSet, polygons)` (reuses base `save`), `save_dataset_from_csv(...)`, `find_by_name(name)`.

## No more SessionWrapper for dataset queries

- Removed the dataset methods and the `.datasets` accessor from `SessionWrapper`.
- Callers now construct `DataSetManager(session)` directly (the way chapkit uses its servicekit managers): `db_worker_functions`, `crud` (csv import, df, csv, delete), `datasets_seed`, and tests.

## Get-all path migrated

- `get_actual_cases` calls `DataSetManager.observations` with org-unit + `disease_cases` filtering pushed into SQL, instead of a raw `select(Observation)` + Python filtering.
- The delete-dataset endpoint uses `DataSetManager.delete_by_id`.

## Other

- `observations_to_dataframe` long-format converter for the flat reader.
- `tests/test_dataset_manager.py`: filtering per dimension + composition, empty/unknown handling, feature-subset dataclass narrowing, converter.

## Deferred (operate on a loaded DataSet model, no session)
`converters.dataset_model_to_dataset` (plotting) and `naive_simulator.simulate_split` read `dataset.observations` on an already-materialised model with no session/id (the simulator's is built purely in memory), so they are not DB get-all paths and are out of scope here.

## Verification
`make lint` clean (ruff + mypy + pyright). Tests pass: `test_dataset_manager`, `test_database`, `test_dataset`, `test_gluonts_adaptor`, `test_prediction_setup_service`, `spatio_temporal_data/`, and the TestClient suite `integration/rest_api/test_from_seeded_engine.py` (covers `actualCases`/`actual-cases`/`isDatasetId` and `datasets/{id}/df`).