### PR TITLE
ci: match v-prefixed release tags for docker builds

### DIFF
--- a/.github/workflows/ci-build-docker-images.yml
+++ b/.github/workflows/ci-build-docker-images.yml
@@ -3,7 +3,7 @@ name: Create and publish chap Docker image
 on:
   push:
     branches: ["dev", "master"]
-    tags: ["1.*", "2.*"]
+    tags: ["v1.*", "v2.*"]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

Release tags in this repo are `v`-prefixed (`v1.4.0`, `v2.0.0`, …), but the docker publish workflow filtered on `1.*` / `2.*` (no `v`), so the tag-based build never actually fired on any release tag. Fix the filter to `["v1.*", "v2.*"]` so it matches the real tag convention.

## Changes

- `ci-build-docker-images.yml`: tag trigger now `["v1.*", "v2.*"]`

A `v2.0.0` tag now publishes `ghcr.io/dhis2-chap/chap-core:v2.0.0`. Follow-up to #428, which used the non-`v` form.