### PR TITLE
fix: return valid charts in custom backtest plot doc examples (CLIM-752)

### DIFF
--- a/docs/contributor/creating_custom_backtest_plots.md
+++ b/docs/contributor/creating_custom_backtest_plots.md
@@ -106,6 +106,7 @@ Use the `@backtest_plot` decorator to register your plot, then inherit from `Bac
 ```python
 from typing import Optional
 import pandas as pd
+import altair as alt
 from chap_core.assessment.backtest_plots import backtest_plot, BacktestPlotBase, ChartType
 
 @backtest_plot(
@@ -120,8 +121,8 @@ class MyCustomPlot(BacktestPlotBase):
         forecasts: pd.DataFrame,
         historical_observations: Optional[pd.DataFrame] = None,
     ) -> ChartType:
-        # Your visualization logic here
-        chart = None
+        # Your visualization logic here; return any Altair chart.
+        chart = alt.Chart(observations).mark_point()
         return chart
 ```
 
@@ -308,6 +309,7 @@ If your plot needs historical context (observations from before the test period)
 ```python
 from typing import Optional
 import pandas as pd
+import altair as alt
 from chap_core.assessment.backtest_plots import backtest_plot, BacktestPlotBase, ChartType
 
 @backtest_plot(
@@ -327,7 +329,7 @@ class TrendPlot(BacktestPlotBase):
         if historical_observations is not None:
             # Use historical data for context
             pass
-        return None
+        return alt.Chart(observations).mark_point()
 ```
 
 ### Returning Different Chart Types


### PR DESCRIPTION
Jira: CLIM-752

## Summary

Fixes an intermittent CI failure where `test_all_backtest_plots` (and `test_all_backtest_plots_via_api`) fail with `AttributeError: 'NoneType' object has no attribute 'to_dict'`.

## Root cause

`tests/test_documentation.py` executes the Python blocks in `docs/contributor/creating_custom_backtest_plots.md`. Two skeleton examples there (`my_custom_plot`, `trend_plot`) returned `None` from `plot()`. The `@backtest_plot` decorator registers them into the process-global `_backtest_plots_registry`, so they leak out of the doc test. Tests that iterate every registered plot then call `create_plot_from_backtest` on them, and `None.to_dict()` raises.

The failure is order/distribution dependent (surfaces when the doc test and the plot-iterating tests land in the same pytest-xdist worker), which is why it appears intermittently and on unrelated PRs.

## Fix

Return a minimal valid Altair chart (`alt.Chart(observations).mark_point()`) from both skeleton examples instead of `None`, and add the missing `import altair as alt` to those two blocks. A skeleton that returns `None` was misleading documentation regardless. (`mark_point` is used rather than an empty chart or `mark_line`, both of which fail Vega compilation without a mark/encoding.)

## Verification

Reproduced locally by running the doc test followed by the integration test in a single process:

```
uv run pytest "tests/test_documentation.py::test_docs_python[docs/contributor/creating_custom_backtest_plots.md]" \
  tests/integration/rest_api/test_python_endpoints.py::test_all_backtest_plots -p no:xdist
```

Passes with the fix (2 passed).