### PR TITLE
feat: proxy requests to chapkit instances via /v2/services/{id}/run (CLIM-776)

### DIFF
--- a/chap_core/rest_api/v2/dependencies.py
+++ b/chap_core/rest_api/v2/dependencies.py
@@ -1,6 +1,7 @@
 import os
 from functools import lru_cache
 
+import httpx
 from fastapi import Header, HTTPException, status
 
 from chap_core.rest_api.services.orchestrator import Orchestrator
@@ -8,6 +9,10 @@ from chap_core.util import load_redis
 
 SERVICE_KEY_HEADER = "X-Service-Key"
 SERVICE_KEY_ENV_VAR = "SERVICEKIT_REGISTRATION_KEY"
+
+# Generous read/write timeouts: proxied artifact downloads can stream large payloads.
+# Train/predict return 202 immediately, so they don't need a long window here.
+_PROXY_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=300.0, pool=10.0)
 
 
 @lru_cache
@@ -17,6 +22,16 @@ def get_redis():
 
 def get_orchestrator():
     return Orchestrator(redis_client=get_redis())
+
+
+@lru_cache
+def get_http_client() -> httpx.AsyncClient:
+    """Shared AsyncClient used to proxy requests to registered chapkit services.
+
+    Provided as a dependency so tests can override it with an ASGITransport-backed
+    client pointed at a stub service.
+    """
+    return httpx.AsyncClient(timeout=_PROXY_TIMEOUT)
 
 
 def verify_service_key(

--- a/chap_core/rest_api/v2/rest_api.py
+++ b/chap_core/rest_api/v2/rest_api.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
-from chap_core.rest_api.v2.routers import services
+from chap_core.rest_api.v2.routers import proxy, services
 
 router = APIRouter()
 router.include_router(services.router)
+router.include_router(proxy.router)

--- a/chap_core/rest_api/v2/routers/proxy.py
+++ b/chap_core/rest_api/v2/routers/proxy.py
@@ -109,19 +109,23 @@ async def proxy_to_service(
     except ServiceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
-    target = httpx.URL(service.url.rstrip("/") + "/" + _raw_subpath(request, service_id))
-    query_string = request.scope.get("query_string") or b""
-    if query_string:
-        target = target.copy_with(query=query_string)
-
     # Forward request headers minus hop-by-hop, Connection-nominated, and host (httpx re-derives host).
     request_headers = _forwardable(request.headers.items(), drop={"host"})
-
-    upstream_request = client.build_request(request.method, target, headers=request_headers)
+    query_string = request.scope.get("query_string") or b""
 
     try:
+        target = httpx.URL(service.url.rstrip("/") + "/" + _raw_subpath(request, service_id))
+        if query_string:
+            target = target.copy_with(query=query_string)
+        upstream_request = client.build_request(request.method, target, headers=request_headers)
         # follow_redirects so a relative upstream Location resolves against the service.
         upstream = await client.send(upstream_request, stream=True, follow_redirects=True)
+    except httpx.InvalidURL as e:
+        # A malformed registered service URL (e.g. a bad port) is a misconfigured upstream.
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Service {service_id} has an invalid URL: {e}",
+        ) from e
     except httpx.TimeoutException as e:
         raise HTTPException(
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,

--- a/chap_core/rest_api/v2/routers/proxy.py
+++ b/chap_core/rest_api/v2/routers/proxy.py
@@ -1,0 +1,105 @@
+"""Transparent reverse proxy from CHAP Core to registered chapkit service instances.
+
+Chapkit model services register with the v2 orchestrator and advertise a base URL that
+is only reachable from within CHAP Core's network. This router exposes a catch-all route
+that forwards any request under ``/v2/services/{service_id}/run/{path}`` to the registered
+service, streaming both request and response so binary artifact downloads work without
+buffering. It is the foundation for building higher-level features (artifact browser,
+config UI, job viewer) on top of chapkit.
+"""
+
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
+from starlette.background import BackgroundTask
+
+from chap_core.rest_api.services.orchestrator import Orchestrator, ServiceNotFoundError
+from chap_core.rest_api.v2.dependencies import get_http_client, get_orchestrator
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/services", tags=["Services"])
+
+# Hop-by-hop headers must not be forwarded by a proxy (RFC 7230 section 6.1).
+HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+# HEAD is intentionally omitted: Starlette auto-adds it alongside GET. Listing it
+# explicitly would register the route twice and produce a duplicate OpenAPI operation id.
+PROXY_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
+
+
+def _filter_headers(headers, drop: set[str]) -> list[tuple[str, str]]:
+    """Drop hop-by-hop and explicitly excluded headers (case-insensitive)."""
+    return [(k, v) for k, v in headers.items() if k.lower() not in HOP_BY_HOP_HEADERS and k.lower() not in drop]
+
+
+@router.api_route(
+    "/{service_id}/run/{path:path}",
+    methods=PROXY_METHODS,
+    summary="Proxy a request to a registered chapkit service",
+)
+async def proxy_to_service(
+    service_id: str,
+    path: str,
+    request: Request,
+    orchestrator: Orchestrator = Depends(get_orchestrator),
+    client: httpx.AsyncClient = Depends(get_http_client),
+) -> StreamingResponse:
+    """Forward an arbitrary request to a registered chapkit service and stream the response back.
+
+    The path below ``run/`` is forwarded verbatim, so callers use the service's real
+    paths, e.g. ``/v2/services/{id}/run/api/v1/artifacts``. Returns 404 if the service id
+    is unknown, and 502/504 if the service is unreachable or times out.
+    """
+    try:
+        service = orchestrator.get(service_id)
+    except ServiceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    target_url = service.url.rstrip("/") + "/" + path
+
+    # Let httpx re-derive host/content-length for the upstream request.
+    request_headers = _filter_headers(request.headers, drop={"host", "content-length"})
+    body = await request.body()
+
+    upstream_request = client.build_request(
+        request.method,
+        target_url,
+        params=request.query_params,
+        headers=request_headers,
+        content=body,
+    )
+
+    try:
+        upstream = await client.send(upstream_request, stream=True)
+    except httpx.TimeoutException as e:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=f"Service {service_id} did not respond in time",
+        ) from e
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Service {service_id} is unreachable: {e}",
+        ) from e
+
+    response_headers = _filter_headers(upstream.headers, drop=set())
+    return StreamingResponse(
+        upstream.aiter_raw(),
+        status_code=upstream.status_code,
+        headers=dict(response_headers),
+        background=BackgroundTask(upstream.aclose),
+    )

