### PR TITLE
feat: add n_retrain parameter to BacktestParams

### DIFF
--- a/chap_core/api_types.py
+++ b/chap_core/api_types.py
@@ -16,7 +16,7 @@ from geojson_pydantic import (
     Point,
     Polygon,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from chap_core.database.base_tables import DBModel
 
@@ -119,6 +119,17 @@ class BacktestParams(DBModel):
     n_periods: int = Field(default=3, gt=0, description="Number of periods to forecast at each split.")
     n_splits: int = Field(default=7, gt=0, description="Total number of rolling train/test splits.")
     stride: int = Field(default=1, gt=0, description="Number of periods to advance between successive splits.")
+    n_retrain: int = Field(
+        default=1,
+        gt=0,
+        description="Number of times the model is retrained, evenly spaced across the splits. 1 means train once.",
+    )
+
+    @model_validator(mode="after")
+    def _check_n_retrain(self) -> "BacktestParams":
+        if self.n_retrain > self.n_splits:
+            raise ValueError("n_retrain cannot exceed n_splits.")
+        return self
 
 
 class RunConfig(BaseModel):

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -400,6 +400,7 @@ class Evaluation(EvaluationBase):
             prediction_length=backtest_params.n_periods,
             n_test_sets=backtest_params.n_splits,
             stride=backtest_params.stride,
+            n_retrain=backtest_params.n_retrain,
         )
 
         # Prepare metadata

