### PR TITLE
feat: prefilter backtest-plot facets from the database

### DIFF
--- a/alembic/versions/a7b8c9d0e1f2_add_max_horizon_distance_to_backtest.py
+++ b/alembic/versions/a7b8c9d0e1f2_add_max_horizon_distance_to_backtest.py
@@ -1,0 +1,33 @@
+"""add_max_horizon_distance_to_backtest
+
+Adds a nullable max_horizon_distance column to the backtest table. Existing rows
+are left NULL; consumers fall back to deriving horizons from the forecasts.
+
+Revision ID: a7b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-06-09
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7b8c9d0e1f2"
+down_revision: Union[str, Sequence[str], None] = "f6a7b8c9d0e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add max_horizon_distance column to backtest table."""
+    op.add_column(
+        "backtest",
+        sa.Column("max_horizon_distance", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove max_horizon_distance column from backtest table."""
+    op.drop_column("backtest", "max_horizon_distance")

--- a/chap_core/assessment/backtest_plots/db_dimensions.py
+++ b/chap_core/assessment/backtest_plots/db_dimensions.py
@@ -21,7 +21,7 @@ from chap_core.assessment.flat_representations import (
     convert_backtest_to_flat_forecasts,
     horizon_diff,
 )
-from chap_core.database.dataset_tables import Observation
+from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.tables import BacktestForecast
 from chap_core.plotting.backtest_plot import clean_time
 from chap_core.time_period import TimePeriod
@@ -45,10 +45,6 @@ class DBFacetDimension(FacetDimension):
         """SQL clauses narrowing `BacktestForecast` to the rows for `value`."""
         return []
 
-    def observation_filters(self, value: Any, session: Session, backtest: Backtest) -> list[ColumnElement]:
-        """SQL clauses narrowing `Observation` to the rows for `value`."""
-        return []
-
 
 class LocationDimension(DBFacetDimension):
     """Facet by org unit (`location`), matching `BacktestForecast.org_unit` directly."""
@@ -63,9 +59,6 @@ class LocationDimension(DBFacetDimension):
 
     def forecast_filters(self, value: Any, session: Session, backtest: Backtest) -> list[ColumnElement]:
         return [BacktestForecast.org_unit == value]
-
-    def observation_filters(self, value: Any, session: Session, backtest: Backtest) -> list[ColumnElement]:
-        return [Observation.org_unit == value]
 
 
 def _split_display(last_seen_period: str) -> str:
@@ -148,19 +141,22 @@ def load_filtered_flat_data(
     dim_by_name = {d.clean_name: d for d in dimensions if isinstance(d, DBFacetDimension)}
 
     forecast_clauses: list[Any] = [BacktestForecast.backtest_id == backtest.id]
-    observation_clauses: list[Any] = [
-        Observation.dataset_id == backtest.dataset_id,
-        Observation.feature_name == "disease_cases",
-    ]
     for name, value in coords.items():
         dim = dim_by_name.get(name)
         if dim is None:
             continue
         forecast_clauses += dim.forecast_filters(value, session, backtest)
-        observation_clauses += dim.observation_filters(value, session, backtest)
 
     forecasts = session.exec(select(BacktestForecast).where(*forecast_clauses)).all()
-    observations = session.exec(select(Observation).where(*observation_clauses)).all()
+
+    # Observations narrow only by org unit (any location coordinate); other dimensions
+    # filter the forecasts and rely on the plot's in-memory filter for observations.
+    org_units = [value for name, value in coords.items() if isinstance(dim_by_name.get(name), LocationDimension)]
+    observations = DataSetManager(session).observations(
+        backtest.dataset_id,
+        org_units=org_units or None,
+        feature_names=["disease_cases"],
+    )
 
     forecasts_df = convert_backtest_to_flat_forecasts(list(forecasts))
     observations_df = convert_backtest_observations_to_flat_observations(list(observations))

--- a/chap_core/assessment/backtest_plots/db_dimensions.py
+++ b/chap_core/assessment/backtest_plots/db_dimensions.py
@@ -1,0 +1,171 @@
+"""Database-backed facet dimensions for backtest plots.
+
+These dimensions know how to (a) enumerate their available coordinate values with
+cheap database queries and (b) translate a requested coordinate into SQL filters,
+so a single subplot can be served by loading only the matching forecast rows
+instead of flattening the entire backtest in memory.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import false, tuple_
+from sqlmodel import select
+
+from chap_core.assessment.backtest_plots import FacetDimension
+from chap_core.assessment.flat_representations import (
+    FlatForecasts,
+    FlatObserved,
+    convert_backtest_observations_to_flat_observations,
+    convert_backtest_to_flat_forecasts,
+    horizon_diff,
+)
+from chap_core.database.dataset_tables import Observation
+from chap_core.database.tables import BacktestForecast
+from chap_core.plotting.backtest_plot import clean_time
+from chap_core.time_period import TimePeriod
+
+if TYPE_CHECKING:
+    from sqlalchemy.sql.elements import ColumnElement
+    from sqlmodel import Session
+
+    from chap_core.assessment.evaluation import FlatEvaluationData
+    from chap_core.database.tables import Backtest
+
+
+class DBFacetDimension(FacetDimension):
+    """A facet dimension whose coordinates and filters can be served from the database."""
+
+    def distinct_values(self, session: Session, backtest: Backtest) -> list[Any]:
+        """Coordinate values available for this dimension, in display form."""
+        raise NotImplementedError
+
+    def forecast_filters(self, value: Any, session: Session, backtest: Backtest) -> list[ColumnElement]:
+        """SQL clauses narrowing `BacktestForecast` to the rows for `value`."""
+        return []
+
+    def observation_filters(self, value: Any, session: Session, backtest: Backtest) -> list[ColumnElement]:
+        """SQL clauses narrowing `Observation` to the rows for `value`."""
+        return []
+
+
+class LocationDimension(DBFacetDimension):
+    """Facet by org unit (`location`), matching `BacktestForecast.org_unit` directly."""
+
+    def distinct_values(self, session: Session, backtest: Backtest) -> list[Any]:
+        if backtest.org_units:
+            return sorted(backtest.org_units)
+        rows = session.exec(
+            select(BacktestForecast.org_unit).where(BacktestForecast.backtest_id == backtest.id).distinct()
+        ).all()
+        return sorted(rows)
+
+    def forecast_filters(self, value: Any, session: Session, backtest: Backtest) -> list[ColumnElement]:
+        return [BacktestForecast.org_unit == value]
+
+    def observation_filters(self, value: Any, session: Session, backtest: Backtest) -> list[ColumnElement]:
+        return [Observation.org_unit == value]
+
+
+def _split_display(last_seen_period: str) -> str:
+    """The split-period coordinate a forecast with this `last_seen_period` falls under.
+
+    Mirrors the plot's `clean_time(time_period - horizon * delta)`, which reduces to
+    `clean_time(last_seen_period - delta)`.
+    """
+    tp = TimePeriod.parse(last_seen_period)
+    return str(clean_time((tp - tp.time_delta).to_string()))
+
+
+def _distinct_last_seen(session: Session, backtest: Backtest) -> list[str]:
+    return list(
+        session.exec(
+            select(BacktestForecast.last_seen_period).where(BacktestForecast.backtest_id == backtest.id).distinct()
+        ).all()
+    )
+
+
+class SplitPeriodDimension(DBFacetDimension):
+    """Facet by split period, derived from `BacktestForecast.last_seen_period`."""
+
+    def distinct_values(self, session: Session, backtest: Backtest) -> list[Any]:
+        return sorted({_split_display(ls) for ls in _distinct_last_seen(session, backtest)})
+
+    def forecast_filters(self, value: Any, session: Session, backtest: Backtest) -> list[ColumnElement]:
+        matching = [ls for ls in _distinct_last_seen(session, backtest) if _split_display(ls) == value]
+        if not matching:
+            return [false()]
+        return [BacktestForecast.last_seen_period.in_(matching)]  # type: ignore[attr-defined]
+
+
+def _distinct_period_pairs(session: Session, backtest: Backtest) -> list[tuple[str, str]]:
+    rows = session.exec(
+        select(BacktestForecast.period, BacktestForecast.last_seen_period)
+        .where(BacktestForecast.backtest_id == backtest.id)
+        .distinct()
+    ).all()
+    return [(str(period), str(last_seen)) for period, last_seen in rows]
+
+
+class HorizonDistanceDimension(DBFacetDimension):
+    """Facet by 1-based horizon distance.
+
+    Coordinates run `1..max_horizon_distance` when the backtest records it, falling
+    back to deriving distinct horizons from the forecasts for legacy rows.
+    """
+
+    def distinct_values(self, session: Session, backtest: Backtest) -> list[Any]:
+        if backtest.max_horizon_distance is not None:
+            return list(range(1, backtest.max_horizon_distance + 1))
+        horizons = {horizon_diff(period, last_seen) for period, last_seen in _distinct_period_pairs(session, backtest)}
+        return sorted(horizons)
+
+    def forecast_filters(self, value: Any, session: Session, backtest: Backtest) -> list[ColumnElement]:
+        pairs = [
+            (period, last_seen)
+            for period, last_seen in _distinct_period_pairs(session, backtest)
+            if horizon_diff(period, last_seen) == int(value)
+        ]
+        if not pairs:
+            return [false()]
+        return [tuple_(BacktestForecast.period, BacktestForecast.last_seen_period).in_(pairs)]  # type: ignore[arg-type]
+
+
+def load_filtered_flat_data(
+    session: Session,
+    backtest: Backtest,
+    coords: dict[str, Any],
+    dimensions: list[FacetDimension],
+) -> FlatEvaluationData:
+    """Load only the forecast/observation rows matching `coords`, as flat frames.
+
+    Coordinates whose dimension is a `DBFacetDimension` are pushed down to SQL; any
+    other coordinate is ignored here and left to the plot's in-memory filter.
+    """
+    from chap_core.assessment.evaluation import FlatEvaluationData
+
+    dim_by_name = {d.clean_name: d for d in dimensions if isinstance(d, DBFacetDimension)}
+
+    forecast_clauses: list[Any] = [BacktestForecast.backtest_id == backtest.id]
+    observation_clauses: list[Any] = [
+        Observation.dataset_id == backtest.dataset_id,
+        Observation.feature_name == "disease_cases",
+    ]
+    for name, value in coords.items():
+        dim = dim_by_name.get(name)
+        if dim is None:
+            continue
+        forecast_clauses += dim.forecast_filters(value, session, backtest)
+        observation_clauses += dim.observation_filters(value, session, backtest)
+
+    forecasts = session.exec(select(BacktestForecast).where(*forecast_clauses)).all()
+    observations = session.exec(select(Observation).where(*observation_clauses)).all()
+
+    forecasts_df = convert_backtest_to_flat_forecasts(list(forecasts))
+    observations_df = convert_backtest_observations_to_flat_observations(list(observations))
+
+    return FlatEvaluationData(
+        forecasts=FlatForecasts(forecasts_df),
+        observations=FlatObserved(observations_df),
+    )

--- a/chap_core/assessment/backtest_plots/evaluation_plot.py
+++ b/chap_core/assessment/backtest_plots/evaluation_plot.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 
 from chap_core.assessment.backtest_plots import ChartType, FacetDimension, FacetedBacktestPlot, backtest_plot
+from chap_core.assessment.backtest_plots.db_dimensions import LocationDimension, SplitPeriodDimension
 from chap_core.plotting.backtest_plot import clean_time
 from chap_core.time_period import TimePeriod
 
@@ -57,8 +58,8 @@ class EvaluationPlot(FacetedBacktestPlot):
     """Shows forecasts with uncertainty bands and observed values with historical context."""
 
     facet_dimensions: list[FacetDimension] = [
-        FacetDimension(field_name="split_period:O", display_name="Split Period"),
-        FacetDimension(field_name="location:N", display_name="Location"),
+        SplitPeriodDimension(field_name="split_period:O", display_name="Split Period"),
+        LocationDimension(field_name="location:N", display_name="Location"),
     ]
 
     def _preprocess(

--- a/chap_core/assessment/backtest_plots/predicted_vs_actual_plot.py
+++ b/chap_core/assessment/backtest_plots/predicted_vs_actual_plot.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 
 from chap_core.assessment.backtest_plots import ChartType, FacetDimension, FacetedBacktestPlot, backtest_plot
+from chap_core.assessment.backtest_plots.db_dimensions import HorizonDistanceDimension
 from chap_core.plotting.backtest_plot import clean_time
 
 
@@ -93,7 +94,7 @@ def build_predicted_vs_actual_chart(
 )
 class PredictedVsActualPlot(FacetedBacktestPlot):
     facet_dimensions: list[FacetDimension] = [
-        FacetDimension(field_name="horizon_distance:O", display_name="Horizon Distance"),
+        HorizonDistanceDimension(field_name="horizon_distance:O", display_name="Horizon Distance"),
     ]
 
     resolve_scale_x = "shared"

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -26,6 +26,7 @@ from chap_core.assessment.flat_representations import (
     FlatObserved,
     convert_backtest_observations_to_flat_observations,
     convert_backtest_to_flat_forecasts,
+    max_horizon_distance,
 )
 from chap_core.data import DataSet as _DataSet
 from chap_core.database.dataset_tables import DataSet, Observation, ObservationBase
@@ -334,6 +335,7 @@ class Evaluation(EvaluationBase):
 
         backtest.org_units = list(org_units)
         backtest.split_periods = list(split_points)
+        backtest.max_horizon_distance = max_horizon_distance(backtest.forecasts)
 
         # Deduplicate observations by (period, org_unit) - keep first occurrence
         seen = set()
@@ -674,6 +676,8 @@ class Evaluation(EvaluationBase):
                 values=values,
             )
             backtest.forecasts.append(forecast)
+
+        backtest.max_horizon_distance = max_horizon_distance(backtest.forecasts)
 
         # Create observations from flat data
         observations_df = pd.DataFrame(cast("pd.DataFrame", flat_data.observations))

--- a/chap_core/assessment/flat_representations.py
+++ b/chap_core/assessment/flat_representations.py
@@ -64,6 +64,13 @@ def horizon_diff(period: str, period2: str) -> int:
     return int((tp - tp2) // tp.time_delta) + 1
 
 
+def max_horizon_distance(backtest_forecasts: list[BacktestForecast]) -> int | None:
+    """Largest 1-based horizon distance across a backtest's forecasts, or None if empty."""
+    if not backtest_forecasts:
+        return None
+    return max(horizon_diff(str(fc.period), str(fc.last_seen_period)) for fc in backtest_forecasts)
+
+
 def _convert_backtest_to_flat_forecasts(backtest_forecasts: list[BacktestForecast]) -> pd.DataFrame:
     """
     Convert a list of BacktestForecast objects to a flat DataFrame format

--- a/chap_core/database/tables.py
+++ b/chap_core/database/tables.py
@@ -53,6 +53,10 @@ class _BacktestRead(BacktestBase):
         sa_column=Column(JSON),
         description="Periods at which the rolling backtest's train/test split was advanced.",
     )
+    max_horizon_distance: int | None = Field(
+        default=None,
+        description="Largest 1-based horizon distance scored in this backtest; horizon coordinates run 1..max_horizon_distance.",
+    )
 
 
 class Backtest(_BacktestRead, table=True):

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -13,6 +13,7 @@ from chap_core.assessment.backtest_plots import (
     get_backtest_plots_registry,
     list_backtest_plots,
 )
+from chap_core.assessment.backtest_plots.db_dimensions import DBFacetDimension, load_filtered_flat_data
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metric_plots import get_metric_plots_registry, list_metric_plots
 from chap_core.assessment.metrics import available_metrics
@@ -219,29 +220,34 @@ def generate_backtest_plots(visualization_name: str, backtest_id: int, session: 
     return JSONResponse(chart.to_dict(format="vega"))
 
 
-def _get_plotter_and_flat_data(plot_id: str, backtest_id: int, session: Session):
+def _get_faceted_plotter_and_backtest(
+    plot_id: str, backtest_id: int, session: Session
+) -> tuple[FacetedBacktestPlot, Backtest]:
     plot_cls = get_backtest_plot(plot_id)
     if plot_cls is None:
         raise HTTPException(status_code=404, detail=f"Plot {plot_id} not found")
 
-    # Fixed typo: FacetedBacktestPlot (with the 'ed')
     if not issubclass(plot_cls, FacetedBacktestPlot):
         raise HTTPException(status_code=400, detail=f"Plot '{plot_id}' does not support faceting properties")
 
-    # Fetch the model instance using id
     backtest = session.get(Backtest, backtest_id)
     if not backtest:
         raise HTTPException(status_code=404, detail="Backtest not found")
 
-    evaluation = Evaluation.from_backtest(backtest)
-    flat_data = evaluation.to_flat()
+    return plot_cls(), backtest
 
-    # Extract the underlying frames from the returned flat_data container object
-    observations = flat_data.observations
-    forecasts = flat_data.forecasts
-    historical_df = flat_data.historical_observations
 
-    return plot_cls(), observations, forecasts, historical_df
+def _is_db_backed(plotter: FacetedBacktestPlot) -> bool:
+    """True when every facet dimension can be served straight from the database."""
+    return bool(plotter.facet_dimensions) and all(isinstance(dim, DBFacetDimension) for dim in plotter.facet_dimensions)
+
+
+def _get_plotter_and_flat_data(plot_id: str, backtest_id: int, session: Session):
+    plotter, backtest = _get_faceted_plotter_and_backtest(plot_id, backtest_id, session)
+
+    flat_data = Evaluation.from_backtest(backtest).to_flat()
+
+    return plotter, flat_data.observations, flat_data.forecasts, flat_data.historical_observations
 
 
 @router.get("/backtest-plots/{visualization_name}/{backtest_id}/facet-coords")
@@ -251,10 +257,23 @@ def get_facet_coordinates(
     """
     Returns unique structural dimension arrays available for layout faceting grids.
     """
-    plotter, observations, forecasts, historical_df = _get_plotter_and_flat_data(
-        visualization_name, backtest_id, session
+    plotter, backtest = _get_faceted_plotter_and_backtest(visualization_name, backtest_id, session)
+
+    if _is_db_backed(plotter):
+        return {
+            cast("DBFacetDimension", dim).clean_name: cast("DBFacetDimension", dim).distinct_values(session, backtest)
+            for dim in plotter.facet_dimensions
+        }
+
+    flat_data = Evaluation.from_backtest(backtest).to_flat()
+    return cast(
+        "dict[str, Any]",
+        plotter.facet_coords(
+            cast("Any", flat_data.observations),
+            cast("Any", flat_data.forecasts),
+            cast("Any", flat_data.historical_observations),
+        ),
     )
-    return cast("dict[str, Any]", plotter.facet_coords(observations, forecasts, historical_df))
 
 
 @router.post("/backtest-plots/{visualization_name}/{backtest_id}/subplot")
@@ -264,11 +283,19 @@ def generate_isolated_plots(
     """
     Filters the source datasets by exact coordinate targets and generates a single Vega schema spec.
     """
-    plotter, observations, forecasts, historical_df = _get_plotter_and_flat_data(
-        visualization_name, backtest_id, session
-    )
+    plotter, backtest = _get_faceted_plotter_and_backtest(visualization_name, backtest_id, session)
 
-    chart = plotter.get_subplot(observations, forecasts, facet_coords, historical_df)
+    if _is_db_backed(plotter):
+        flat_data = load_filtered_flat_data(session, backtest, facet_coords, plotter.facet_dimensions)
+    else:
+        flat_data = Evaluation.from_backtest(backtest).to_flat()
+
+    chart = plotter.get_subplot(
+        cast("Any", flat_data.observations),
+        cast("Any", flat_data.forecasts),
+        facet_coords,
+        cast("Any", flat_data.historical_observations),
+    )
     return JSONResponse(chart.to_dict(format="vega"))
 
 

--- a/chap_core/simulation/naive_simulator.py
+++ b/chap_core/simulation/naive_simulator.py
@@ -11,6 +11,7 @@ import numpy as np
 import pydantic
 from numpy.random import normal, poisson
 
+from chap_core.assessment.flat_representations import max_horizon_distance
 from chap_core.database.dataset_tables import DataSet, Observation
 from chap_core.database.tables import Backtest, BacktestForecast
 
@@ -93,6 +94,7 @@ class BacktestSimulator:
         for i in range(self._params.n_splits):
             forecasts.extend(self.simulate_split(dataset, periods[i : i + self._params.prediction_length]))
         backtest.forecasts = forecasts
+        backtest.max_horizon_distance = max_horizon_distance(forecasts)
         return backtest
 
     def simulate_split(self, dataset: DataSet, periods: list[str]) -> list[Any]:

--- a/tests/evaluation/test_db_dimensions.py
+++ b/tests/evaluation/test_db_dimensions.py
@@ -1,0 +1,138 @@
+"""Equivalence tests for the database-backed facet dimensions.
+
+These confirm that pushing coordinate filtering down to SQL (`load_filtered_flat_data`)
+and enumerating coordinates with cheap queries (`distinct_values`) produce the same
+result as the in-memory full-scan path the plots used before.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from sqlmodel import Session, SQLModel, create_engine
+
+from chap_core.assessment.backtest_plots.db_dimensions import (
+    HorizonDistanceDimension,
+    LocationDimension,
+    SplitPeriodDimension,
+    load_filtered_flat_data,
+)
+from chap_core.assessment.backtest_plots.evaluation_plot import EvaluationPlot
+from chap_core.assessment.backtest_plots.predicted_vs_actual_plot import PredictedVsActualPlot
+from chap_core.assessment.evaluation import Evaluation
+
+FORECAST_COLS = ["location", "time_period", "horizon_distance", "sample", "forecast"]
+
+
+@pytest.fixture
+def db_session(backtest):
+    """Persist the in-memory `backtest` fixture into a throwaway SQLite database."""
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add(backtest)
+        session.commit()
+        session.refresh(backtest)
+        yield session
+
+
+def _records(df: pd.DataFrame, cols: list[str]) -> set[tuple]:
+    if df.empty:
+        return set()
+    return set(map(tuple, df[cols].itertuples(index=False, name=None)))
+
+
+def test_location_coords_match_full_scan(db_session, backtest):
+    full = Evaluation.from_backtest(backtest).to_flat()
+    plotter = EvaluationPlot()
+    full_coords = plotter.facet_coords(pd.DataFrame(full.observations), pd.DataFrame(full.forecasts))
+
+    db_values = LocationDimension(field_name="location:N", display_name="Location").distinct_values(
+        db_session, backtest
+    )
+    assert set(db_values) == set(full_coords["location"])
+
+
+def test_split_period_coords_match_full_scan(db_session, backtest):
+    full = Evaluation.from_backtest(backtest).to_flat()
+    plotter = EvaluationPlot()
+    full_coords = plotter.facet_coords(pd.DataFrame(full.observations), pd.DataFrame(full.forecasts))
+
+    db_values = SplitPeriodDimension(field_name="split_period:O", display_name="Split Period").distinct_values(
+        db_session, backtest
+    )
+    assert set(db_values) == set(full_coords["split_period"])
+
+
+def test_horizon_coords_match_full_scan(db_session, backtest):
+    full = Evaluation.from_backtest(backtest).to_flat()
+    plotter = PredictedVsActualPlot()
+    full_coords = plotter.facet_coords(pd.DataFrame(full.observations), pd.DataFrame(full.forecasts))
+
+    db_values = HorizonDistanceDimension(
+        field_name="horizon_distance:O", display_name="Horizon Distance"
+    ).distinct_values(db_session, backtest)
+    assert set(db_values) == set(full_coords["horizon_distance"])
+
+
+def test_location_filter_matches_full_scan(db_session, backtest):
+    full_forecasts = pd.DataFrame(Evaluation.from_backtest(backtest).to_flat().forecasts)
+    location = sorted(full_forecasts["location"].unique())[0]
+    dims = EvaluationPlot.facet_dimensions
+
+    filtered = load_filtered_flat_data(db_session, backtest, {"location": location}, dims)
+
+    expected = full_forecasts[full_forecasts["location"] == location]
+    assert _records(pd.DataFrame(filtered.forecasts), FORECAST_COLS) == _records(expected, FORECAST_COLS)
+
+
+def test_horizon_filter_matches_full_scan(db_session, backtest):
+    full_forecasts = pd.DataFrame(Evaluation.from_backtest(backtest).to_flat().forecasts)
+    horizon = int(sorted(full_forecasts["horizon_distance"].unique())[-1])
+    dims = PredictedVsActualPlot.facet_dimensions
+
+    filtered = load_filtered_flat_data(db_session, backtest, {"horizon_distance": horizon}, dims)
+
+    expected = full_forecasts[full_forecasts["horizon_distance"] == horizon]
+    assert _records(pd.DataFrame(filtered.forecasts), FORECAST_COLS) == _records(expected, FORECAST_COLS)
+
+
+def test_split_periods_partition_forecasts(db_session, backtest):
+    """The split-period filters partition the full forecast set: every row appears in
+    exactly one split coordinate's load."""
+    full_forecasts = pd.DataFrame(Evaluation.from_backtest(backtest).to_flat().forecasts)
+    dims = EvaluationPlot.facet_dimensions
+    split_dim = SplitPeriodDimension(field_name="split_period:O", display_name="Split Period")
+
+    collected: list[set[tuple]] = []
+    for split in split_dim.distinct_values(db_session, backtest):
+        filtered = load_filtered_flat_data(db_session, backtest, {"split_period": split}, dims)
+        collected.append(_records(pd.DataFrame(filtered.forecasts), FORECAST_COLS))
+
+    # No overlap between split partitions.
+    for i in range(len(collected)):
+        for j in range(i + 1, len(collected)):
+            assert collected[i].isdisjoint(collected[j])
+
+    union: set[tuple] = set().union(*collected) if collected else set()
+    assert union == _records(full_forecasts, FORECAST_COLS)
+
+
+def test_unknown_split_coord_returns_no_rows(db_session, backtest):
+    dims = EvaluationPlot.facet_dimensions
+    filtered = load_filtered_flat_data(db_session, backtest, {"split_period": "1900-01-01"}, dims)
+    assert pd.DataFrame(filtered.forecasts).empty
+
+
+def test_subplot_renders_from_db_filtered_data(db_session, backtest):
+    import altair as alt
+
+    full = Evaluation.from_backtest(backtest).to_flat()
+    plotter = EvaluationPlot()
+    coords = plotter.facet_coords(pd.DataFrame(full.observations), pd.DataFrame(full.forecasts))
+    selection = {"split_period": coords["split_period"][0], "location": coords["location"][0]}
+
+    filtered = load_filtered_flat_data(db_session, backtest, selection, EvaluationPlot.facet_dimensions)
+    chart = plotter.get_subplot(pd.DataFrame(filtered.observations), pd.DataFrame(filtered.forecasts), selection)
+    assert isinstance(chart, alt.TopLevelMixin)
+    assert not isinstance(chart, alt.FacetChart)

--- a/tests/evaluation/test_evaluation_serialization.py
+++ b/tests/evaluation/test_evaluation_serialization.py
@@ -185,6 +185,15 @@ class TestEvaluationSerialization:
             rtol=1e-6,
         )
 
+    def test_roundtrip_populates_max_horizon_distance(self, backtest, tmp_path):
+        """from_file should derive max_horizon_distance from the rebuilt forecasts."""
+        evaluation = Evaluation.from_backtest(backtest)
+        output_file = tmp_path / "test_evaluation.nc"
+        evaluation.to_file(filepath=output_file)
+
+        loaded_evaluation = Evaluation.from_file(output_file)
+        assert loaded_evaluation.to_backtest().max_horizon_distance == 4
+
     def test_roundtrip_preserves_observation_data(self, backtest, tmp_path):
         """Test that save/load preserves observation data integrity."""
         evaluation = Evaluation.from_backtest(backtest)

--- a/tests/evaluation/test_flat_representations.py
+++ b/tests/evaluation/test_flat_representations.py
@@ -2,6 +2,7 @@ import pytest
 from chap_core.assessment.flat_representations import (
     convert_backtest_observations_to_flat_observations,
     convert_backtest_to_flat_forecasts,
+    max_horizon_distance,
 )
 
 
@@ -18,3 +19,17 @@ def test_convert_backtest_to_flat_forecast(backtest_weeks_large):
 
     print(flat_forecasts)
     print(flat_observations)
+
+
+def test_max_horizon_distance(forecasts):
+    # Furthest forecast: period 2022-02 seen from 2021-11 -> 3 months -> horizon 4
+    assert max_horizon_distance(forecasts) == 4
+
+
+def test_max_horizon_distance_weekly(forecasts_weeks):
+    # Furthest forecast: period 2022W02 seen from 2021W51 -> 3 weeks -> horizon 4
+    assert max_horizon_distance(forecasts_weeks) == 4
+
+
+def test_max_horizon_distance_empty():
+    assert max_horizon_distance([]) is None

--- a/tests/simulation/test_dataset_model.py
+++ b/tests/simulation/test_dataset_model.py
@@ -1,6 +1,11 @@
 import pytest
 
-from chap_core.simulation.naive_simulator import DatasetDimensions, AdditiveSimulator, BacktestSimulator
+from chap_core.simulation.naive_simulator import (
+    DatasetDimensions,
+    AdditiveSimulator,
+    BacktestSimulator,
+    ForecastParams,
+)
 
 
 @pytest.fixture
@@ -23,3 +28,10 @@ def test_forecast_simulator(dims):
     dataset = AdditiveSimulator().simulate(dims)
     backtest = BacktestSimulator().simulate(dataset, dims)
     assert len(backtest.forecasts) == len(dims.locations) * 3 * 2
+
+
+def test_forecast_simulator_sets_max_horizon_distance(dims):
+    params = ForecastParams()
+    dataset = AdditiveSimulator().simulate(dims)
+    backtest = BacktestSimulator(params).simulate(dataset, dims)
+    assert backtest.max_horizon_distance == params.prediction_length

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -41,6 +41,7 @@ ALEMBIC_INI = PROJECT_ROOT / "alembic.ini"
 _COLUMNS_ADDED_BY_MIGRATIONS = [
     ("modeltemplatedb", "archived"),
     ("prediction", "prediction_setup_id"),
+    ("backtest", "max_horizon_distance"),
 ]
 
 # Tables added by alembic migrations (not in the baseline schema).


### PR DESCRIPTION
## Summary

Improves backtest-plot faceting performance by pushing coordinate filtering down to the database instead of flattening the entire backtest into memory and filtering in pandas.

Previously, rendering a single subplot (one location / split period / horizon) or just listing facet coordinates loaded every forecast sample of every location, period, and horizon, then filtered in pandas. This change serves the well-known facet dimensions directly from the database.

## Changes

### `max_horizon_distance` on `Backtest` (first commit)
- New nullable `max_horizon_distance` column recording the largest 1-based horizon distance scored in a backtest.
- Populated at every creation site (`from_samples_with_truth`, `from_file`, naive simulator) via a shared `max_horizon_distance` helper built on the existing `horizon_diff`.
- Alembic migration for the column. Legacy rows stay `NULL` and fall back to deriving horizons from the forecasts.

### Database-backed facet dimensions (second commit)
- `DBFacetDimension` subclasses for `location`, `split_period`, and `horizon_distance`. Each knows how to (a) enumerate available coordinates with cheap queries and (b) translate a requested coordinate into SQL filters:
  - `location` -> `org_unit ==`
  - `split_period` -> `last_seen_period` match (`split = clean_time(last_seen - delta)`)
  - `horizon_distance` -> coordinates `1..max_horizon_distance`, filter via `tuple_(period, last_seen).in_(...)`
- `load_filtered_flat_data` loads only the matching forecast/observation rows and returns the same `FlatEvaluationData` shape, so plot code is unchanged.
- The `/facet-coords` and `/subplot` endpoints use the database-backed path when all of a plot's facet dimensions support it, and fall back to the full-scan path otherwise. The plot's in-memory filter stays as a correctness safety-net.

## Tests
- Helper and creation-site tests for `max_horizon_distance`.
- Equivalence tests: facet coordinates and filtered forecast row-sets match the previous full-scan path; split-period filters form a disjoint, complete partition of the forecasts; unknown coordinate returns no rows.
- Existing REST faceting integration tests pass through the rewired endpoints unchanged.

## Follow-ups (not in this PR)
- The `/subplots` batch endpoint still uses the full-load path.
- No `BacktestForecast` composite index yet; the new `WHERE` clauses (`org_unit`, `last_seen_period`, `period`) will table-scan until one is added.
