### PR TITLE
docs: add Troubleshooting section for logs and database access (CLIM-763, CLIM-764)

### DIFF
--- a/docs/modeling-app/fresh-installation.md
+++ b/docs/modeling-app/fresh-installation.md
@@ -98,16 +98,4 @@ This preserves your database data. To start again, simply run `docker compose up
 
 ### Viewing Logs
 
-To view logs from all services:
-
-```console
-docker compose logs -f
-```
-
-To view logs from a specific service:
-
-```console
-docker compose logs -f chap
-docker compose logs -f worker
-docker compose logs -f postgres
-```
+See [Troubleshooting: Viewing Logs](troubleshooting/logs.md) for how to inspect logs from the running services.

--- a/docs/modeling-app/troubleshooting/database-access.md
+++ b/docs/modeling-app/troubleshooting/database-access.md
@@ -1,0 +1,33 @@
+# Accessing the Database
+
+Chap Core stores its data in a PostgreSQL database that runs as the `postgres` service in Docker Compose. The database port is not published to the host, so you connect to it through the running `postgres` container rather than from your host machine.
+
+The database credentials come from your `.env` file: `POSTGRES_USER` (default `chap`), `POSTGRES_PASSWORD` (default `chap`), and `POSTGRES_DB` (default `chap_core`).
+
+## Open a psql shell
+
+To open an interactive `psql` session:
+
+```console
+docker compose exec postgres sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
+```
+
+Running it as `sh -c '...'` lets `psql` read the credentials from the container's own environment, so it works regardless of what you set in `.env`. From the prompt you can list the tables with `\dt`, run SQL queries, and type `\q` to exit.
+
+## Run a one-off command
+
+To run a single command without opening an interactive session, pass it with `-c`. For example, to list the tables:
+
+```console
+docker compose exec postgres sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "\dt"'
+```
+
+The same works for SQL queries, for example:
+
+```console
+docker compose exec postgres sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT COUNT(*) FROM dataset;"'
+```
+
+## Backing up and restoring
+
+For creating and restoring database backups with `pg_dump`, see [Backup Your Database](../upgrading-installation.md#1-backup-your-database-recommended) in the upgrade guide.

--- a/docs/modeling-app/troubleshooting/logs.md
+++ b/docs/modeling-app/troubleshooting/logs.md
@@ -1,0 +1,44 @@
+# Viewing Logs
+
+When something goes wrong with a Docker Compose deployment of Chap Core, the logs are usually the first place to look. There are two complementary places to check.
+
+## Service logs (`docker compose logs`)
+
+The REST API and worker log to their container output (stdout/stderr), so use `docker compose logs` to read them.
+
+To stream logs from all services:
+
+```console
+docker compose logs -f
+```
+
+To view logs from a specific service:
+
+```console
+docker compose logs -f chap
+docker compose logs -f worker
+docker compose logs -f postgres
+```
+
+The most relevant services are:
+
+- `chap`: the Chap Core REST API
+- `worker`: the Celery worker that runs the models. Check this if a model run fails
+- `postgres`: the database
+
+## Per-task log files
+
+In addition to the service output, the worker writes a pair of log files for each task (typically a model run) into the directory given by the `CHAP_LOGS_DIR` environment variable. In the default Docker Compose setup this is `/data/logs`, backed by a named `logs` volume shared between the `chap` and `worker` services:
+
+- `task_{task_id}.debug.txt`: full debug logs for the task (server-side only). Check this when a model run fails
+- `task_{task_id}.status.txt`: user-facing progress messages for the task (also exposed via the API)
+
+`{task_id}` is the internal Celery task id. Because these files live inside the container's volume rather than in the repository on the host, read them through the running container, for example:
+
+```console
+# List the task log files
+docker compose exec worker ls /data/logs
+
+# View the debug log for a specific task
+docker compose exec worker cat /data/logs/task_<task_id>.debug.txt
+```

--- a/docs/modeling-app/upgrading-installation.md
+++ b/docs/modeling-app/upgrading-installation.md
@@ -127,16 +127,4 @@ This preserves your database data. To start again, simply run `docker compose up
 
 ### Viewing Logs
 
-To view logs from all services:
-
-```console
-docker compose logs -f
-```
-
-To view logs from a specific service:
-
-```console
-docker compose logs -f chap
-docker compose logs -f worker
-docker compose logs -f postgres
-```
+See [Troubleshooting: Viewing Logs](troubleshooting/logs.md) for how to inspect logs from the running services.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
       - Managing models: modeling-app/managing-model-templates.md
       - Troubleshooting:
           - Viewing Logs: modeling-app/troubleshooting/logs.md
+          - Accessing the Database: modeling-app/troubleshooting/database-access.md
   - For Newcomers:
       - For newcomers: external_models/newcomer.md
       - Learning Modelling: external_models/learn_modelling.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,8 @@ nav:
           - Updating to a New Version: modeling-app/upgrading-installation.md
           - Enabling Optional Model Services: modeling-app/enabling-optional-model-services.md
       - Managing models: modeling-app/managing-model-templates.md
+      - Troubleshooting:
+          - Viewing Logs: modeling-app/troubleshooting/logs.md
   - For Newcomers:
       - For newcomers: external_models/newcomer.md
       - Learning Modelling: external_models/learn_modelling.md


### PR DESCRIPTION
Jira: CLIM-763, CLIM-764

## Summary

Adds a **Troubleshooting** section under DHIS2 Implementers with a **Viewing Logs** page, and links to it from the install guides instead of duplicating the log instructions.

## Changes

- New nav section `DHIS2 Implementers > Troubleshooting`, with `Viewing Logs` as its first subpage (`docs/modeling-app/troubleshooting/logs.md`). Structured as a section so further troubleshooting topics can be added later.
- The Viewing Logs page documents both:
  - **Service logs** via `docker compose logs` (the `chap` API and `worker` log to stdout/stderr).
  - **Per-task log files** written by the worker to `CHAP_LOGS_DIR` (`/data/logs` in compose): `task_{task_id}.debug.txt` and `task_{task_id}.status.txt`, with how to read them via `docker compose exec`.
- `fresh-installation.md` and `upgrading-installation.md` now link to the new page rather than repeating the log commands.

## Notes

The previously documented `logs/rest_api.log`, `logs/worker.log`, and `logs/tas_{task_id}.log` (from the unpublished `surplus_after_refactoring.md`) are outdated. The API/worker no longer write those files (FileHandler setup in `chap_core/log_config.py` is disabled), and per-task files were renamed and moved into the `CHAP_LOGS_DIR` volume. The new page reflects the current behaviour.

Verified with `mkdocs build --strict` (nav and cross-page links resolve cleanly).