--- a/chap_core/assessment/prediction_evaluator.py
+++ b/chap_core/assessment/prediction_evaluator.py
@@ -65,9 +65,12 @@ def backtest(
     data. The estimator is (re)trained at ``n_retrain`` evenly spaced split
     points and the most recent predictor generates forecasts for each
     successive test window. With ``n_retrain=1`` (the default) the model is
-    trained once on the initial training set; with ``n_retrain=2`` it is also
-    retrained halfway through the splits, using the expanding window of data
-    available at that point.
+    trained once on the initial training set, identical to the previous
+    single-train backtest; with ``n_retrain=2`` it is also retrained halfway
+    through the splits, using the expanding window of data available at that
+    point. The split-0 training uses the dedicated training set returned by
+    ``train_test_generator`` (which carries the ``_train_set`` metadata);
+    subsequent retrains use that split's expanding historic window.
 
     Parameters
     ----------
@@ -93,14 +96,16 @@ def backtest(
         For each test split, a dataset mapping locations to
         ``SamplesWithTruth`` (predicted samples merged with observed values).
     """
-    _, test_generator = train_test_generator(
+    train_set, test_generator = train_test_generator(
         data, prediction_length, n_test_sets, stride=stride, future_weather_provider=weather_provider
     )
     retrain_at = _retrain_split_indices(n_test_sets, n_retrain)
     predictor: Predictor | None = None
     for i, (historic_data, future_data, future_truth) in enumerate(test_generator):
         if i in retrain_at:
-            predictor = estimator.train(historic_data)
+            # Split 0 trains on the dedicated train_set (preserving the single-train
+            # behaviour exactly); later retrains use the expanding historic window.
+            predictor = estimator.train(train_set if i == 0 else historic_data)
         assert predictor is not None, "First split must trigger training"
         r = predictor.predict(historic_data, future_data)
         if r is None:

--- a/chap_core/assessment/prediction_evaluator.py
+++ b/chap_core/assessment/prediction_evaluator.py
@@ -46,14 +46,28 @@ class Estimator(Protocol):
     def train(self, data: DataSet) -> Predictor: ...
 
 
+def _retrain_split_indices(n_test_sets: int, n_retrain: int) -> set[int]:
+    """Return the split indices at which the model is retrained.
+
+    The ``n_retrain`` retrain points are evenly spaced across the
+    ``n_test_sets`` splits and always include the first split (index 0). For
+    example, ``n_test_sets=7, n_retrain=2`` retrains at splits ``{0, 3}``.
+    """
+    return {(j * n_test_sets) // n_retrain for j in range(n_retrain)}
+
+
 def backtest(
-    estimator: Estimator, data: DataSet, prediction_length, n_test_sets, stride=1, weather_provider=None
+    estimator: Estimator, data: DataSet, prediction_length, n_test_sets, stride=1, weather_provider=None, n_retrain=1
 ) -> Iterable[DataSet]:
-    """Train a model once and generate predictions for each test split.
+    """Train a model and generate predictions for each test split.
 
     Uses ``train_test_generator`` to create an expanding window split of the
-    data. The estimator is trained on the initial training set, then the
-    trained predictor generates forecasts for each successive test window.
+    data. The estimator is (re)trained at ``n_retrain`` evenly spaced split
+    points and the most recent predictor generates forecasts for each
+    successive test window. With ``n_retrain=1`` (the default) the model is
+    trained once on the initial training set; with ``n_retrain=2`` it is also
+    retrained halfway through the splits, using the expanding window of data
+    available at that point.
 
     Parameters
     ----------
@@ -69,6 +83,9 @@ def backtest(
         Periods to advance between successive splits.
     weather_provider
         Optional future weather data provider.
+    n_retrain
+        Number of times the model is retrained, evenly spaced across the
+        splits. 1 means train once at the beginning.
 
     Yields
     ------
@@ -76,11 +93,15 @@ def backtest(
         For each test split, a dataset mapping locations to
         ``SamplesWithTruth`` (predicted samples merged with observed values).
     """
-    train, test_generator = train_test_generator(
+    _, test_generator = train_test_generator(
         data, prediction_length, n_test_sets, stride=stride, future_weather_provider=weather_provider
     )
-    predictor = estimator.train(train)
-    for historic_data, future_data, future_truth in test_generator:
+    retrain_at = _retrain_split_indices(n_test_sets, n_retrain)
+    predictor: Predictor | None = None
+    for i, (historic_data, future_data, future_truth) in enumerate(test_generator):
+        if i in retrain_at:
+            predictor = estimator.train(historic_data)
+        assert predictor is not None, "First split must trigger training"
         r = predictor.predict(historic_data, future_data)
         if r is None:
             continue

--- a/chap_core/cli_endpoints/_args.py
+++ b/chap_core/cli_endpoints/_args.py
@@ -42,7 +42,8 @@ BacktestParamsArg = Annotated[
     Parameter(
         help="Backtest configuration. Use --backtest-params.n-periods for forecast horizon, "
         "--backtest-params.n-splits for number of train/test splits, "
-        "--backtest-params.stride for step size between splits"
+        "--backtest-params.stride for step size between splits, "
+        "--backtest-params.n-retrain for number of retrains across the splits"
     ),
 ]
 

--- a/tests/evaluation/test_prediction_evaluator.py
+++ b/tests/evaluation/test_prediction_evaluator.py
@@ -13,3 +13,33 @@ def test_backtest_passes_stride_to_train_test_generator():
         list(backtest(mock_estimator, mock_data, prediction_length=3, n_test_sets=4, stride=2))
 
         mock_ttg.assert_called_once_with(mock_data, 3, 4, stride=2, future_weather_provider=None)
+
+
+def _splits(n):
+    """Build ``n`` (historic, future, truth) split tuples with distinguishable historic data."""
+    return [(f"historic{i}", f"future{i}", MagicMock()) for i in range(n)]
+
+
+def test_backtest_trains_once_by_default():
+    mock_estimator = MagicMock()
+
+    with patch("chap_core.assessment.prediction_evaluator.train_test_generator") as mock_ttg:
+        mock_ttg.return_value = (MagicMock(), iter(_splits(4)))
+
+        list(backtest(mock_estimator, MagicMock(), prediction_length=3, n_test_sets=4, stride=1))
+
+    assert mock_estimator.train.call_count == 1
+    mock_estimator.train.assert_called_once_with("historic0")
+
+
+def test_backtest_retrains_at_evenly_spaced_splits():
+    mock_estimator = MagicMock()
+
+    with patch("chap_core.assessment.prediction_evaluator.train_test_generator") as mock_ttg:
+        mock_ttg.return_value = (MagicMock(), iter(_splits(4)))
+
+        list(backtest(mock_estimator, MagicMock(), prediction_length=3, n_test_sets=4, stride=1, n_retrain=2))
+
+    assert mock_estimator.train.call_count == 2
+    trained_on = [call.args[0] for call in mock_estimator.train.call_args_list]
+    assert trained_on == ["historic0", "historic2"]

--- a/tests/evaluation/test_prediction_evaluator.py
+++ b/tests/evaluation/test_prediction_evaluator.py
@@ -24,22 +24,24 @@ def test_backtest_trains_once_by_default():
     mock_estimator = MagicMock()
 
     with patch("chap_core.assessment.prediction_evaluator.train_test_generator") as mock_ttg:
-        mock_ttg.return_value = (MagicMock(), iter(_splits(4)))
+        mock_ttg.return_value = ("train_set", iter(_splits(4)))
 
         list(backtest(mock_estimator, MagicMock(), prediction_length=3, n_test_sets=4, stride=1))
 
     assert mock_estimator.train.call_count == 1
-    mock_estimator.train.assert_called_once_with("historic0")
+    # Split 0 trains on the dedicated train_set, preserving the single-train behaviour.
+    mock_estimator.train.assert_called_once_with("train_set")
 
 
 def test_backtest_retrains_at_evenly_spaced_splits():
     mock_estimator = MagicMock()
 
     with patch("chap_core.assessment.prediction_evaluator.train_test_generator") as mock_ttg:
-        mock_ttg.return_value = (MagicMock(), iter(_splits(4)))
+        mock_ttg.return_value = ("train_set", iter(_splits(4)))
 
         list(backtest(mock_estimator, MagicMock(), prediction_length=3, n_test_sets=4, stride=1, n_retrain=2))
 
     assert mock_estimator.train.call_count == 2
     trained_on = [call.args[0] for call in mock_estimator.train.call_args_list]
-    assert trained_on == ["historic0", "historic2"]
+    # Split 0 uses train_set; the halfway retrain (split 2) uses its expanding historic window.
+    assert trained_on == ["train_set", "historic2"]

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -1,0 +1,14 @@
+import pytest
+from pydantic import ValidationError
+
+from chap_core.api_types import BacktestParams
+
+
+def test_backtest_params_n_retrain_defaults_to_one():
+    params = BacktestParams(n_periods=3, n_splits=7, stride=1)
+    assert params.n_retrain == 1
+
+
+def test_backtest_params_rejects_n_retrain_above_n_splits():
+    with pytest.raises(ValidationError):
+        BacktestParams(n_periods=3, n_splits=4, stride=1, n_retrain=5)


### PR DESCRIPTION
## Summary

Adds an `n_retrain` parameter to `BacktestParams` (CLIM-766) that controls how many times the model is retrained during backtesting.

- `n_retrain=1` (default): model is trained once and predictions run across all `n_splits` windows. Identical to the previous backtest.
- `n_retrain=2`: model is trained at the start and retrained once halfway through the splits.
- `n_retrain=k`: retrains at `k` evenly spaced split points, using the expanding window of data available at each point.

## Changes

- `api_types.py`: new `n_retrain` field (default 1, `gt=0`) plus a validator enforcing `n_retrain <= n_splits`.
- `prediction_evaluator.py`: `backtest()` gains `n_retrain`; the single up-front train is replaced by retraining inside the loop at the computed split indices (`_retrain_split_indices`). Split 0 trains on the dedicated `train_set` from `train_test_generator` (which carries the `_train_set` metadata), so the `n_retrain=1` default is byte-identical to the old code; later retrains train on that split's expanding historic window.
- `evaluation.py`: `Evaluation.create` passes `n_retrain` through.
- `_args.py`: documents `--backtest-params.n-retrain` in CLI help.

## Tests

- `test_prediction_evaluator.py`: asserts `train` is called once on `train_set` by default, and on `[train_set, historic2]` for `n_retrain=2` over 4 splits.
- `test_api_types.py`: default is 1; rejects `n_retrain > n_splits`.

`make lint` passes; related suites (evaluation, dataset-splitting, CLI args, REST validation) pass.
