### PR TITLE
feat(thresholds): add pluggable threshold calculation endpoint [CLIM-637]

### DIFF
--- a/chap_core/assessment/metrics/__init__.py
+++ b/chap_core/assessment/metrics/__init__.py
@@ -104,7 +104,6 @@ from chap_core.assessment.metrics.outbreak_detection import (
     OutbreakAccuracyMetric,
     SensitivityMetric,
     SpecificityMetric,
-    compute_seasonal_thresholds,
 )
 from chap_core.assessment.metrics.peak_diff import PeakPeriodLagMetric, PeakValueDiffMetric
 from chap_core.assessment.metrics.percentile_coverage import (
@@ -158,7 +157,6 @@ __all__ = [
     "WinklerScoreLog1pMetric",
     "WinklerScoreMetric",
     "available_metrics",
-    "compute_seasonal_thresholds",
     "get_metric",
     "get_metrics_registry",
     "list_metrics",

--- a/chap_core/assessment/metrics/outbreak_detection.py
+++ b/chap_core/assessment/metrics/outbreak_detection.py
@@ -15,33 +15,11 @@ from chap_core.assessment.metrics.base import (
     Metric,
     MetricSpec,
 )
+
+# The outbreak metrics score forecasts against seasonal thresholds, computed by the
+# threshold strategy module.
+from chap_core.assessment.thresholds.seasonal import _extract_month, compute_seasonal_thresholds
 from chap_core.time_period import TimePeriod
-
-
-def _extract_month(time_period: pd.Series) -> pd.Index:
-    """Vectorised month-of-year extraction from monthly time_period strings.
-
-    Equivalent to ``time_period.apply(lambda tp: TimePeriod.parse(str(tp)).start_timestamp.month)``
-    but ~100x faster on large frames. Only valid for monthly periods; callers gate on
-    ``_has_monthly_time_periods``.
-    """
-    return pd.PeriodIndex(time_period.astype(str), freq="M").month
-
-
-def compute_seasonal_thresholds(historical_observations: pd.DataFrame) -> pd.DataFrame:
-    """Compute outbreak thresholds from historical observations.
-
-    Args:
-        historical_observations: DataFrame with columns [location, time_period, disease_cases]
-
-    Returns:
-        DataFrame with columns [location, month, threshold]
-    """
-    df = historical_observations.copy()
-    df["month"] = _extract_month(df["time_period"])
-    grouped = df.groupby(["location", "month"])["disease_cases"].agg(["mean", "std"]).reset_index()
-    grouped["threshold"] = grouped["mean"] + 2 * grouped["std"]
-    return grouped[["location", "month", "threshold"]]
 
 
 def _get_thresholds(metric_instance: Metric) -> pd.DataFrame:

--- a/chap_core/assessment/thresholds/__init__.py
+++ b/chap_core/assessment/thresholds/__init__.py
@@ -1,0 +1,59 @@
+"""Threshold (endemic channel) calculation plugin system.
+
+Each strategy is a single class registered with the :func:`threshold` decorator,
+mirroring the ``@backtest_plot`` registry. New strategies are added by writing a
+class and importing its module from :func:`_discover_strategies` — the endpoint
+code never needs editing.
+"""
+
+from __future__ import annotations
+
+from chap_core.assessment.thresholds.base import ThresholdStrategyBase
+
+# Global registry for threshold strategies
+_threshold_strategies_registry: dict[str, type[ThresholdStrategyBase]] = {}
+
+
+def threshold(strategy_id: str, name: str, description: str = ""):
+    """Decorator to register a threshold strategy class."""
+
+    def decorator(cls: type[ThresholdStrategyBase]) -> type[ThresholdStrategyBase]:
+        if not issubclass(cls, ThresholdStrategyBase):
+            raise TypeError(f"{cls.__name__} must inherit from ThresholdStrategyBase")
+
+        cls.id = strategy_id
+        cls.name = name
+        cls.description = description
+
+        _threshold_strategies_registry[strategy_id] = cls
+        return cls
+
+    return decorator
+
+
+def get_threshold_strategies_registry() -> dict[str, type[ThresholdStrategyBase]]:
+    return _threshold_strategies_registry.copy()
+
+
+def get_threshold_strategy(strategy_id: str) -> type[ThresholdStrategyBase] | None:
+    return _threshold_strategies_registry.get(strategy_id)
+
+
+def list_threshold_strategies() -> list[dict]:
+    return [
+        {
+            "id": cls.id,
+            "name": cls.name,
+            "description": cls.description,
+        }
+        for cls in _threshold_strategies_registry.values()
+    ]
+
+
+def _discover_strategies():
+    from chap_core.assessment.thresholds import (
+        seasonal,
+    )
+
+
+_discover_strategies()

--- a/chap_core/assessment/thresholds/base.py
+++ b/chap_core/assessment/thresholds/base.py
@@ -19,7 +19,7 @@ class ThresholdStrategyBase(ABC):
 
     Subclasses implement :meth:`compute`, which receives a flat DataFrame of
     historical observations and the periods to produce thresholds for, and
-    returns one threshold per ``(period_id, org_unit)``.
+    returns one threshold per ``(period_id, location)``.
     """
 
     id: str = ""
@@ -42,6 +42,6 @@ class ThresholdStrategyBase(ABC):
             params: Optional strategy-specific parameters.
 
         Returns:
-            DataFrame with columns ``[period_id, org_unit, threshold]`` — one row
-            per ``(period_id, org_unit)``.
+            DataFrame with columns ``[period_id, location, threshold]`` — one row
+            per ``(period_id, location)``.
         """

--- a/chap_core/assessment/thresholds/base.py
+++ b/chap_core/assessment/thresholds/base.py
@@ -1,0 +1,47 @@
+"""Base class for threshold (endemic channel) calculation strategies.
+
+A strategy turns a dataset's historical ``disease_cases`` observations into one
+threshold value per requested ``(period_id, org_unit)``. Subclasses implement
+:meth:`compute`; registration happens via the :func:`threshold` decorator.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class ThresholdStrategyBase(ABC):
+    """Base class for threshold strategies.
+
+    Subclasses implement :meth:`compute`, which receives a flat DataFrame of
+    historical observations and the periods to produce thresholds for, and
+    returns one threshold per ``(period_id, org_unit)``.
+    """
+
+    id: str = ""
+    name: str = ""
+    description: str = ""
+
+    @abstractmethod
+    def compute(
+        self,
+        historical_observations: pd.DataFrame,
+        period_ids: list[str],
+        params: dict | None = None,
+    ) -> pd.DataFrame:
+        """Compute thresholds for the requested periods.
+
+        Args:
+            historical_observations: DataFrame with columns
+                ``[location, time_period, disease_cases]``.
+            period_ids: Periods to produce a threshold for (e.g. ``["2024-01"]``).
+            params: Optional strategy-specific parameters.
+
+        Returns:
+            DataFrame with columns ``[period_id, org_unit, threshold]`` — one row
+            per ``(period_id, org_unit)``.
+        """

--- a/chap_core/assessment/thresholds/seasonal.py
+++ b/chap_core/assessment/thresholds/seasonal.py
@@ -1,0 +1,57 @@
+"""Seasonal threshold strategy: mean + k*std over historical same-month values."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from chap_core.assessment.thresholds import threshold
+from chap_core.assessment.thresholds.base import ThresholdStrategyBase
+
+
+def _extract_month(time_period: pd.Series) -> pd.Index:
+    """Vectorised month-of-year extraction from monthly time_period strings.
+
+    Equivalent to ``time_period.apply(lambda tp: TimePeriod.parse(str(tp)).start_timestamp.month)``
+    but ~100x faster on large frames. Only valid for monthly periods.
+    """
+    return pd.PeriodIndex(time_period.astype(str), freq="M").month
+
+
+def compute_seasonal_thresholds(historical_observations: pd.DataFrame, k: float = 2.0) -> pd.DataFrame:
+    """Compute outbreak thresholds from historical observations.
+
+    Args:
+        historical_observations: DataFrame with columns [location, time_period, disease_cases]
+        k: Number of standard deviations above the mean (default 2.0).
+
+    Returns:
+        DataFrame with columns [location, month, threshold]
+    """
+    df = historical_observations.copy()
+    df["month"] = _extract_month(df["time_period"])
+    grouped = df.groupby(["location", "month"])["disease_cases"].agg(["mean", "std"]).reset_index()
+    grouped["threshold"] = grouped["mean"] + k * grouped["std"]
+    return grouped[["location", "month", "threshold"]]
+
+
+@threshold(
+    "seasonal",
+    "Seasonal mean + k*std",
+    "Outbreak threshold as mean + k standard deviations of historical same-month values.",
+)
+class SeasonalThresholdStrategy(ThresholdStrategyBase):
+    """Wraps :func:`compute_seasonal_thresholds` as a registered strategy."""
+
+    def compute(
+        self,
+        historical_observations: pd.DataFrame,
+        period_ids: list[str],
+        params: dict | None = None,
+    ) -> pd.DataFrame:
+        k = float((params or {}).get("k", 2.0))
+        per_month = compute_seasonal_thresholds(historical_observations, k=k)
+        requested = pd.DataFrame({"period_id": period_ids})
+        requested["month"] = _extract_month(requested["period_id"])
+        merged = requested.merge(per_month, on="month")
+        merged = merged.rename(columns={"location": "org_unit"})
+        return merged[["period_id", "org_unit", "threshold"]]

--- a/chap_core/assessment/thresholds/seasonal.py
+++ b/chap_core/assessment/thresholds/seasonal.py
@@ -53,5 +53,4 @@ class SeasonalThresholdStrategy(ThresholdStrategyBase):
         requested = pd.DataFrame({"period_id": period_ids})
         requested["month"] = _extract_month(requested["period_id"])
         merged = requested.merge(per_month, on="month")
-        merged = merged.rename(columns={"location": "org_unit"})
-        return merged[["period_id", "org_unit", "threshold"]]
+        return merged[["period_id", "location", "threshold"]]

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -723,14 +723,18 @@ class ThresholdRequest(DBModel):
     dataset_id: int = Field(description="Primary key of the dataset to compute thresholds from.")
     period_ids: list[str] = Field(description='Periods to produce a threshold for, e.g. `["2024-01", "2024-02"]`.')
     strategy: str = Field(description="Registered threshold strategy id (see GET /thresholds/strategies).")
+    locations: list[str] | None = Field(
+        default=None,
+        description="Optional locations to restrict the result to. When omitted or empty, every location in the dataset is returned.",
+    )
     params: dict = Field(default={}, description="Optional strategy-specific parameters.")
 
 
 class ThresholdEntry(DBModel):
-    """One computed threshold for a single (period, org unit)."""
+    """One computed threshold for a single (period, location)."""
 
     period: str = Field(description="Period the threshold applies to.")
-    orgUnit: str = Field(description="Org unit the threshold applies to.")
+    location: str = Field(description="Location the threshold applies to.")
     value: float | None = Field(description="Computed threshold value, or `None` if it could not be computed.")
 
 
@@ -779,7 +783,9 @@ def compute_thresholds(request: ThresholdRequest, session: Session = Depends(get
             status_code=404, detail=f"Unknown threshold strategy: {request.strategy}. Available: {available}"
         )
 
-    observations = DataSetManager(session).observations(request.dataset_id, feature_names=["disease_cases"])
+    observations = DataSetManager(session).observations(
+        request.dataset_id, org_units=request.locations or None, feature_names=["disease_cases"]
+    )
     if not observations:
         raise HTTPException(
             status_code=404, detail=f"No disease_cases observations found for dataset {request.dataset_id}"
@@ -792,7 +798,7 @@ def compute_thresholds(request: ThresholdRequest, session: Session = Depends(get
     return [
         ThresholdEntry(
             period=str(row["period_id"]),
-            orgUnit=str(row["org_unit"]),
+            location=str(row["location"]),
             value=None if (row["threshold"] is None or np.isnan(row["threshold"])) else float(row["threshold"]),
         )
         for row in result.to_dict("records")

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 import numpy as np
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import selectinload
-from sqlmodel import Session, select
+from sqlmodel import Field, Session, select
 
 import chap_core.rest_api.db_worker_functions as wf
 from chap_core.api_types import (
@@ -16,13 +16,15 @@ from chap_core.api_types import (
     PredictionEntry,
 )
 from chap_core.assessment.dataset_splitting import train_test_generator
+from chap_core.assessment.thresholds import get_threshold_strategy, list_threshold_strategies
+from chap_core.database.base_tables import DBModel
 from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import DataSet as DataSetTable
 from chap_core.database.dataset_tables import DataSetCreateInfo
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
 from chap_core.database.tables import Backtest, BacktestForecast, Prediction
 from chap_core.datatypes import create_tsdataclass
-from chap_core.spatio_temporal_data.converters import observations_to_dataset
+from chap_core.spatio_temporal_data.converters import observations_to_dataframe, observations_to_dataset
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 
 from ...celery_tasks import JOB_NAME_KW, JOB_TYPE_KW, CeleryPool, JobType
@@ -713,3 +715,85 @@ async def create_backtest_with_data(
     )
     job_id = job.id
     return ImportSummaryResponse(id=job_id, imported_count=imported_count, rejected=rejections)
+
+
+class ThresholdRequest(DBModel):
+    """Request body for computing thresholds (endemic channel) for a dataset."""
+
+    dataset_id: int = Field(description="Primary key of the dataset to compute thresholds from.")
+    period_ids: list[str] = Field(description='Periods to produce a threshold for, e.g. `["2024-01", "2024-02"]`.')
+    strategy: str = Field(description="Registered threshold strategy id (see GET /thresholds/strategies).")
+    params: dict = Field(default={}, description="Optional strategy-specific parameters.")
+
+
+class ThresholdEntry(DBModel):
+    """One computed threshold for a single (period, org unit)."""
+
+    period: str = Field(description="Period the threshold applies to.")
+    orgUnit: str = Field(description="Org unit the threshold applies to.")
+    value: float | None = Field(description="Computed threshold value, or `None` if it could not be computed.")
+
+
+class ThresholdStrategyInfo(DBModel):
+    """Catalogue entry for one registered threshold strategy."""
+
+    id: str = Field(description="Canonical strategy identifier used in request bodies.")
+    display_name: str = Field(description="Human-friendly strategy name shown in pickers.")
+    description: str = Field(default="", description="Short paragraph explaining what the strategy computes.")
+
+
+@router.get(
+    "/thresholds/strategies",
+    response_model=list[ThresholdStrategyInfo],
+    tags=["Datasets"],
+    summary="Discover which threshold strategies are available",
+)
+def list_threshold_strategy_types():
+    """List the registered threshold strategies (seasonal mean + k*std, ...), with a name and description for each.
+
+    Use this to populate a strategy picker before requesting a specific threshold via
+    `POST /v1/analytics/thresholds`.
+    """
+    return [
+        ThresholdStrategyInfo(id=s["id"], display_name=s["name"], description=s["description"])
+        for s in list_threshold_strategies()
+    ]
+
+
+@router.post(
+    "/thresholds",
+    response_model=list[ThresholdEntry],
+    tags=["Datasets"],
+    summary="Compute thresholds (endemic channel) for a dataset",
+)
+def compute_thresholds(request: ThresholdRequest, session: Session = Depends(get_session)):
+    """Compute one outbreak threshold per (period, org unit) from a dataset's historical disease_cases, using the chosen strategy.
+
+    404 if the strategy id is not registered or the dataset has no `disease_cases`
+    observations.
+    """
+    strategy_cls = get_threshold_strategy(request.strategy)
+    if strategy_cls is None:
+        available = ", ".join(s["id"] for s in list_threshold_strategies())
+        raise HTTPException(
+            status_code=404, detail=f"Unknown threshold strategy: {request.strategy}. Available: {available}"
+        )
+
+    observations = DataSetManager(session).observations(request.dataset_id, feature_names=["disease_cases"])
+    if not observations:
+        raise HTTPException(
+            status_code=404, detail=f"No disease_cases observations found for dataset {request.dataset_id}"
+        )
+
+    df = observations_to_dataframe(observations).rename(columns={"value": "disease_cases"})[
+        ["location", "time_period", "disease_cases"]
+    ]
+    result = strategy_cls().compute(df, request.period_ids, request.params)
+    return [
+        ThresholdEntry(
+            period=str(row["period_id"]),
+            orgUnit=str(row["org_unit"]),
+            value=None if (row["threshold"] is None or np.isnan(row["threshold"])) else float(row["threshold"]),
+        )
+        for row in result.to_dict("records")
+    ]

--- a/docs/contributor/creating_custom_threshold_strategies.md
+++ b/docs/contributor/creating_custom_threshold_strategies.md
@@ -6,7 +6,7 @@ using the threshold plugin system.
 ## Overview
 
 A threshold strategy turns a dataset's historical `disease_cases` observations into one
-threshold value per requested `(period_id, org_unit)`. Chap provides a registry — mirroring
+threshold value per requested `(period_id, location)`. Chap provides a registry — mirroring
 the backtest plot and metric registries — so new strategies can be added without touching
 the endpoint code.
 

--- a/docs/contributor/creating_custom_threshold_strategies.md
+++ b/docs/contributor/creating_custom_threshold_strategies.md
@@ -1,0 +1,85 @@
+# Creating Custom Threshold Strategies
+
+This guide explains how to add a new threshold ("endemic channel") calculation strategy
+using the threshold plugin system.
+
+## Overview
+
+A threshold strategy turns a dataset's historical `disease_cases` observations into one
+threshold value per requested `(period_id, org_unit)`. Chap provides a registry — mirroring
+the backtest plot and metric registries — so new strategies can be added without touching
+the endpoint code.
+
+Each strategy:
+
+- Receives a flat pandas DataFrame of historical observations and the periods to score
+- Returns one threshold per `(period_id, org_unit)`
+- Is automatically registered and discoverable
+- Is exposed through the REST API at `POST /v1/analytics/thresholds` and listed by
+  `GET /v1/analytics/thresholds/strategies` once registered
+
+## Data Schemas
+
+### Historical observations DataFrame (input)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `location` | str | Org unit identifier |
+| `time_period` | str | Time period (e.g. `"2024-01"`) |
+| `disease_cases` | float | Observed disease cases |
+
+### Result DataFrame (output)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `period_id` | str | Period the threshold applies to |
+| `org_unit` | str | Org unit the threshold applies to |
+| `threshold` | float | Computed threshold value |
+
+## Writing a strategy
+
+Subclass `ThresholdStrategyBase`, implement `compute()`, and register the class with the
+`@threshold(...)` decorator:
+
+```python
+import pandas as pd
+
+from chap_core.assessment.thresholds import threshold
+from chap_core.assessment.thresholds.base import ThresholdStrategyBase
+
+
+@threshold(
+    "historical_percentile",
+    "Historical percentile",
+    "Threshold as the given percentile of historical same-month values.",
+)
+class HistoricalPercentileStrategy(ThresholdStrategyBase):
+    def compute(
+        self,
+        historical_observations: pd.DataFrame,
+        period_ids: list[str],
+        params: dict | None = None,
+    ) -> pd.DataFrame:
+        q = float((params or {}).get("percentile", 0.95))
+        ...  # return DataFrame with columns [period_id, org_unit, threshold]
+```
+
+`params` carries optional, strategy-specific parameters supplied in the request body. See
+`chap_core/assessment/thresholds/seasonal.py` for the built-in seasonal mean + k*std strategy.
+
+## Registering for discovery
+
+The `@threshold` decorator registers your class in a global registry when its module is
+imported. For Chap to discover the strategy at startup, import your module in
+`_discover_strategies()` in `chap_core/assessment/thresholds/__init__.py`:
+
+```python
+def _discover_strategies():
+    from chap_core.assessment.thresholds import (  # noqa: F401
+        historical_percentile,
+        seasonal,
+    )
+```
+
+Once registered, the strategy id can be passed as `strategy` to
+`POST /v1/analytics/thresholds` and appears in `GET /v1/analytics/thresholds/strategies`.

--- a/docs/contributor/index.md
+++ b/docs/contributor/index.md
@@ -27,6 +27,7 @@ This section provides documentation for contributors to the Chap platform.
 - [Adding CLI Commands](adding_cli_commands.md) - How to add a new `chap` subcommand
 - [Creating Custom Backtest Plots](creating_custom_backtest_plots.md) - How to create custom visualizations
 - [Creating Custom Metrics](creating_custom_metrics.md) - How to create custom evaluation metrics
+- [Creating Custom Threshold Strategies](creating_custom_threshold_strategies.md) - How to add a custom threshold (endemic channel) strategy
 
 ## Design Documents
 - [Evaluation Abstraction](evaluation_abstraction.md) - Evaluation system design

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ not_in_nav: |
   contributor/adding_cli_commands.md
   contributor/creating_custom_backtest_plots.md
   contributor/creating_custom_metrics.md
+  contributor/creating_custom_threshold_strategies.md
   contributor/evaluation_walkthrough_exec.md
   external_models/surplus_after_refactoring.md
   feature_tutorials/index.md

--- a/tests/evaluation/test_outbreak_detection_metrics.py
+++ b/tests/evaluation/test_outbreak_detection_metrics.py
@@ -65,6 +65,22 @@ def test_compute_seasonal_thresholds_period_formats(time_period_format, threshol
     assert result.iloc[0]["threshold"] == pytest.approx(threshold_value)
 
 
+def test_compute_seasonal_thresholds_single_datapoint_is_nan():
+    """A (location, month) with a single historical value has undefined std, so the threshold is NaN (-> null)."""
+    df = pd.DataFrame(
+        [
+            {"location": "A", "time_period": "2020-06", "disease_cases": 100.0},
+            {"location": "B", "time_period": "2020-06", "disease_cases": 50.0},
+            {"location": "B", "time_period": "2021-06", "disease_cases": 70.0},
+        ]
+    )
+    result = compute_seasonal_thresholds(df)
+    a = result[result["location"] == "A"].iloc[0]
+    b = result[result["location"] == "B"].iloc[0]
+    assert np.isnan(a["threshold"])  # single data point -> cannot compute -> NaN
+    assert not np.isnan(b["threshold"])  # two data points -> computed
+
+
 def _make_forecasts(location, time_period, horizon, samples):
     """Helper to create a forecast DataFrame from sample values."""
     return pd.DataFrame(

--- a/tests/evaluation/test_outbreak_detection_metrics.py
+++ b/tests/evaluation/test_outbreak_detection_metrics.py
@@ -6,8 +6,8 @@ from chap_core.assessment.metrics.outbreak_detection import (
     OutbreakAccuracyMetric,
     SensitivityMetric,
     SpecificityMetric,
-    compute_seasonal_thresholds,
 )
+from chap_core.assessment.thresholds.seasonal import compute_seasonal_thresholds
 
 
 @pytest.fixture()

--- a/tests/integration/rest_api/test_from_seeded_engine.py
+++ b/tests/integration/rest_api/test_from_seeded_engine.py
@@ -132,11 +132,19 @@ def test_compute_thresholds(override_session):
     response = client.post("/v1/analytics/thresholds", json=body)
     assert response.status_code == 200, response.json()
     entries = response.json()
-    # 2 requested periods x 3 org units in the seeded dataset
+    # 2 requested periods x 3 locations in the seeded dataset
     assert len(entries) == 6
     assert {e["period"] for e in entries} == {"2023-01", "2023-02"}
-    assert {e["orgUnit"] for e in entries} == {"loc_1", "loc_2", "loc_3"}
+    assert {e["location"] for e in entries} == {"loc_1", "loc_2", "loc_3"}
     assert all(e["value"] is not None for e in entries)
+
+
+def test_compute_thresholds_filters_by_locations(override_session):
+    body = {"dataset_id": 1, "period_ids": ["2023-01"], "strategy": "seasonal", "locations": ["loc_1"]}
+    response = client.post("/v1/analytics/thresholds", json=body)
+    assert response.status_code == 200, response.json()
+    entries = response.json()
+    assert {e["location"] for e in entries} == {"loc_1"}
 
 
 def test_compute_thresholds_unknown_strategy(override_session):

--- a/tests/integration/rest_api/test_from_seeded_engine.py
+++ b/tests/integration/rest_api/test_from_seeded_engine.py
@@ -118,6 +118,39 @@ def test_backtest_plot(override_session, tmp_path):
     #    f.write(html_template)
 
 
+def test_threshold_strategies_discovery(override_session):
+    strategies = client.get_json("/v1/analytics/thresholds/strategies")
+    ids = {s["id"] for s in strategies}
+    assert "seasonal" in ids
+    seasonal = next(s for s in strategies if s["id"] == "seasonal")
+    assert seasonal["displayName"]
+    assert seasonal["description"]
+
+
+def test_compute_thresholds(override_session):
+    body = {"dataset_id": 1, "period_ids": ["2023-01", "2023-02"], "strategy": "seasonal"}
+    response = client.post("/v1/analytics/thresholds", json=body)
+    assert response.status_code == 200, response.json()
+    entries = response.json()
+    # 2 requested periods x 3 org units in the seeded dataset
+    assert len(entries) == 6
+    assert {e["period"] for e in entries} == {"2023-01", "2023-02"}
+    assert {e["orgUnit"] for e in entries} == {"loc_1", "loc_2", "loc_3"}
+    assert all(e["value"] is not None for e in entries)
+
+
+def test_compute_thresholds_unknown_strategy(override_session):
+    body = {"dataset_id": 1, "period_ids": ["2023-01"], "strategy": "does_not_exist"}
+    response = client.post("/v1/analytics/thresholds", json=body)
+    assert response.status_code == 404, response.text
+
+
+def test_compute_thresholds_unknown_dataset(override_session):
+    body = {"dataset_id": 9999, "period_ids": ["2023-01"], "strategy": "seasonal"}
+    response = client.post("/v1/analytics/thresholds", json=body)
+    assert response.status_code == 404, response.text
+
+
 def wrap_vega_spec(vega_spec) -> str:
     html_template = f"""
     <!DOCTYPE html>

--- a/tests/integration/rest_api/test_threshold_strategies.py
+++ b/tests/integration/rest_api/test_threshold_strategies.py
@@ -1,0 +1,46 @@
+"""Tests for the threshold strategy registry and the seasonal strategy."""
+
+from chap_core.assessment.thresholds import get_threshold_strategy, list_threshold_strategies
+from chap_core.assessment.thresholds.seasonal import compute_seasonal_thresholds
+from chap_core.spatio_temporal_data.converters import observations_to_dataframe
+
+
+def _disease_cases_df(dataset_observations):
+    df = observations_to_dataframe(dataset_observations)
+    df = df[df["feature_name"] == "disease_cases"].rename(columns={"value": "disease_cases"})
+    return df[["location", "time_period", "disease_cases"]]
+
+
+def _seasonal_strategy():
+    strategy_cls = get_threshold_strategy("seasonal")
+    assert strategy_cls is not None
+    return strategy_cls()
+
+
+def test_seasonal_strategy_is_registered():
+    assert "seasonal" in {s["id"] for s in list_threshold_strategies()}
+    assert get_threshold_strategy("seasonal") is not None
+
+
+def test_unknown_strategy_returns_none():
+    assert get_threshold_strategy("does_not_exist") is None
+
+
+def test_seasonal_strategy_shape(dataset_observations, org_units):
+    df = _disease_cases_df(dataset_observations)
+    period_ids = ["2023-01", "2023-02"]
+    result = _seasonal_strategy().compute(df, period_ids)
+    assert set(result.columns) == {"period_id", "org_unit", "threshold"}
+    assert len(result) == len(period_ids) * len(org_units)
+    assert set(result["period_id"]) == set(period_ids)
+    assert set(result["org_unit"]) == set(org_units)
+
+
+def test_seasonal_strategy_parity_with_compute_seasonal_thresholds(dataset_observations):
+    df = _disease_cases_df(dataset_observations)
+    result = _seasonal_strategy().compute(df, ["2023-01"])
+    per_month = compute_seasonal_thresholds(df)
+    january = per_month[per_month["month"] == 1]
+    for row in result.itertuples():
+        expected = january[january["location"] == row.org_unit]["threshold"].iloc[0]
+        assert row.threshold == expected

--- a/tests/integration/rest_api/test_threshold_strategies.py
+++ b/tests/integration/rest_api/test_threshold_strategies.py
@@ -30,10 +30,10 @@ def test_seasonal_strategy_shape(dataset_observations, org_units):
     df = _disease_cases_df(dataset_observations)
     period_ids = ["2023-01", "2023-02"]
     result = _seasonal_strategy().compute(df, period_ids)
-    assert set(result.columns) == {"period_id", "org_unit", "threshold"}
+    assert set(result.columns) == {"period_id", "location", "threshold"}
     assert len(result) == len(period_ids) * len(org_units)
     assert set(result["period_id"]) == set(period_ids)
-    assert set(result["org_unit"]) == set(org_units)
+    assert set(result["location"]) == set(org_units)
 
 
 def test_seasonal_strategy_parity_with_compute_seasonal_thresholds(dataset_observations):
@@ -42,5 +42,5 @@ def test_seasonal_strategy_parity_with_compute_seasonal_thresholds(dataset_obser
     per_month = compute_seasonal_thresholds(df)
     january = per_month[per_month["month"] == 1]
     for row in result.itertuples():
-        expected = january[january["location"] == row.org_unit]["threshold"].iloc[0]
+        expected = january[january["location"] == row.location]["threshold"].iloc[0]
         assert row.threshold == expected


### PR DESCRIPTION
## Summary

Implements [CLIM-637](https://dhis2.atlassian.net/browse/CLIM-637): expose threshold (endemic channel) computation as a REST endpoint backed by a registry, so new strategies can be added the same way metrics and backtest plots are. Builds on the `DataSetManager.observations(...)` filterable reads added in #392.

## Changes

- **New `chap_core/assessment/thresholds/` module** (modeled on the `@backtest_plot` registry):
  - `base.py` — `ThresholdStrategyBase` ABC with a `compute(historical_observations, period_ids, params) -> DataFrame[period_id, location, threshold]` contract.
  - `__init__.py` — `@threshold(id, name, description)` decorator, registry, `get_threshold_strategy` / `list_threshold_strategies`, and `_discover_strategies()`.
  - `seasonal.py` — `SeasonalThresholdStrategy` (`"seasonal"`) wrapping `compute_seasonal_thresholds`.
- **Moved** `compute_seasonal_thresholds` + `_extract_month` into `thresholds/seasonal.py` (now parametrized by `k`, default 2.0 = unchanged behavior). `outbreak_detection.py` and tests import them from the new location; no compat shim left behind.
- **Endpoints** on the v1 analytics router (synchronous, value-only):
  - `POST /v1/analytics/thresholds` — body `{datasetId, periodIds, strategy, locations?, params?}`, returns one `{period, location, value}` per (period, location). `locations` is optional; omitted or empty returns every location in the dataset. 404 on unknown strategy or dataset with no `disease_cases`.
  - `GET /v1/analytics/thresholds/strategies` — discovery list for a strategy picker.
- **Naming**: the threshold feature uses `location` throughout (request/response/strategy). `DataSetManager` keeps its existing `org_units` param (maps to the `Observation.org_unit` DB column); the endpoint passes `org_units=request.locations or None`.
- **Docs**: `docs/contributor/creating_custom_threshold_strategies.md` (added to nav).

## Example payloads

### `POST /v1/analytics/thresholds`

Request (`locations` and `params` are optional; `params.k` defaults to `2.0`):

```json
{
  "datasetId": 1,
  "periodIds": ["2024-01", "2024-02"],
  "strategy": "seasonal",
  "locations": ["loc_1", "loc_2"],
  "params": { "k": 2.0 }
}
```

Response `200` — one entry per (period, location). `value` is `null` when it cannot be computed (e.g. only a single historical data point for that location/month, so the standard deviation is undefined):

```json
[
  { "period": "2024-01", "location": "loc_1", "value": 134.21 },
  { "period": "2024-01", "location": "loc_2", "value": 88.5 },
  { "period": "2024-02", "location": "loc_1", "value": 140.0 },
  { "period": "2024-02", "location": "loc_2", "value": null }
]
```

Minimal request (all locations, default params):

```json
{ "datasetId": 1, "periodIds": ["2024-01"], "strategy": "seasonal" }
```

Error `404` — unknown strategy:

```json
{ "detail": "Unknown threshold strategy: foo. Available: seasonal" }
```

### `GET /v1/analytics/thresholds/strategies`

Response `200`:

```json
[
  {
    "id": "seasonal",
    "displayName": "Seasonal mean + k*std",
    "description": "Outbreak threshold as mean + k standard deviations of historical same-month values."
  }
]
```

## Design note: period selection

`periodIds` are the *target* periods to produce thresholds for; the observations read is the *historical training data* the strategy computes from. The read is intentionally not filtered by `periodIds` — the seasonal strategy needs the full same-calendar-month history (across years) to compute mean + k*std, and target periods are often future periods not yet in the dataset. The only read-time filters are `feature_names=["disease_cases"]` and the optional `locations`.

## Edge case: insufficient data

A `(location, month)` with only a single historical value has an undefined sample standard deviation, so its threshold is `NaN` and the endpoint returns `value: null` for it. Locked in by a test so it can't silently regress.

## Future optimization (not in this PR)

A month-of-year filter on observation reads (fetch only the months a request needs) was considered and **declined**: `Observation` has no index on `period`/`(dataset_id, period)` so it would only trim Python-side materialization from the same full scan; period strings are non-uniform (`202401`, `2024-01`, `2024W01`, `20240101`) making a SQL month filter brittle; and month-of-year is strategy-specific so it would leak into the shared `DataSetManager`. If the endpoint is ever slow on large datasets, the proper lever is a composite index on `(dataset_id, period)` plus SQL-side aggregation (today all aggregation is done in pandas after loading rows) — which benefits every observation read.

## Tests

- Registration, endpoint happy path, locations filter, unknown-strategy and unknown-dataset 404s, multi-period multi-location shape, discovery endpoint, parity with `compute_seasonal_thresholds`, and single-datapoint -> null. Reuses existing fixtures.

## Acceptance criteria

- [x] New strategies register via decorator; no edit to the endpoint code required.
- [x] Endpoint returns one threshold per (period_id, location) for a dataset and strategy.
- [x] At least one built-in strategy registered (seasonal mean + k*std, behavior-equivalent to current `compute_seasonal_thresholds`).
- [x] Discovery endpoint lists registered strategies.
- [x] Tests cover registration, happy path, unknown-strategy error, output shape, and parity.

## Out of scope (per ticket)

Persisting thresholds, a second strategy, and strategy-param validation models.

[CLIM-637]: https://dhis2.atlassian.net/browse/CLIM-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