--- a/chap_core/rest_api/v2/routers/proxy.py
+++ b/chap_core/rest_api/v2/routers/proxy.py
@@ -10,9 +10,14 @@ without buffering. It is the foundation for read-only features built on top of c
 The proxy is intentionally limited to safe methods: mutating verbs are not exposed because
 the route is unauthenticated. Adding mutations later requires an explicit authorization
 boundary first.
+
+The path below ``run/`` is forwarded verbatim from the raw request path so reserved
+characters in artifact ids and filenames survive, and upstream redirects are followed so a
+relative ``Location`` resolves against the service rather than CHAP Core's own origin.
 """
 
 import logging
+from collections.abc import Iterable
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -44,6 +49,43 @@ HOP_BY_HOP_HEADERS = frozenset(
 PROXY_METHODS = ["GET", "HEAD"]
 
 
+def _connection_named_headers(header_pairs: Iterable[tuple[str, str]]) -> set[str]:
+    """Header names nominated as hop-by-hop by a ``Connection`` header (RFC 7230 section 6.1)."""
+    drop: set[str] = set()
+    for key, value in header_pairs:
+        if key.lower() != "connection":
+            continue
+        for token in value.split(","):
+            normalized = token.strip().lower()
+            if normalized and normalized not in ("close", "keep-alive"):
+                drop.add(normalized)
+    return drop
+
+
+def _forwardable(header_pairs: Iterable[tuple[str, str]], drop: set[str]) -> list[tuple[str, str]]:
+    """Filter out hop-by-hop, Connection-nominated, and explicitly excluded headers."""
+    pairs = list(header_pairs)
+    excluded = HOP_BY_HOP_HEADERS | drop | _connection_named_headers(pairs)
+    return [(k, v) for k, v in pairs if k.lower() not in excluded]
+
+
+def _raw_subpath(request: Request, service_id: str) -> str:
+    """The still-percent-encoded path below ``run/``.
+
+    FastAPI decodes ``{path}`` (turning ``a%2Fb`` into ``a/b``), so we slice the original
+    encoded path out of the ASGI ``raw_path`` to forward reserved characters verbatim.
+    """
+    raw_path = request.scope.get("raw_path")
+    if raw_path is None:
+        return str(request.path_params["path"])
+    text: str = raw_path.decode("ascii")
+    marker = f"/{service_id}/run/"
+    index = text.find(marker)
+    if index == -1:
+        return str(request.path_params["path"])
+    return text[index + len(marker) :]
+
+
 @router.api_route(
     "/{service_id}/run/{path:path}",
     methods=PROXY_METHODS,
@@ -67,22 +109,19 @@ async def proxy_to_service(
     except ServiceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
-    target_url = service.url.rstrip("/") + "/" + path
+    target = httpx.URL(service.url.rstrip("/") + "/" + _raw_subpath(request, service_id))
+    query_string = request.scope.get("query_string") or b""
+    if query_string:
+        target = target.copy_with(query=query_string)
 
-    # Forward request headers minus hop-by-hop and host (httpx re-derives host).
-    request_headers = [
-        (k, v) for k, v in request.headers.items() if k.lower() not in HOP_BY_HOP_HEADERS and k.lower() != "host"
-    ]
+    # Forward request headers minus hop-by-hop, Connection-nominated, and host (httpx re-derives host).
+    request_headers = _forwardable(request.headers.items(), drop={"host"})
 
-    upstream_request = client.build_request(
-        request.method,
-        target_url,
-        params=request.query_params,
-        headers=request_headers,
-    )
+    upstream_request = client.build_request(request.method, target, headers=request_headers)
 
     try:
-        upstream = await client.send(upstream_request, stream=True)
+        # follow_redirects so a relative upstream Location resolves against the service.
+        upstream = await client.send(upstream_request, stream=True, follow_redirects=True)
     except httpx.TimeoutException as e:
         raise HTTPException(
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
@@ -99,11 +138,8 @@ async def proxy_to_service(
         status_code=upstream.status_code,
         background=BackgroundTask(upstream.aclose),
     )
-    # Use multi_items() and assign raw_headers so repeated headers (e.g. Set-Cookie) are
-    # preserved as distinct entries rather than collapsed into one comma-joined value.
-    response.raw_headers = [
-        (k.encode("latin-1"), v.encode("latin-1"))
-        for k, v in upstream.headers.multi_items()
-        if k.lower() not in HOP_BY_HOP_HEADERS
-    ]
+    # multi_items() + raw_headers so repeated headers (e.g. Set-Cookie) are preserved as
+    # distinct entries rather than collapsed into one comma-joined value.
+    response_headers = _forwardable(upstream.headers.multi_items(), drop=set())
+    response.raw_headers = [(k.encode("latin-1"), v.encode("latin-1")) for k, v in response_headers]
     return response

--- a/chap_core/rest_api/v2/routers/proxy.py
+++ b/chap_core/rest_api/v2/routers/proxy.py
@@ -1,11 +1,15 @@
-"""Transparent reverse proxy from CHAP Core to registered chapkit service instances.
+"""Read-only reverse proxy from CHAP Core to registered chapkit service instances.
 
 Chapkit model services register with the v2 orchestrator and advertise a base URL that
 is only reachable from within CHAP Core's network. This router exposes a catch-all route
-that forwards any request under ``/v2/services/{service_id}/run/{path}`` to the registered
-service, streaming both request and response so binary artifact downloads work without
-buffering. It is the foundation for building higher-level features (artifact browser,
-config UI, job viewer) on top of chapkit.
+that forwards read-only (GET/HEAD) requests under ``/v2/services/{service_id}/run/{path}``
+to the registered service, streaming the response back so binary artifact downloads work
+without buffering. It is the foundation for read-only features built on top of chapkit
+(artifact browser, config inspection, job viewer).
+
+The proxy is intentionally limited to safe methods: mutating verbs are not exposed because
+the route is unauthenticated. Adding mutations later requires an explicit authorization
+boundary first.
 """
 
 import logging
