### PR TITLE
test: move minimalist-example doc bash test to slow suite

### DIFF
--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -34,6 +34,7 @@ SKIP_FILES = [
     "docs/external_models/data_formats.md",
     "docs/feature_tutorials/extended_predictor.md",
     "docs/chap-cli/evaluation-workflow.md",
+    "docs/chap-cli/minimalist-example.md",  # runs `chap eval` against a remote model + dataset
     # Workshop tutorials (instructional content, not testable code)
     # Note: 11_feb_presession.md is tested in test_documentation_slow.py
     "docs/kigali-workshop",

--- a/tests/test_documentation_slow.py
+++ b/tests/test_documentation_slow.py
@@ -127,6 +127,7 @@ class TestSlowDocumentationBash:
         "docs/external_models/data_formats.md",
         "docs/feature_tutorials/extended_predictor.md",
         "docs/chap-cli/evaluation-workflow.md",
+        "docs/chap-cli/minimalist-example.md",
         "docs/kigali-workshop/kigali-workshop-material/11_feb_presession.md",
     ]
 


### PR DESCRIPTION
## Summary

The bash code block in `docs/chap-cli/minimalist-example.md` runs a full `chap eval` against a GitHub-hosted model (`minimalist_example_uv`) and a remote dataset. This makes `test_docs_bash[docs/chap-cli/minimalist-example.md]` the slowest test in the default suite at ~35s, and it requires network access — not appropriate for the snappy default `make test`.

This moves it to the `--run-slow`-gated slow doc tests, matching how the other heavy doc bash examples are handled.

## Changes

- `tests/test_documentation.py`: add `minimalist-example.md` to `SKIP_FILES` so it's excluded from the default doc tests.
- `tests/test_documentation_slow.py`: add it to `TestSlowDocumentationBash.SLOW_DOC_FILES` so it still runs under `make test-docs-slow` / `--run-slow`.

## Verification

- Default collection no longer includes the test.
- `pytest tests/test_documentation_slow.py --run-slow` collects `TestSlowDocumentationBash::test_slow_docs_bash[docs/chap-cli/minimalist-example.md]`.