### PR TITLE
feat: make 'chap test' a real self-diagnostic

### DIFF
--- a/chap_core/cli_endpoints/utils.py
+++ b/chap_core/cli_endpoints/utils.py
@@ -95,16 +95,64 @@ def write_open_api_spec(out_path: str):
         json.dump(schema, f, indent=4)
 
 
-def test(**base_kwargs):
-    """
-    Simple test-command to check that the chap command works
-    """
-    from chap_core.log_config import initialize_logging
+def _health_checks() -> list[tuple[str, bool, str]]:
+    """Probe that chap-core's core runtime imports resolve.
 
-    initialize_logging()
+    Returns one ``(label, ok, detail)`` row per check group; ``detail`` names
+    the offending imports when ``ok`` is False. Kept side-effect free (no
+    network, Docker, or DB access) so it is safe to run anywhere.
+    """
+    import importlib
 
-    logger.debug("Debug message")
-    logger.info("Info message")
+    import chap_core
+
+    checks: list[tuple[str, bool, str]] = []
+
+    def _probe(label, loader, items):
+        failed = []
+        for item in items:
+            try:
+                loader(item)
+            except Exception as exc:
+                failed.append(f"{item} ({type(exc).__name__})")
+        ok = not failed
+        checks.append((label, ok, "OK" if ok else "missing: " + ", ".join(failed)))
+
+    _probe("numpy / pandas / xarray", importlib.import_module, ["numpy", "pandas", "xarray"])
+    _probe(
+        "public API (data, fetch, ModelTemplateInterface)",
+        lambda name: getattr(chap_core, name),
+        ["data", "fetch", "ModelTemplateInterface"],
+    )
+
+    return checks
+
+
+def test():
+    """Self-diagnostic: report version/environment and verify core imports resolve.
+
+    Exits non-zero if any check fails, so it is usable as an install smoke test.
+    """
+    import platform
+    import sys
+
+    import chap_core
+
+    print(f"chap-core      {chap_core.__version__}")
+    print(f"Python         {platform.python_version()}  ({sys.executable})")
+    print(f"platform       {sys.platform}")
+    print()
+    print("imports:")
+    checks = _health_checks()
+    for label, _ok, detail in checks:
+        print(f"  {label} ... {detail}")
+    print()
+
+    if all(ok for _, ok, _ in checks):
+        print("All checks passed.")
+    else:
+        print("Some checks FAILED.")
+        raise SystemExit(1)
 
 
 def plot_dataset(data_filename: Path, plot_name: str = "standardized-feature-plot"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 from chap_core.util import docker_available
 from chap_core.cli_endpoints.evaluate import eval_cmd
 from chap_core.cli_endpoints.utils import sanity_check_model
+from chap_core.cli_endpoints.utils import test as run_chap_test
 
 
 @pytest.mark.skipif(not docker_available(), reason="Docker not available")
@@ -328,3 +329,36 @@ def test_eval_cmd_with_data_source_mapping(tmp_path):
 
     # Verify output file was created
     assert output_file.exists()
+
+
+def test_chap_test_reports_environment_and_passes(capsys):
+    """`chap test` prints version/environment, passes its import checks, and exits 0."""
+    run_chap_test()
+
+    out = capsys.readouterr().out
+    assert "chap-core" in out
+    assert "numpy / pandas / xarray ... OK" in out
+    assert "public API (data, fetch, ModelTemplateInterface) ... OK" in out
+    assert "All checks passed." in out
+
+
+def test_chap_test_exits_nonzero_when_a_core_import_fails(monkeypatch, capsys):
+    """A failing core import is surfaced and makes `chap test` exit non-zero."""
+    import importlib
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name, *args, **kwargs):
+        if name == "xarray":
+            raise ImportError("simulated missing xarray")
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_chap_test()
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "missing: xarray" in out
+    assert "Some checks FAILED." in out


### PR DESCRIPTION
## Summary

`chap test` was a placeholder that only logged a debug + info line (the debug line is invisible at the default level) and silently swallowed arbitrary `--<keyword>` args via `**base_kwargs`. It proved strictly less than `chap --version`. This turns it into a useful install smoke test.

## What it does now

```console
$ chap test
chap-core      2.0.0.dev1
Python         3.13.12  (/path/.venv/bin/python3)
platform       darwin

imports:
  numpy / pandas / xarray ... OK
  public API (data, fetch, ModelTemplateInterface) ... OK

All checks passed.
```

- Prints chap-core version, Python version/executable, and platform.
- Verifies the core runtime imports resolve: the scientific stack (`numpy`/`pandas`/`xarray`) and the lazy public API (`data`, `fetch`, `ModelTemplateInterface`).
- Exits non-zero (and prints which imports are missing) if any check fails, so it is usable in CI / post-install verification.
- Side-effect free: no network, Docker, or DB access. Also drops the `**base_kwargs` catch-all so the command no longer accepts arbitrary flags.

The check logic is a small `_health_checks()` helper returning `(label, ok, detail)` rows; the command formats them and sets the exit code.

## Tests

- `test_chap_test_reports_environment_and_passes` — asserts the version/import lines print and the command exits 0.
- `test_chap_test_exits_nonzero_when_a_core_import_fails` — monkeypatches a core import to fail and asserts the missing import is surfaced and the command exits 1.

## Verification

- `make lint` clean (0/0).
- New tests pass; `chap test` exits 0 locally.