### PR TITLE
fix: align Alembic default DB credentials with .env.example

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -28,7 +28,7 @@ from chap_core.database.tables import Backtest, BacktestForecast, BacktestMetric
 target_metadata = SQLModel.metadata
 
 # Get database URL from environment variable, with default for local development
-database_url = os.getenv("CHAP_DATABASE_URL", "postgresql://root:thisisnotgoingtobeexposed@localhost:5432/chap_core")
+database_url = os.getenv("CHAP_DATABASE_URL", "postgresql://chap:chap@localhost:5432/chap_core")
 config.set_main_option("sqlalchemy.url", database_url)
 
 

--- a/docs/contributor/database_migrations.md
+++ b/docs/contributor/database_migrations.md
@@ -12,7 +12,7 @@ docker compose -f compose.yml -f compose.dev.yml up -d postgres
 
 The `compose.dev.yml` file exposes the postgres port on localhost for development, allowing you to run Alembic commands locally and connect with database tools like pgAdmin or DBeaver.
 
-Alembic will use the default database URL (`postgresql://root:thisisnotgoingtobeexposed@localhost:5432/chap_core`) when running locally. If you need to connect to a different database, set the `CHAP_DATABASE_URL` environment variable:
+Alembic will use the default database URL (`postgresql://chap:chap@localhost:5432/chap_core`) when running locally. If you need to connect to a different database, set the `CHAP_DATABASE_URL` environment variable:
 
 ```bash
 export CHAP_DATABASE_URL="postgresql://user:password@host:port/database"


### PR DESCRIPTION
## Summary

Aligns the Alembic fallback database URL with the current project defaults.

`alembic/env.py` fell back to the pre-1.1.5 credentials `postgresql://root:thisisnotgoingtobeexposed@localhost:5432/chap_core` when `CHAP_DATABASE_URL` is unset. Since v1.1.5 the project defaults (`.env.example`, compose) use `chap` / `chap` / `chap_core`, so the fallback no longer matched. The contributor docs faithfully documented this stale default, so both were updated.

## Changes

- `alembic/env.py`: fallback URL -> `postgresql://chap:chap@localhost:5432/chap_core`
- `docs/contributor/database_migrations.md`: same default in the prose

## Notes

The fallback is only used for local development when `CHAP_DATABASE_URL` is not set; in compose the URL is always provided from the environment, so this does not affect deployed instances. The intentional references to the old credentials in the upgrade guide (explaining the pre-1.1.5 migration) are left as-is.
