### PR TITLE
fix: reject duplicate configured-models POST with 409 (CLIM-730)

### DIFF
--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -12,6 +12,7 @@ import sqlalchemy
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from chap_core.exceptions import ConfiguredModelConflictError
 from chap_core.log_config import is_debug_mode
 from chap_core.predictor.naive_estimator import NaiveEstimator
 
@@ -138,6 +139,7 @@ class SessionWrapper:
         configuration: ModelConfiguration,
         configuration_name="default",
         uses_chapkit=False,
+        error_on_existing=False,
     ) -> int:
         # get model template name
         model_template = self.session.exec(
@@ -158,6 +160,13 @@ class SessionWrapper:
         # check if configured model already exists
         existing_configured = self.session.exec(select(ConfiguredModelDB).where(ConfiguredModelDB.name == name)).first()
         if existing_configured:
+            if error_on_existing:
+                raise ConfiguredModelConflictError(
+                    f"Configured model with name '{name}' (model_template_id={model_template_id}) already exists"
+                )
+            # Silent get-or-create is intentional for internal idempotent setup
+            # (seeding, chapkit sync). API callers pass error_on_existing=True to
+            # distinguish create from get-or-create (see CLIM-730).
             logger.info(f"Configured model with name {name} already exists. Returning existing id")
             return cast("int", existing_configured.id)
 

--- a/chap_core/exceptions.py
+++ b/chap_core/exceptions.py
@@ -18,6 +18,10 @@ class GEEError(Exception):
 class ModelConfigurationException(Exception): ...
 
 
+class ConfiguredModelConflictError(Exception):
+    """Raised when creating a configured model that already exists (same name)."""
+
+
 class InvalidDateError(Exception): ...
 
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -48,6 +48,7 @@ from chap_core.database.tables import (
     PredictionSetupReadWithPredictions,
 )
 from chap_core.datatypes import FullData, HealthPopulationData, create_tsdataclass
+from chap_core.exceptions import ConfiguredModelConflictError
 from chap_core.geometry import Polygons
 from chap_core.rest_api.celery_tasks import (
     JOB_NAME_KW,
@@ -818,6 +819,7 @@ def get_configured_model_info(
     response_model=ConfiguredModelDB,
     tags=["Models"],
     summary="Configure a template into a runnable model",
+    responses={409: {"description": "A configured model with the same name already exists"}},
 )
 def add_configured_model(
     model_configuration: ModelConfigurationCreate,
@@ -828,7 +830,8 @@ def add_configured_model(
     Use this when an operator has filled out the configuration form for a template
     (lags, precision, extra covariates, ...) and wants to save it. The new row
     inherits whether the template originated from a CHAPKit service. Returns 404 if
-    the template id is unknown.
+    the template id is unknown, 409 if a configured model with the same name already
+    exists (POST creates, it does not get-or-create).
     """
     session_wrapper = SessionWrapper(session=session)
     model_template_id = model_configuration.model_template_id
@@ -838,15 +841,19 @@ def add_configured_model(
     if template is None:
         raise HTTPException(status_code=404, detail="Model template not found")
     uses_chapkit = template.uses_chapkit
-    db_id = session_wrapper.add_configured_model(
-        model_template_id,
-        ModelConfiguration(
-            user_option_values=model_configuration.user_option_values,
-            additional_continuous_covariates=model_configuration.additional_continuous_covariates,
-        ),
-        configuration_name,
-        uses_chapkit=uses_chapkit,
-    )
+    try:
+        db_id = session_wrapper.add_configured_model(
+            model_template_id,
+            ModelConfiguration(
+                user_option_values=model_configuration.user_option_values,
+                additional_continuous_covariates=model_configuration.additional_continuous_covariates,
+            ),
+            configuration_name,
+            uses_chapkit=uses_chapkit,
+            error_on_existing=True,
+        )
+    except ConfiguredModelConflictError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
     return session.get(ConfiguredModelDB, db_id)
 
 

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -1246,6 +1246,21 @@ def test_add_configured_model_flow(celery_session_worker, dependency_overrides):
     assert response.status_code == 200, response.json()
 
 
+def test_add_configured_model_duplicate_returns_409(dependency_overrides):
+    """POST creates; a second POST with the same (name, modelTemplateId) is a 409, not a
+    silent get-or-create (CLIM-730)."""
+    content = get_content("/v1/crud/model-templates")
+    model = next(m for m in content if m["name"] == "naive_model")
+    payload = {"name": "dup_config", "modelTemplateId": model["id"], "userOptionValues": {}}
+
+    first = client.post("/v1/crud/configured-models", json=payload)
+    assert first.status_code == 200, first.json()
+
+    second = client.post("/v1/crud/configured-models", json=payload)
+    assert second.status_code == 409, second.json()
+    assert "already exists" in second.json()["detail"]
+
+
 def test_add_configured_model_unknown_template_returns_404(dependency_overrides):
     payload = {"name": "orphan", "modelTemplateId": 999999, "userOptionValues": {}}
     response = client.post("/v1/crud/configured-models", json=payload)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -182,6 +182,22 @@ def test_add_configured_model_chapkit_skips_required_validation(engine):
             )
 
 
+def test_add_configured_model_error_on_existing(model_template_yaml_config, engine):
+    from chap_core.exceptions import ConfiguredModelConflictError
+
+    with SessionWrapper(engine) as session:
+        template_id = session.add_model_template_from_yaml_config(model_template_yaml_config)
+        first_id = session.add_configured_model(template_id, ModelConfiguration(user_option_values={}))
+
+        # default (no flag) stays silently idempotent for internal setup paths
+        same_id = session.add_configured_model(template_id, ModelConfiguration(user_option_values={}))
+        assert same_id == first_id
+
+        # API path opts into rejecting duplicates
+        with pytest.raises(ConfiguredModelConflictError):
+            session.add_configured_model(template_id, ModelConfiguration(user_option_values={}), error_on_existing=True)
+
+
 def test_yaml_update_preserves_uses_chapkit(model_template_yaml_config, engine):
     with SessionWrapper(engine) as session:
         template_id = session.add_model_template_from_yaml_config(model_template_yaml_config)


### PR DESCRIPTION
## Problem

`POST /v1/crud/configured-models` was silently idempotent: posting the same `{name, modelTemplateId}` body twice returned the same id both times with HTTP 200 and no warning. Clients could not distinguish *create* from *get-or-create*, which masks bugs (a caller that thinks it created a fresh row instead picks up whatever `userOptionValues` the existing row had) and is not what the OpenAPI surface promises a POST means.

Verified before the fix: a second `add_configured_model(...)` call returned the same id (`1`) silently.

## Fix

- `SessionWrapper.add_configured_model` gains an `error_on_existing` flag (default `False`). When `True` it raises a new `ConfiguredModelConflictError` instead of returning the existing row's id. The default keeps the silent get-or-create behaviour that internal idempotent setup paths (seeding, chapkit sync) rely on.
- The `POST /v1/crud/configured-models` handler passes `error_on_existing=True` and translates the error into `HTTPException(409)` with a detail naming the conflicting `name` and `model_template_id`. The `409` is documented in the endpoint's OpenAPI `responses`.

## On the DB constraint / migration

The issue scope suggested a composite unique constraint on `(name, modelTemplateId)` plus an alembic migration. `ConfiguredModelDB.name` is **already** `unique=True`, so the uniqueness invariant is already enforced at write time at the DB level — a composite `(name, model_template_id)` constraint would be redundant (and weaker than the existing name-unique one). No migration added.

## Client cutover

`chap_client` / `chap-scheduler` call sites that relied on silent idempotency need to preflight via `list_configured_models` or swallow the 409 — that cutover lands in those repos, out of scope for this chap-core change.

## Tests

- `test_add_configured_model_error_on_existing` (unit): default stays idempotent; `error_on_existing=True` raises `ConfiguredModelConflictError`.
- `test_add_configured_model_duplicate_returns_409` (REST): first POST 200, second POST 409 with an "already exists" detail.

`make lint` and the targeted suites pass.