@@ -36,20 +40,14 @@ HOP_BY_HOP_HEADERS = frozenset(
     }
 )
 
-# HEAD is intentionally omitted: Starlette auto-adds it alongside GET. Listing it
-# explicitly would register the route twice and produce a duplicate OpenAPI operation id.
-PROXY_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
-
-
-def _filter_headers(headers, drop: set[str]) -> list[tuple[str, str]]:
-    """Drop hop-by-hop and explicitly excluded headers (case-insensitive)."""
-    return [(k, v) for k, v in headers.items() if k.lower() not in HOP_BY_HOP_HEADERS and k.lower() not in drop]
+# Read-only only. FastAPI does not auto-add HEAD, so it is listed explicitly.
+PROXY_METHODS = ["GET", "HEAD"]
 
 
 @router.api_route(
     "/{service_id}/run/{path:path}",
     methods=PROXY_METHODS,
-    summary="Proxy a request to a registered chapkit service",
+    summary="Proxy a read-only request to a registered chapkit service",
 )
 async def proxy_to_service(
     service_id: str,
@@ -58,7 +56,7 @@ async def proxy_to_service(
     orchestrator: Orchestrator = Depends(get_orchestrator),
     client: httpx.AsyncClient = Depends(get_http_client),
 ) -> StreamingResponse:
-    """Forward an arbitrary request to a registered chapkit service and stream the response back.
+    """Forward a read-only request to a registered chapkit service and stream the response back.
 
     The path below ``run/`` is forwarded verbatim, so callers use the service's real
     paths, e.g. ``/v2/services/{id}/run/api/v1/artifacts``. Returns 404 if the service id
@@ -71,16 +69,16 @@ async def proxy_to_service(
 
     target_url = service.url.rstrip("/") + "/" + path
 
-    # Let httpx re-derive host/content-length for the upstream request.
-    request_headers = _filter_headers(request.headers, drop={"host", "content-length"})
-    body = await request.body()
+    # Forward request headers minus hop-by-hop and host (httpx re-derives host).
+    request_headers = [
+        (k, v) for k, v in request.headers.items() if k.lower() not in HOP_BY_HOP_HEADERS and k.lower() != "host"
+    ]
 
     upstream_request = client.build_request(
         request.method,
         target_url,
         params=request.query_params,
         headers=request_headers,
-        content=body,
     )
 
     try:
@@ -96,10 +94,16 @@ async def proxy_to_service(
             detail=f"Service {service_id} is unreachable: {e}",
         ) from e
 
-    response_headers = _filter_headers(upstream.headers, drop=set())
-    return StreamingResponse(
+    response = StreamingResponse(
         upstream.aiter_raw(),
         status_code=upstream.status_code,
-        headers=dict(response_headers),
         background=BackgroundTask(upstream.aclose),
     )
+    # Use multi_items() and assign raw_headers so repeated headers (e.g. Set-Cookie) are
+    # preserved as distinct entries rather than collapsed into one comma-joined value.
+    response.raw_headers = [
+        (k.encode("latin-1"), v.encode("latin-1"))
+        for k, v in upstream.headers.multi_items()
+        if k.lower() not in HOP_BY_HOP_HEADERS
+    ]
+    return response

--- a/tests/integration/rest_api/test_services_proxy_router.py
+++ b/tests/integration/rest_api/test_services_proxy_router.py
@@ -184,6 +184,33 @@ def test_unknown_service_returns_404(client):
     assert response.status_code == 404
 
 
+def test_malformed_service_url_returns_502():
+    orchestrator = Orchestrator(redis_client=fakeredis.FakeRedis())
+    orchestrator.register(
+        RegistrationRequest.model_validate(
+            {
+                "url": "http://host:bad",
+                "info": {
+                    "id": "bad-url-model",
+                    "display_name": "Bad URL Model",
+                    "model_metadata": {"author": "Test"},
+                    "period_type": "monthly",
+                },
+            }
+        )
+    )
+
+    app.dependency_overrides[get_orchestrator] = lambda: orchestrator
+    app.dependency_overrides[get_http_client] = lambda: httpx.AsyncClient()
+    try:
+        test_client = TestClient(app, raise_server_exceptions=False)
+        response = test_client.get("/v2/services/bad-url-model/run/api/v1/info")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 502
+
+
 def test_unreachable_service_returns_502(test_orchestrator):
     def raise_connect_error(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("connection refused", request=request)

--- a/tests/integration/rest_api/test_services_proxy_router.py
+++ b/tests/integration/rest_api/test_services_proxy_router.py
@@ -2,6 +2,7 @@ import fakeredis
 import httpx
 import pytest
 from fastapi import FastAPI, Request, Response
+from fastapi.responses import RedirectResponse
 from fastapi.testclient import TestClient
 
 from chap_core.rest_api.app import app
@@ -41,6 +42,25 @@ def stub_app():
         response = Response(content=b"ok")
         response.headers.append("set-cookie", "a=1")
         response.headers.append("set-cookie", "b=2")
+        return response
+
+    @stub.get("/api/v1/redirect")
+    async def redirect():
+        return RedirectResponse(url="/api/v1/echo/landed", status_code=307)
+
+    @stub.get("/raw/{rest:path}")
+    async def raw_echo(rest: str, request: Request):
+        return {"raw_path": request.scope["raw_path"].decode("ascii")}
+
+    @stub.get("/api/v1/seen-headers")
+    async def seen_headers(request: Request):
+        return {"headers": [k.lower() for k in request.headers.keys()]}
+
+    @stub.get("/api/v1/conn-response")
+    async def conn_response():
+        response = Response(content=b"ok")
+        response.headers["x-resp-secret"] = "value"
+        response.headers["connection"] = "x-resp-secret"
         return response
 
     return stub
@@ -121,6 +141,41 @@ def test_binary_download_preserves_body_and_headers(client):
     assert response.content == b"\x00\x01\x02chap"
     assert response.headers["content-type"] == "application/octet-stream"
     assert response.headers["content-disposition"] == 'attachment; filename="artifact.bin"'
+
+
+def test_upstream_redirect_is_followed(client):
+    response = client.get(f"/v2/services/{SERVICE_ID}/run/api/v1/redirect")
+
+    assert response.status_code == 200
+    assert response.json()["path"] == "landed"
+
+
+def test_encoded_path_forwarded_verbatim(client):
+    response = client.get(f"/v2/services/{SERVICE_ID}/run/raw/a%2Fb")
+
+    assert response.status_code == 200
+    assert response.json()["raw_path"] == "/raw/a%2Fb"
+
+
+def test_connection_nominated_request_header_dropped(client):
+    response = client.get(
+        f"/v2/services/{SERVICE_ID}/run/api/v1/seen-headers",
+        headers={"Connection": "x-secret", "X-Secret": "value", "X-Keep": "ok"},
+    )
+
+    # The header nominated by Connection is dropped; the unrelated one passes through.
+    # (httpx re-adds its own Connection header for the upstream hop, which is expected.)
+    seen = response.json()["headers"]
+    assert "x-secret" not in seen
+    assert "x-keep" in seen
+
+
+def test_connection_nominated_response_header_dropped(client):
+    response = client.get(f"/v2/services/{SERVICE_ID}/run/api/v1/conn-response")
+
+    assert response.status_code == 200
+    assert "x-resp-secret" not in response.headers
+    assert "connection" not in response.headers
 
 
 def test_unknown_service_returns_404(client):

--- a/tests/integration/rest_api/test_services_proxy_router.py
+++ b/tests/integration/rest_api/test_services_proxy_router.py
@@ -1,0 +1,128 @@
+import fakeredis
+import httpx
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from chap_core.rest_api.app import app
+from chap_core.rest_api.services.orchestrator import Orchestrator
+from chap_core.rest_api.services.schemas import RegistrationRequest
+from chap_core.rest_api.v2.dependencies import get_http_client, get_orchestrator
+
+SERVICE_ID = "stub-model"
+SERVICE_URL = "http://stub-service"
+
+
+@pytest.fixture
+def stub_app():
+    """A minimal stand-in for a chapkit service that echoes what it received."""
+    stub = FastAPI()
+
+    @stub.api_route("/api/v1/echo/{rest:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+    async def echo(rest: str, request: Request):
+        body = await request.body()
+        return {
+            "method": request.method,
+            "path": rest,
+            "query": dict(request.query_params),
+            "body": body.decode() or None,
+        }
+
+    @stub.get("/api/v1/artifacts/$download")
+    async def download():
+        return Response(
+            content=b"\x00\x01\x02chap",
+            media_type="application/octet-stream",
+            headers={"content-disposition": 'attachment; filename="artifact.bin"'},
+        )
+
+    return stub
+
+
+@pytest.fixture
+def test_orchestrator():
+    orchestrator = Orchestrator(redis_client=fakeredis.FakeRedis())
+    orchestrator.register(
+        RegistrationRequest.model_validate(
+            {
+                "url": SERVICE_URL,
+                "info": {
+                    "id": SERVICE_ID,
+                    "display_name": "Stub Model",
+                    "model_metadata": {"author": "Test"},
+                    "period_type": "monthly",
+                },
+            }
+        )
+    )
+    return orchestrator
+
+
+@pytest.fixture
+def client(test_orchestrator, stub_app):
+    stub_client = httpx.AsyncClient(transport=httpx.ASGITransport(app=stub_app))
+
+    app.dependency_overrides[get_orchestrator] = lambda: test_orchestrator
+    app.dependency_overrides[get_http_client] = lambda: stub_client
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def test_get_passthrough(client):
+    response = client.get(f"/v2/services/{SERVICE_ID}/run/api/v1/echo/here")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["method"] == "GET"
+    assert data["path"] == "here"
+
+
+def test_query_string_forwarded(client):
+    response = client.get(f"/v2/services/{SERVICE_ID}/run/api/v1/echo/x?page=2&size=10")
+
+    assert response.status_code == 200
+    assert response.json()["query"] == {"page": "2", "size": "10"}
+
+
+def test_post_body_and_method_forwarded(client):
+    response = client.post(
+        f"/v2/services/{SERVICE_ID}/run/api/v1/echo/configs",
+        json={"name": "demo"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["method"] == "POST"
+    assert data["body"] == '{"name":"demo"}'
+
+
+def test_binary_download_preserves_body_and_headers(client):
+    response = client.get(f"/v2/services/{SERVICE_ID}/run/api/v1/artifacts/$download")
+
+    assert response.status_code == 200
+    assert response.content == b"\x00\x01\x02chap"
+    assert response.headers["content-type"] == "application/octet-stream"
+    assert response.headers["content-disposition"] == 'attachment; filename="artifact.bin"'
+
+
+def test_unknown_service_returns_404(client):
+    response = client.get("/v2/services/does-not-exist/run/api/v1/echo/x")
+
+    assert response.status_code == 404
+
+
+def test_unreachable_service_returns_502(test_orchestrator):
+    def raise_connect_error(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    dead_client = httpx.AsyncClient(transport=httpx.MockTransport(raise_connect_error))
+
+    app.dependency_overrides[get_orchestrator] = lambda: test_orchestrator
+    app.dependency_overrides[get_http_client] = lambda: dead_client
+    try:
+        test_client = TestClient(app, raise_server_exceptions=False)
+        response = test_client.get(f"/v2/services/{SERVICE_ID}/run/api/v1/echo/x")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 502

--- a/tests/integration/rest_api/test_services_proxy_router.py
+++ b/tests/integration/rest_api/test_services_proxy_router.py
@@ -18,7 +18,7 @@ def stub_app():
     """A minimal stand-in for a chapkit service that echoes what it received."""
     stub = FastAPI()
 
-    @stub.api_route("/api/v1/echo/{rest:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
+    @stub.api_route("/api/v1/echo/{rest:path}", methods=["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"])
     async def echo(rest: str, request: Request):
         body = await request.body()
         return {
@@ -35,6 +35,13 @@ def stub_app():
             media_type="application/octet-stream",
             headers={"content-disposition": 'attachment; filename="artifact.bin"'},
         )
+
+    @stub.get("/api/v1/multi-cookie")
+    async def multi_cookie():
+        response = Response(content=b"ok")
+        response.headers.append("set-cookie", "a=1")
+        response.headers.append("set-cookie", "b=2")
+        return response
 
     return stub
 
@@ -84,16 +91,27 @@ def test_query_string_forwarded(client):
     assert response.json()["query"] == {"page": "2", "size": "10"}
 
 
-def test_post_body_and_method_forwarded(client):
+def test_head_request_allowed(client):
+    response = client.head(f"/v2/services/{SERVICE_ID}/run/api/v1/echo/here")
+
+    assert response.status_code == 200
+    assert response.content == b""
+
+
+def test_mutating_method_not_allowed(client):
     response = client.post(
         f"/v2/services/{SERVICE_ID}/run/api/v1/echo/configs",
         json={"name": "demo"},
     )
 
+    assert response.status_code == 405
+
+
+def test_repeated_response_headers_preserved(client):
+    response = client.get(f"/v2/services/{SERVICE_ID}/run/api/v1/multi-cookie")
+
     assert response.status_code == 200
-    data = response.json()
-    assert data["method"] == "POST"
-    assert data["body"] == '{"name":"demo"}'
+    assert response.headers.get_list("set-cookie") == ["a=1", "b=2"]
 
 
 def test_binary_download_preserves_body_and_headers(client):


### PR DESCRIPTION
## Context

chapkit model services register with CHAP Core's v2 registry and advertise a base URL that is only reachable from within CHAP Core's network. Until now there was no way for a CHAP Core / DHIS2 / CHAP frontend caller to reach the rest of a chapkit instance's API (artifacts, configs, jobs, system) — CHAP Core only consumed a narrow slice (train/predict/info/health).

This adds a transparent, read-only reverse proxy that forwards requests to the registered chapkit instance and streams the response back. It is the foundation for building read-only features (artifact browser, config inspection, job viewer) on top of chapkit without each one needing a bespoke CHAP Core endpoint.

## What

New catch-all route:

```
GET|HEAD /api/v2/services/{service_id}/run/{path}
```

The target URL is resolved from the orchestrator (`ServiceDetail.url`), the request is forwarded with `httpx.AsyncClient`, and the response is streamed back so binary artifact downloads (`$download`) work without buffering.

### Behaviour decisions
- **Method scope:** read-only — `GET` and `HEAD` only. Mutating verbs are intentionally not exposed because the route is unauthenticated; adding them later requires an explicit authorization boundary first.
- **Auth:** open, matching CHAP Core's existing unauthenticated read endpoints (`GET /v2/services`). The network/deployment boundary is the trust boundary. The HTTP client is injected via a `get_http_client` dependency, leaving room to add an auth dependency later without changing the route.
- **Path mapping:** transparent verbatim forward. `/api/v2/services/{id}/run/api/v1/artifacts?page=1` -> `{service.url}/api/v1/artifacts?page=1`.

### Proxy correctness
- **Verbatim paths:** the forwarded path is sliced from the raw request path (ASGI `raw_path`) and the raw query string, so reserved characters in artifact ids and filenames (e.g. `%2F`) survive instead of being decoded by FastAPI's path converter.
- **Redirects:** upstream redirects are followed, so a relative `Location` (e.g. a FastAPI trailing-slash 307) resolves against the service rather than leaking to CHAP Core's own origin.
- **Headers:** hop-by-hop headers, headers nominated by the `Connection` header, and `host` are stripped before forwarding; on the response, repeated headers (e.g. `Set-Cookie`) are preserved as distinct entries rather than collapsed into one comma-joined value; `content-type` / `content-disposition` are preserved.
- **Failure handling:** unknown service -> 404; unreachable upstream or malformed registered URL -> 502; upstream timeout -> 504.

## Files
- `chap_core/rest_api/v2/routers/proxy.py` — new read-only proxy router.
- `chap_core/rest_api/v2/dependencies.py` — `get_http_client()` + shared `AsyncClient`.
- `chap_core/rest_api/v2/rest_api.py` — mount the proxy router.
- `tests/integration/rest_api/test_services_proxy_router.py` — new tests.

## Testing
New tests stand up a stub chapkit FastAPI app and route the proxy's client at it via `ASGITransport`, exercising the proxy end-to-end: GET passthrough, query-string forwarding, HEAD support, binary download (body + headers preserved), repeated `Set-Cookie` preserved, upstream redirect followed, encoded path forwarded verbatim, `Connection`-nominated headers dropped in both directions, mutating method -> 405, unknown service -> 404, unreachable service -> 502, malformed registered URL -> 502. `make lint` and `make test` both pass.

## Manual verification
1. Start CHAP Core's API (Redis up) and the EWARS chapkit example so it self-registers.
2. `GET /api/v2/services` -> confirm `chapkit-ewars-model`.
3. `GET /api/v2/services/chapkit-ewars-model/run/api/v1/info` -> chapkit `MLServiceInfo`.
4. `GET /api/v2/services/chapkit-ewars-model/run/api/v1/artifacts` -> artifact list.
5. `GET /api/v2/services/chapkit-ewars-model/run/health` -> `{"status": "healthy"}`.




[CLIM-776]: https://dhis2.atlassian.net/browse/CLIM-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
