### PR TITLE
chore(deps): bump uv images to 0.11 and setup-uv to v8.2.0

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/ci-lint-code-style.yml
+++ b/.github/workflows/ci-lint-code-style.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python
         run: uv python install 3.13
       - name: Install the project

--- a/.github/workflows/ci-test-docs-slow.yml
+++ b/.github/workflows/ci-test-docs-slow.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python
         run: uv python install 3.13
       - name: Install the project

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -68,7 +68,7 @@ jobs:
       #     large-packages: false
       #     swap-storage: true
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python ${{ matrix.python-version }}
         run: |
           sudo apt-get update

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           echo "Service Account Private Key is set"
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python 3.13
         run: uv python install 3.13
       - name: Install the project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.10-python3.13-trixie-slim
+FROM ghcr.io/astral-sh/uv:0.11-python3.13-trixie-slim
 
 # Compile Python bytecode for faster startup (.venv only)
 ENV UV_COMPILE_BYTECODE=1

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 #THIS DOCKERFILE RUNS THE WEB API
 
 # Use the official Python base image
-FROM ghcr.io/astral-sh/uv:0.10-python3.13-trixie-slim
+FROM ghcr.io/astral-sh/uv:0.11-python3.13-trixie-slim
 
 # Enable bytecode compilation
 ENV UV_COMPILE_BYTECODE=1

--- a/Dockerfile.inla
+++ b/Dockerfile.inla
@@ -9,7 +9,7 @@ ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
 
 # Copy uv binary from official source image
-COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /bin/uv
 
 # Create non-root user 'chap' and prepare /app directory
 RUN useradd -m -s /bin/bash chap && \

--- a/Dockerfile.integrationtest
+++ b/Dockerfile.integrationtest
@@ -1,4 +1,4 @@
-FROM python:3.12.0-slim
+FROM python:3.13-slim
 
 COPY tests/docker_db_flow.py docker_db_flow.py
 COPY tests/docker_db_flow_configured_models.py docker_db_flow_configured_models.py

--- a/Dockerfile.r-model.integrationtest
+++ b/Dockerfile.r-model.integrationtest
@@ -1,4 +1,4 @@
-FROM python:3.12.0-slim
+FROM python:3.13-slim
 
 COPY tests/docker_db_flow_r_model.py docker_db_flow_r_model.py
 COPY example_data example_data

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Use the official Python base image
-FROM ghcr.io/astral-sh/uv:0.10-python3.13-trixie-slim
+FROM ghcr.io/astral-sh/uv:0.11-python3.13-trixie-slim
 
 # Set the working directory in the container
 WORKDIR /app

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -17,7 +17,7 @@ ENV GIT_REVISION=${GIT_REVISION}
 USER root
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
-    curl -LsSf https://astral.sh/uv/0.11.4/install.sh | sh && \
+    curl -LsSf https://astral.sh/uv/0.11.19/install.sh | sh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add uv to PATH

--- a/external_models/Dockerfile
+++ b/external_models/Dockerfile
@@ -20,7 +20,7 @@ COPY ./pyproject.toml .
 COPY ./README.md .
 
 # get uv
-COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /bin/uv
 
 RUN pip install --upgrade pip
 RUN uv pip install --system -e .


### PR DESCRIPTION
## Changes
- uv container images: `ghcr.io/astral-sh/uv:0.10` → `0.11` line (latest stable 0.11.19) across `Dockerfile`, `Dockerfile.dev`, `Dockerfile.test`, `Dockerfile.inla`, and `external_models/Dockerfile`.
- `Dockerfile.worker`: curl install pin `0.11.4` → `0.11.19`.
- `setup-uv` GitHub Action: `v8.1.0` → `v8.2.0` (all 6 workflows).
- `Dockerfile.integrationtest` and `Dockerfile.r-model.integrationtest`: `python:3.12.0-slim` → `python:3.13-slim` to match `requires-python >=3.13`.

## Verification
- `docker build -f Dockerfile` and `docker build -f Dockerfile.worker` both build cleanly with the new uv pins.