### PR TITLE
docs: document the standard run command that brings up model services

### DIFF
--- a/docs/external_models/chapkit.md
+++ b/docs/external_models/chapkit.md
@@ -1,16 +1,14 @@
 # Running models with chapkit
 
-Chapkit is a new experimental way of integrating and running models through chap.
+Chapkit is one of two ways chap runs models. Chap is gradually migrating models to chapkit; both chapkit and the older approach are supported.
 
-In contrast to the current chap implementation, where models are run directly through docker and pyenv wrappers inside chap, chapkit models are separate REST API services that chap interacts with through HTTP requests.
+In contrast to the older approach, where models are run directly through docker and pyenv wrappers inside chap, chapkit models are separate REST API services that chap interacts with through HTTP requests.
 
 This has several advantages:
 
 - There are no docker-in-docker problems where chap (which is inside docker) has to run docker commands to start model containers.
 - We have a strict and clear API for how chap interacts with models, which makes it easier to develop and maintain.
 - Models can easily be distributed through docker images or other means, as long as they implement the chapkit API. It is up to the model to define how it is deployed and run, but chapkit makes it easy to spin up a rest api and make a docker image for a model.
-
-This is still experimental and under development, but we have a working prototype with a few models already.
 
 This document describes very briefly how to make a model compatible with chapkit, and how to use chapkit models in chap.
 
@@ -139,21 +137,11 @@ chap eval --model-name http://localhost:5001 --dataset-csv https://raw.githubuse
 
 ## How to use chapkit models in chap with the modeling app
 
-NOTE: This is experimental, and the way this is done might change in the future.
+The bundled chapkit model services ship as compose overlays and register
+themselves with chap on startup. Start chap with the overlay and they appear in
+the modeling app automatically — see
+[First-time Setup](../modeling-app/fresh-installation.md) for the run command.
 
-1) Add your model to a file compose-models.yml, pick a port for your model that is not used by other models
-2) Add your model to a config file inside config/configured_models (e.g. config/configured_models/local_config.yaml), with the url pointing to your model, using the container name you specified in compose-models, e.g. http://chtorch:5001 (localhost will not work for communication between the chap worker container and your model container). Here is an example:
-  ```yaml
-- url: http://chtorch:8000
-  uses_chapkit: true
-  versions:
-    v1: "/v1"
-  configurations:
-    debug:
-      user_option_values:
-          max_epochs: 2
-```
-3) Start both chap and your model by running `docker compose -f compose.yml -f compose-models.yml up --build --force-recreate`
-
-Now, the model should show up in the modeling app.
+To add a model service that is not bundled, see
+[Enabling Optional Model Services](../modeling-app/enabling-optional-model-services.md).
 

--- a/docs/modeling-app/enabling-optional-model-services.md
+++ b/docs/modeling-app/enabling-optional-model-services.md
@@ -2,6 +2,9 @@
 
 Some models require an external service to be running alongside Chap. These services are not started by default but can be enabled using a Docker Compose overlay file.
 
+!!! note
+    This page covers models that are **not** part of the bundled overlay. The bundled model services started by `compose.chapkit.yml` (see [First-time Setup](fresh-installation.md)) register themselves automatically and need no config edits or rebuild. Use the steps below only for additional services like `ewars_plus` or `chtorch`.
+
 ## Available Optional Services
 
 | Service | Image | Port | Description |

--- a/docs/modeling-app/fresh-installation.md
+++ b/docs/modeling-app/fresh-installation.md
@@ -50,10 +50,10 @@ This creates a `.env` file with default database credentials used by Docker Comp
 ## 4. Start Chap Core
 
 ```console
-docker compose up
+docker compose -f compose.yml -f compose.chapkit.yml up -d
 ```
 
-This single command will:
+This command will:
 
 - Pull all required Docker images
 - Start the PostgreSQL database
@@ -61,8 +61,12 @@ This single command will:
 - Start the Chap Core API server
 - Start the Celery worker for background jobs
 - **Automatically create and initialize your database**
+- Start the bundled model services, which register themselves with Chap on startup and then appear in the modeling app — no extra configuration or rebuild needed
 
 The Chap Core REST API will be available at `http://localhost:8000` once all services are running.
+
+!!! note "About the model services"
+    `compose.chapkit.yml` is an umbrella overlay that starts the bundled model services alongside Chap. Plain `docker compose up` (just `compose.yml`) also works and gives you Chap Core with its built-in models, but without those additional model services. `compose.yml` and `compose.ghcr.yml` are alternatives — do not stack them.
 
 ## 5. Verify the Installation
 
@@ -76,7 +80,13 @@ You can verify that Chap Core is running correctly by:
 curl http://localhost:8000/health
 ```
 
-3. **View service logs**:
+3. **Check the available models**: confirm the models (including the bundled model services) are registered:
+
+```console
+curl http://localhost:8000/v1/crud/configured-models
+```
+
+4. **View service logs**:
 
 ```console
 docker compose logs -f
@@ -88,13 +98,13 @@ docker compose logs -f
 
 ### Stopping Chap Core
 
-To stop all services:
+To stop all services (pass the same `-f` flags used to start them):
 
 ```console
-docker compose down
+docker compose -f compose.yml -f compose.chapkit.yml down
 ```
 
-This preserves your database data. To start again, simply run `docker compose up`.
+This preserves your database data. To start again, run the same `docker compose -f compose.yml -f compose.chapkit.yml up -d` command from step 4.
 
 ### Viewing Logs
 


### PR DESCRIPTION
## Summary

A DHIS2 implementer following the install docs ran `docker compose up`, which starts Chap Core with its built-in models but **not** the bundled model-service containers — those live only in `compose.chapkit.yml` / `compose.ewars.yml` and self-register with Chap on startup (`compose.yml` itself defines only `chap`/`worker`/`redis`/`postgres`). The overlay command that brings the model services up existed only in the README, not in the implementer-facing install guide. Some docs also still pointed at the stale `compose-models.yml` and called chapkit "experimental".

Chap currently runs **both** mechanisms (legacy MLproject + chapkit) and is gradually migrating to chapkit; both are supported. These edits make the run command correct and current without turning into a chapkit deep-dive.

## Changes

- **`docs/modeling-app/fresh-installation.md`**: standard run command is now `docker compose -f compose.yml -f compose.chapkit.yml up -d`, with a note that plain `docker compose up` still works (built-in models, no extra services) and that `compose.yml`/`compose.ghcr.yml` are alternatives. Added a verify step (`curl /v1/crud/configured-models`) and matched the stop/restart commands to the overlay.
- **`docs/external_models/chapkit.md`**: removed the obsolete `compose-models.yml` + hand-written `config/configured_models` instructions (now points to the install guide), and dropped the "experimental / might change" framing.
- **`docs/modeling-app/enabling-optional-model-services.md`**: added a note distinguishing this path (non-bundled services like `chtorch`/`ewars_plus`, needs config + rebuild) from the bundled self-registering overlay.

## Verification

- `make docs` (strict) passes.
- `make test-docs` passes (118).
- `grep -rn "compose-models.yml" docs/ README.md` is now empty.
- `docker compose -f compose.yml -f compose.chapkit.yml config --services` resolves cleanly and lists `postgres, redis, worker, chap, ewars` — confirming the documented command is valid and includes the model service. (Did not do a full stack bring-up; self-registration is already covered by the repo's chapkit e2e / self-registration tests.)