### PR TITLE
fix(ci): skip release and publish workflows when running in forks

### DIFF
--- a/.github/workflows/ci-build-docker-images.yml
+++ b/.github/workflows/ci-build-docker-images.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   build-and-push:
+    if: github.repository == 'dhis2-chap/chap-core'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/push-to-pypi.yml
+++ b/.github/workflows/push-to-pypi.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository == 'dhis2-chap/chap-core'
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'dhis2-chap/chap-core'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   trigger-docs:
+    if: github.repository == 'dhis2-chap/chap-core'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger chap-site deploy


### PR DESCRIPTION
## Summary

Adds `if: github.repository == 'dhis2-chap/chap-core'` job guards to the four workflows that publish artifacts or need upstream secrets:

- `ci-build-docker-images.yml` (pushes to ghcr.io)
- `trigger-docs-deploy.yml` (needs `CHAP_SITE_DEPLOY_TOKEN`)
- `push-to-pypi.yml` (PyPI trusted publishing)
- `release-chart.yaml` (pushes Helm charts to gh-pages)

## Why

Forks with Actions enabled run these workflows on every push to their `master`, where they fail immediately (no secrets, no registry write access) and email the commit author. This is especially noisy when a maintainer clicks "Update branch" on a fork PR: the merge commit is authored by the maintainer and pushed to the fork, so the maintainer gets the failure spam. The `release-chart` job is worse than noisy: it actually succeeds in forks and creates a stray `gh-pages` branch there.

Plain CI workflows (lint, tests, docs build) are intentionally left unguarded since those are useful signal on fork branches.

No CI-relevant code changes; `make lint` passes.