### PR TITLE
docs: document creating Jira issues with components via acli

### DIFF
--- a/.claude/commands/jira.md
+++ b/.claude/commands/jira.md
@@ -59,6 +59,37 @@ acli jira workitem create --project PROJECT_KEY --type Task --summary "Summary t
 
 Available types: Task, Story, Bug, Epic, etc.
 
+#### Create with a component (and/or parent)
+
+`acli` has no `--component` flag. To set a component or parent, create the work
+item from a JSON file with `--from-json`. Components and parent must live under
+`additionalAttributes`, not at the top level. The description must be in
+Atlassian Document Format (ADF).
+
+```json
+{
+  "projectKey": "CLIM",
+  "type": "Task",
+  "summary": "Your summary",
+  "description": {"type":"doc","version":1,"content":[{"type":"paragraph","content":[{"type":"text","text":"Body"}]}]},
+  "additionalAttributes": {
+    "components": [{"name": "Chap Modeling Platform"}],
+    "parent": {"key": "CLIM-718"}
+  }
+}
+```
+
+```bash
+acli jira workitem create --from-json /tmp/issue.json
+```
+
+Gotchas:
+- Component name is case-sensitive. List existing components in use with:
+  ```bash
+  acli jira workitem search --jql 'project=CLIM AND component is not EMPTY' --limit 3
+  ```
+- `components` and `parent` belong under `additionalAttributes`, not at the top level.
+
 ### Transition Work Item
 
 ```bash


### PR DESCRIPTION
## Summary
- Document how to create Jira issues with a component (and/or parent) via `acli`, since there is no `--component` flag.
- Adds a `--from-json` example to the `jira` skill (`.claude/commands/jira.md`) showing `components`/`parent` under `additionalAttributes` and the ADF description format.
- Notes the case-sensitivity gotcha and the JQL command to list existing component names.

This supports CLAUDE.md rule #14 (always set at least one component on new Jira issues).