### PR TITLE
chore: bump version to 2.1.0.dev1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chap_core"
-version = "2.0.0"
+version = "2.1.0.dev1"
 description = "Climate Health Analysis Platform (CHAP)"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"


### PR DESCRIPTION
Bump version to 2.1.0.dev1 now that stable 2.0.0 has been released, opening the 2.1 development cycle.