### PR TITLE
ci: add manual workflow_dispatch to docker image build

### DIFF
--- a/.github/workflows/ci-build-docker-images.yml
+++ b/.github/workflows/ci-build-docker-images.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: ["dev", "master"]
     tags: ["v1.*", "v2.*"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag/branch/sha) to build"
+        required: true
+      tag:
+        description: "Docker image tag to publish"
+        required: true
 
 env:
   REGISTRY: ghcr.io
@@ -30,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -44,7 +54,9 @@ jobs:
       - name: Determine Docker image tag
         id: tag
         run: |
-          if [[ "$GITHUB_REF" == "refs/heads/dev" ]]; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+          elif [[ "$GITHUB_REF" == "refs/heads/dev" ]]; then
             TAG="dev"
           elif [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
             TAG="latest"


### PR DESCRIPTION
## Summary

Tag-triggered docker builds read the `on.push.tags` filter from the workflow file **as it exists in the tagged commit**. Tags cut before the filter fix (e.g. `v2.0.0` at `daa015d5`, which still has the old `1.*` filter) can therefore never be built by re-pushing the tag. Add a manual `workflow_dispatch` trigger so any ref can be built on demand.

## Changes

- `workflow_dispatch` trigger with two inputs:
  - `ref` - git ref (tag/branch/sha) to check out and build
  - `tag` - docker image tag to publish
- Checkout uses `github.event.inputs.ref || github.ref` so push events are unaffected.
- Tag-determination short-circuits to the provided `tag` input on `workflow_dispatch`; push behavior (`dev`/`latest`/release tag) is unchanged.

## Usage

To backfill the v2.0.0 image:

    gh workflow run ci-build-docker-images.yml -f ref=v2.0.0 -f tag=v2.0.0

This checks out the v2.0.0 source and publishes `ghcr.io/dhis2-chap/chap-core:v2.0.0` (and the worker image) with full build-provenance attestation.