### PR TITLE
fix: aggregate-eval preserves NaN for all-NaN cells (don't fabricate 0 forecasts)

### DIFF
--- a/chap_core/cli_endpoints/aggregate_eval.py
+++ b/chap_core/cli_endpoints/aggregate_eval.py
@@ -69,7 +69,14 @@ def aggregate_eval_cmd(
 
     sliced = ds.sel(location=kept_locations)
     sliced = sliced.assign_coords(parent=("location", kept_parents))
-    aggregated = sliced.groupby("parent").sum()
+    # ``min_count=1`` so a (time, horizon) cell whose children are *all* NaN aggregates to NaN
+    # rather than 0. The default ``skipna=True`` sum returns 0 for an all-NaN group, which
+    # fabricates spurious 0 forecasts at the ragged edges of a rolling-origin backtest (the
+    # boundary target months only have some horizons populated). Those fake zeros then read as
+    # real 0-forecasts in plots and corrupt downstream metrics. With min_count=1 a cell still
+    # sums whichever children are present (preserving partial-coverage behaviour) but collapses
+    # to NaN only when none are.
+    aggregated = sliced.groupby("parent").sum(min_count=1)
     aggregated = aggregated.rename({"parent": "location"})
 
     aggregated.attrs.update(ds.attrs)

--- a/tests/test_aggregate_eval.py
+++ b/tests/test_aggregate_eval.py
@@ -129,3 +129,38 @@ def test_aggregate_eval_errors_when_no_locations_match(tmp_path):
 
     with pytest.raises(ValueError, match="nothing to aggregate"):
         aggregate_eval_cmd(nc_path, geojson_path, out_path)
+
+
+def test_aggregate_eval_preserves_nan_for_all_nan_cells(tmp_path):
+    """A (time, horizon) cell where every child is NaN must aggregate to NaN, not 0.
+
+    Rolling-origin backtests leave the boundary (target month, horizon) cells unpopulated
+    (NaN). A plain skipna sum would turn an all-NaN parent cell into 0, fabricating a spurious
+    0 forecast; aggregation must keep it NaN. A cell with *some* children present should still
+    sum the present ones.
+    """
+    _, original = _build_eval_dataset(tmp_path)
+    # Make one (time, horizon) cell all-NaN for both children of parent P (a, b),
+    # and another cell NaN for only one child (a) to check partial coverage still sums.
+    ds = original.copy(deep=True)
+    ds["forecast"].loc[dict(location=["a", "b"], time_period="2024-01", horizon_distance=1)] = np.nan
+    ds["forecast"].loc[dict(location="a", time_period="2024-02", horizon_distance=1)] = np.nan
+    nc_path = tmp_path / "eval_nan.nc"
+    ds.to_netcdf(nc_path)
+
+    geojson_path = tmp_path / "areas.geojson"
+    _write_geojson(geojson_path, [("a", "P"), ("b", "P"), ("c", "Q")])
+    out_path = tmp_path / "aggregated.nc"
+    aggregate_eval_cmd(nc_path, geojson_path, out_path)
+
+    result = xr.open_dataset(out_path)
+    try:
+        # all-NaN cell -> NaN (the bug would make this 0)
+        all_nan_cell = result["forecast"].sel(location="P", time_period="2024-01", horizon_distance=1).values
+        assert np.isnan(all_nan_cell).all()
+        # partial cell -> sum of the present child only (b), NaN child (a) skipped
+        partial = result["forecast"].sel(location="P", time_period="2024-02", horizon_distance=1).values
+        expected_b = ds["forecast"].sel(location="b", time_period="2024-02", horizon_distance=1).values
+        np.testing.assert_array_equal(partial, expected_b)
+    finally:
+        result.close()


### PR DESCRIPTION
## Problem
`chap aggregate-eval` turns genuinely-missing forecast cells into **0 forecasts**.

The aggregation sums children with xarray's default `skipna=True`:
```python
aggregated = sliced.groupby("parent").sum()
```
For a `(time_period, horizon_distance)` cell where **all** children are NaN, `skipna` sum returns **0**, not NaN.

Rolling-origin backtests legitimately leave the boundary `(target month, horizon)` cells unpopulated (NaN). For example with `n_periods=3` and data ending `2026-01`, the latest valid split origin is `2025-10`, so `2025-12` only has `h=2/h=3` and `2026-01` only has `h=3` — the other cells are NaN. After aggregation those become `0`.

## Impact
- **Plots:** `plot-backtest` renders the fabricated zeros as real 0-forecasts at the first/last target periods (a visible dip to zero).
- **Metrics:** the all-NaN cells are correctly skipped by `export-metrics` at the un-aggregated level, but after aggregation they are `0`, so a 0-forecast gets scored against the real observed value → large spurious errors in **district/parent-level** metrics.

## Fix
Use `sum(min_count=1)` so a cell with no present children collapses to **NaN**, while a cell with *some* children present still sums whichever are present (preserving the documented partial-coverage behaviour):
```python
aggregated = sliced.groupby("parent").sum(min_count=1)
```

## Test
Adds `test_aggregate_eval_preserves_nan_for_all_nan_cells` covering both an all-NaN cell (→ NaN) and a partial cell (→ sum of present children). Full `tests/test_aggregate_eval.py` passes.
