### PR TITLE
fix: skip chapkit probe for github urls

### DIFF
--- a/chap_core/models/utils.py
+++ b/chap_core/models/utils.py
@@ -154,7 +154,15 @@ def get_model_template_from_directory_or_github_url(
         "use_existing" will use the existing directory specified by the model path if that exists. If that does not exist, "latest" will be used.
     """
 
-    detected = not is_chapkit_model and is_url(model_template_path) and _is_chapkit_url(model_template_path)
+    # GitHub URLs are git-clone targets, never live chapkit services, so skip the
+    # chapkit probe for them to avoid a spurious 404 against github.com/.../api/v1/info.
+    is_github_url = is_url(model_template_path) and model_template_path.startswith("https://github.com")
+    detected = (
+        not is_chapkit_model
+        and is_url(model_template_path)
+        and not is_github_url
+        and _is_chapkit_url(model_template_path)
+    )
     if is_chapkit_model or detected:
         if detected:
             logger.info("Auto-detected chapkit service at %s", model_template_path)

--- a/tests/external/test_external_chapkit_model.py
+++ b/tests/external/test_external_chapkit_model.py
@@ -74,6 +74,16 @@ class TestUrlModelNameFallback:
         with pytest.raises(ValueError, match="could not be reached as a chapkit service"):
             get_model_template_from_directory_or_github_url("https://nonexistent.example.com:9999")
 
+    def test_github_url_skips_chapkit_probe(self):
+        """GitHub URLs are git-clone targets and must not trigger the chapkit /api/v1/info probe."""
+        with (
+            patch("chap_core.models.utils._is_chapkit_url") as mock_probe,
+            patch("chap_core.models.utils._get_model_code_base", side_effect=RuntimeError("clone reached")),
+        ):
+            with pytest.raises(RuntimeError, match="clone reached"):
+                get_model_template_from_directory_or_github_url("https://github.com/sandvelab/monthly_ar_model")
+        mock_probe.assert_not_called()
+
 
 class TestIsUrl:
     def test_http_url(self):


### PR DESCRIPTION
## Problem

When loading a model from a GitHub URL (e.g. `chap eval --model-name https://github.com/sandvelab/monthly_ar_model ...`), the chapkit auto-detection ran its `/api/v1/info` probe against the GitHub URL itself, producing a confusing log line:

```
GET https://github.com/sandvelab/monthly_ar_model/api/v1/info "HTTP/1.1 404 Not Found"
```

The probe correctly failed and fell back to cloning, but the wasted HTTP request and scary 404 made the detection look flaky.

## Fix

GitHub URLs are git-clone targets and are never live chapkit services, so skip the chapkit probe entirely for `https://github.com/...` URLs in `get_model_template_from_directory_or_github_url`.

## Test

Added `test_github_url_skips_chapkit_probe`, asserting the chapkit probe is never invoked for a GitHub URL and that loading proceeds straight to the clone path.