### PR TITLE
fix: refresh apt index before installing build deps in CI

### DIFF
--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -71,6 +71,7 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
       - name: Set up Python ${{ matrix.python-version }}
         run: |
+          sudo apt-get update
           sudo apt-get install -y libbz2-dev liblzma-dev
           uv python install ${{ matrix.python-version }}
       - name: Install the project


### PR DESCRIPTION
## Problem

The `ci-test-external-models` workflow was failing at the `apt-get install -y libbz2-dev liblzma-dev` step with a 404:

```
Err:4 ... liblzma-dev amd64 5.6.1+really5.4.5-1ubuntu0.2
  404  Not Found
E: Failed to fetch .../liblzma-dev_5.6.1%2breally5.4.5-1ubuntu0.2_amd64.deb  404  Not Found
```

This is a stale apt index issue, not a workflow logic bug. The runner's cached index listed a `liblzma-dev` version whose `.deb` had already been superseded on the mirror by a newer `xz-utils` point release, so the old filename 404s.

## Fix

Run `sudo apt-get update` immediately before the install to refresh the index against the current mirror.