### PR TITLE
ci: build docker images on 2.x tags

### DIFF
--- a/.github/workflows/ci-build-docker-images.yml
+++ b/.github/workflows/ci-build-docker-images.yml
@@ -3,7 +3,7 @@ name: Create and publish chap Docker image
 on:
   push:
     branches: ["dev", "master"]
-    tags: ["1.*"]
+    tags: ["1.*", "2.*"]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

The Docker image publish workflow only triggered on `1.*` tags. Now that 2.x releases are underway, add `2.*` to the tag filter so 2.x release tags also build and publish images.

## Changes

- `ci-build-docker-images.yml`: tag trigger now `["1.*", "2.*"]`

No other changes needed — the tag-determination step already derives the Docker tag generically from the git ref and validates that the tag points to `master`, so a `2.x` tag publishes images like `ghcr.io/dhis2-chap/chap-core:2.1.0`.