### PR TITLE
feat: split sample bias plot into per-horizon and per-time-period plots

### DIFF
--- a/chap_core/assessment/backtest_plots/sample_bias_plot.py
+++ b/chap_core/assessment/backtest_plots/sample_bias_plot.py
@@ -1,8 +1,8 @@
 """
-Sample bias plot for backtests.
+Sample bias plots for backtests.
 
-This module provides a backtest plot that shows the ratio of forecast samples
-above truth by horizon distance and time period.
+This module provides backtest plots that show the ratio of forecast samples
+above truth, one by horizon distance and one by time period.
 """
 
 import altair as alt
@@ -11,26 +11,22 @@ import pandas as pd
 from chap_core.assessment.backtest_plots import ChartType, FacetDimension, FacetedBacktestPlot, backtest_plot
 from chap_core.assessment.flat_representations import FlatForecasts, FlatObserved
 from chap_core.assessment.metrics import RatioAboveTruthMetric
-from chap_core.plotting.backtest_plot import text_chart
 
-
-@backtest_plot(
-    plot_id="ratio_of_samples_above_truth",
-    name="Sample Bias Plot",
-    description="Backtest plot showing forecast bias relative to observations.",
+_BIAS_DESCRIPTION = (
+    "Shows biases in the samples returned by the model, specifically whether the samples "
+    "generally are over or under the true observation. This can be used to assess model "
+    "calibration and tendency to over- or under-predict."
 )
-class SampleBiasPlot(FacetedBacktestPlot):
+
+
+class SampleBiasPlotBase(FacetedBacktestPlot):
     """
-    Backtest plot showing forecast bias relative to observations.
+    Shared preprocessing for the sample bias plots.
 
-    This plot shows the ratio of forecast samples that are above the true
-    observation value, organized by:
-    - Horizon distance (how far ahead the forecast is)
-    - Time period and location (when/where the observation occurred)
-
-    It is an aggregate dashboard with no per-coordinate decomposition, so it
-    declares no facet dimensions; it conforms to the faceting interface only so
-    every registered plot shares the same shape.
+    Computes the ratio of forecast samples that are above the true observation
+    value per forecast row. The plots are aggregates with no per-coordinate
+    decomposition, so they declare no facet dimensions; they conform to the
+    faceting interface only so every registered plot shares the same shape.
     """
 
     facet_dimensions: list[FacetDimension] = []
@@ -47,54 +43,42 @@ class SampleBiasPlot(FacetedBacktestPlot):
         metric = RatioAboveTruthMetric()
         return metric.get_detailed_metric(flat_observations, flat_forecasts)
 
+
+@backtest_plot(
+    plot_id="sample_bias_by_horizon",
+    name="Sample Bias by Horizon",
+    description=f"Ratio of forecast samples above truth per forecast horizon. {_BIAS_DESCRIPTION}",
+)
+class SampleBiasByHorizonPlot(SampleBiasPlotBase):
+    """Bar chart of the mean ratio of samples above truth per forecast horizon."""
+
     def _plot(self, metric_df: pd.DataFrame) -> ChartType:
-        """Render the bias dashboard from the metric frame."""
-        charts = []
-
-        # Title
-        charts.append(
-            alt.Chart()
-            .mark_text(align="left", fontSize=20, fontWeight="bold")
-            .encode(text=alt.value("Sample Bias Dashboard"))
-            .properties(height=24)
-        )
-
-        charts.append(
-            text_chart(
-                "These plots show biases in the samples returned by the model, "
-                "\nspecifically whether the samples generally are over or under the true observation.\n"
-                "This can be used to assess model calibration and tendency to over- or under-predict.",
-                line_length=50,
-            )
-        )
-
-        # By horizon: aggregate by horizon_distance (mean across locations and time periods)
         horizon_df = metric_df.groupby(["horizon_distance"]).agg({"metric": "mean"}).reset_index()
-        horizon_chart = (
+        return (  # type: ignore[no-any-return]
             alt.Chart(horizon_df)
-            .mark_bar(point=True)
+            .mark_bar()
             .encode(
                 x=alt.X("horizon_distance:O", title="Horizon (periods ahead)"),
                 y=alt.Y("metric:Q", title="Ratio of samples above truth"),
                 tooltip=["horizon_distance", "metric"],
             )
-            .properties(
-                width=600,
-                height=400,
-                title={
-                    "text": "Ratio of samples above truth by horizon",
-                    "subtitle": "Ratio (0.0-1.0) of forecast samples > truth. x-axis: forecast horizon distance",
-                    "anchor": "start",
-                    "fontSize": 16,
-                    "subtitleFontSize": 12,
-                },
-            )
+            .properties(height=300)
         )
-        charts.append(horizon_chart)
 
-        # By time period and location: aggregate by time_period and location (mean across horizons)
+
+@backtest_plot(
+    plot_id="sample_bias_by_time_period",
+    name="Sample Bias by Time Period",
+    description=(
+        f"Ratio of forecast samples above truth over time periods, one line per location. {_BIAS_DESCRIPTION}"
+    ),
+)
+class SampleBiasByTimePeriodPlot(SampleBiasPlotBase):
+    """Line chart of the mean ratio of samples above truth per time period and location."""
+
+    def _plot(self, metric_df: pd.DataFrame) -> ChartType:
         time_df = metric_df.groupby(["time_period", "location"]).agg({"metric": "mean"}).reset_index()
-        time_chart = (
+        return (  # type: ignore[no-any-return]
             alt.Chart(time_df)
             .mark_line(point=True)
             .encode(
@@ -103,25 +87,5 @@ class SampleBiasPlot(FacetedBacktestPlot):
                 color=alt.Color("location:N", title="Location"),
                 tooltip=["time_period", "location", "metric"],
             )
-            .properties(
-                width=600,
-                height=400,
-                title={
-                    "text": "Ratio of samples above truth by time period",
-                    "subtitle": "Ratio (0.0-1.0) of forecast samples > truth. x-axis: time period of observation",
-                    "anchor": "start",
-                    "fontSize": 16,
-                    "subtitleFontSize": 12,
-                },
-            )
+            .properties(height=300)
         )
-        charts.append(time_chart)
-
-        # Combine all charts vertically
-        dashboard = alt.vconcat(*charts).configure(
-            axis={"labelFontSize": 11, "titleFontSize": 12},
-            legend={"labelFontSize": 11, "titleFontSize": 12},
-            view={"stroke": None},
-        )
-
-        return dashboard  # type: ignore[no-any-return]

--- a/chap_core/cli_endpoints/generated_plot_ids.py
+++ b/chap_core/cli_endpoints/generated_plot_ids.py
@@ -9,5 +9,6 @@ BACKTEST_PLOT_IDS: tuple[str, ...] = (
     "horizon_location_grid",
     "predicted_vs_actual",
     "predicted_vs_actual_linear",
-    "ratio_of_samples_above_truth",
+    "sample_bias_by_horizon",
+    "sample_bias_by_time_period",
 )

--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -221,16 +221,33 @@ def generate_backtest_plots(visualization_name: str, backtest_id: int, session: 
     return JSONResponse(chart.to_dict(format="vega"))
 
 
-def _fill_container_width(chart: alt.TopLevelMixin) -> alt.TopLevelMixin:
-    """Make a subplot fill its width when the frontend embeds it in a flexible container.
+def _fill_container_width(chart: alt.TopLevelMixin) -> dict[str, Any]:
+    """Compile a subplot to a Vega spec that fills its width when the frontend embeds
+    it in a flexible container (height is left at the plot's fixed value).
 
-    Single-view charts get ``width='container'`` (height is left at the plot's fixed
-    value). Multi-view (concat) and faceted specs can't use container sizing, so their
-    fixed widths are returned untouched.
+    Single-view charts get ``width='container'`` before compiling. Vertically
+    concatenated charts can't use container sizing in Vega-Lite, but when every row
+    shares one width the compiler hoists it to a single top-level ``width`` that all
+    row groups reference; replacing that fixed value with a ``containerSize()``-driven
+    signal in the compiled Vega spec makes the whole stack responsive (the original
+    width stays as the fallback outside a sized DOM container). Other multi-view
+    (concat/facet) specs keep their fixed widths.
     """
-    if isinstance(chart, (alt.ConcatChart, alt.HConcatChart, alt.VConcatChart, alt.FacetChart)):
-        return chart
-    return chart.properties(width="container")
+    if isinstance(chart, alt.VConcatChart):
+        spec = cast("dict[str, Any]", chart.to_dict(format="vega"))
+        if not isinstance(spec.get("width"), (int, float)):
+            return spec
+        fallback = spec.pop("width")
+        expr = f"isFinite(containerSize()[0]) ? containerSize()[0] : {fallback}"
+        spec["autosize"] = {"type": "fit-x", "contains": "padding"}
+        spec.setdefault("signals", []).insert(
+            0,
+            {"name": "width", "init": expr, "on": [{"update": expr, "events": "window:resize"}]},
+        )
+        return spec
+    if isinstance(chart, (alt.ConcatChart, alt.HConcatChart, alt.FacetChart)):
+        return cast("dict[str, Any]", chart.to_dict(format="vega"))
+    return cast("dict[str, Any]", chart.properties(width="container").to_dict(format="vega"))
 
 
 def _get_faceted_plotter_and_backtest(
@@ -309,7 +326,7 @@ def generate_isolated_plots(
         facet_coords,
         cast("Any", flat_data.historical_observations),
     )
-    return JSONResponse(_fill_container_width(chart).to_dict(format="vega"))
+    return JSONResponse(_fill_container_width(chart))
 
 
 @router.get("/backtest-plots/{visualization_name}/{backtest_id}/subplots")
@@ -328,6 +345,4 @@ def generate_all_subplots(
         observations, forecasts, coords=coords_matrix, historical_observations=historical_df
     )
 
-    return [
-        {"key": key, "spec": _fill_container_width(subplot).to_dict(format="vega")} for key, subplot in subplot_tuples
-    ]
+    return [{"key": key, "spec": _fill_container_width(subplot)} for key, subplot in subplot_tuples]

--- a/docs/chap-cli/evaluation-workflow.md
+++ b/docs/chap-cli/evaluation-workflow.md
@@ -111,7 +111,8 @@ chap plot-backtest \
 | `evaluation_plot` | Evaluation summary plot with forecasts vs observations and uncertainty bands |
 | `horizon_location_grid` | Grid of forecast intervals and metrics across locations and forecast horizons |
 | `predicted_vs_actual` | Scatter of predicted (median) vs actual values, faceted by horizon |
-| `ratio_of_samples_above_truth` | Shows forecast bias relative to observations |
+| `sample_bias_by_horizon` | Ratio of forecast samples above truth per forecast horizon |
+| `sample_bias_by_time_period` | Ratio of forecast samples above truth over time periods, one line per location |
 
 ### Output Formats
 

--- a/docs/contributor/creating_custom_backtest_plots.md
+++ b/docs/contributor/creating_custom_backtest_plots.md
@@ -234,7 +234,7 @@ from chap_core.assessment.evaluation import Evaluation
 evaluation = Evaluation.from_file("example_data/example_evaluation.nc")
 
 # Create a plot (using a built-in plot type)
-chart = create_plot_from_evaluation("ratio_of_samples_above_truth", evaluation)
+chart = create_plot_from_evaluation("sample_bias_by_horizon", evaluation)
 
 # Save to HTML for inspection (uncomment to save)
 # chart.save("my_plot.html")
@@ -372,7 +372,7 @@ Study these existing implementations as examples:
 
 | File | Description |
 |------|-------------|
-| `sample_bias_plot.py` | Aggregate dashboard with no facet dimensions |
+| `sample_bias_plot.py` | Aggregate plots with no facet dimensions |
 | `predicted_vs_actual_plot.py` | Horizon-faceted scatter of predicted vs actual |
 | `evaluation_plot.py` | Complex faceted plot with historical context |
 
@@ -413,7 +413,7 @@ registry = get_backtest_plots_registry()
 
 # Get a specific plot class
 from chap_core.assessment.backtest_plots import get_backtest_plot
-plot_cls = get_backtest_plot("ratio_of_samples_above_truth")
+plot_cls = get_backtest_plot("sample_bias_by_horizon")
 
 # List all plots with metadata
 from chap_core.assessment.backtest_plots import list_backtest_plots

--- a/tests/evaluation/test_backtest_plot.py
+++ b/tests/evaluation/test_backtest_plot.py
@@ -17,7 +17,7 @@ from chap_core.assessment.backtest_plots.horizon_location_grid import HorizonLoc
 from chap_core.plotting.backtest_plot import clean_time
 from chap_core.assessment.backtest_plots.predicted_vs_actual_linear_plot import PredictedVsActualLinearPlot
 from chap_core.assessment.backtest_plots.predicted_vs_actual_plot import PredictedVsActualPlot
-from chap_core.assessment.backtest_plots.sample_bias_plot import SampleBiasPlot
+from chap_core.assessment.backtest_plots.sample_bias_plot import SampleBiasByHorizonPlot, SampleBiasByTimePeriodPlot
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.cli_endpoints.utils import plot_backtest
 from chap_core.database.tables import Backtest
@@ -29,8 +29,11 @@ def test_backtest_plot_registry():
 
     # Check that expected plots are registered
     assert "horizon_location_grid" in registry
-    assert "ratio_of_samples_above_truth" in registry
+    assert "sample_bias_by_horizon" in registry
+    assert "sample_bias_by_time_period" in registry
     assert "evaluation_plot" in registry
+    # The combined dashboard was split into the two plots above
+    assert "ratio_of_samples_above_truth" not in registry
 
     # Check that all registered plots are subclasses of BacktestPlotBase
     for plot_id, plot_cls in registry.items():
@@ -42,8 +45,11 @@ def test_get_backtest_plot():
     plot_cls = get_backtest_plot("horizon_location_grid")
     assert plot_cls is HorizonLocationGridPlot
 
-    plot_cls = get_backtest_plot("ratio_of_samples_above_truth")
-    assert plot_cls is SampleBiasPlot
+    plot_cls = get_backtest_plot("sample_bias_by_horizon")
+    assert plot_cls is SampleBiasByHorizonPlot
+
+    plot_cls = get_backtest_plot("sample_bias_by_time_period")
+    assert plot_cls is SampleBiasByTimePeriodPlot
 
     plot_cls = get_backtest_plot("evaluation_plot")
     assert plot_cls is EvaluationPlot
@@ -72,11 +78,15 @@ def test_evaluation_plot_directly(flat_observations, flat_forecasts, default_tra
     assert chart is not None
 
 
-def test_sample_bias_plot_directly(flat_observations, flat_forecasts, default_transformer):
-    """Test the sample bias plot with flat data."""
-    plot = SampleBiasPlot()
+@pytest.mark.parametrize("plot_cls", [SampleBiasByHorizonPlot, SampleBiasByTimePeriodPlot])
+def test_sample_bias_plots_directly(plot_cls, flat_observations, flat_forecasts, default_transformer):
+    """Test the sample bias plots produce single-view charts with flat data."""
+    plot = plot_cls()
     chart = plot.plot(pd.DataFrame(flat_observations), pd.DataFrame(flat_forecasts))
     assert chart is not None
+    spec = chart.to_dict()
+    assert "vconcat" not in spec and "hconcat" not in spec
+    assert spec["height"] == 300
 
 
 def test_horizon_location_grid_directly(flat_observations, flat_forecasts_multiple_samples, default_transformer):

--- a/tests/evaluation/test_backtest_plot_faceting.py
+++ b/tests/evaluation/test_backtest_plot_faceting.py
@@ -58,7 +58,7 @@ from chap_core.assessment.backtest_plots.predicted_vs_actual_linear_plot import 
 from chap_core.assessment.backtest_plots.predicted_vs_actual_plot import (
     PredictedVsActualPlot,
 )
-from chap_core.assessment.backtest_plots.sample_bias_plot import SampleBiasPlot
+from chap_core.assessment.backtest_plots.sample_bias_plot import SampleBiasByHorizonPlot, SampleBiasByTimePeriodPlot
 
 
 CLIM_548 = "CLIM-548: FacetedBacktestPlot refactor not implemented yet"
@@ -223,10 +223,11 @@ def test_get_full_plot_returns_faceted_chart(plot_cls, expected_fields, observat
     assert isinstance(chart, alt.TopLevelMixin)
 
 
-def test_no_dimension_plot_conforms_to_interface(observations_df, forecasts_df):
+@pytest.mark.parametrize("plot_cls", [SampleBiasByHorizonPlot, SampleBiasByTimePeriodPlot])
+def test_no_dimension_plot_conforms_to_interface(plot_cls, observations_df, forecasts_df):
     """A FacetedBacktestPlot may declare no dimensions: facet_coords is empty and a
     subplot with no coordinates renders the full chart."""
-    plotter = SampleBiasPlot()
+    plotter = plot_cls()
     assert plotter.facet_dimensions == []
 
     coords = plotter.facet_coords(observations_df, forecasts_df)

--- a/tests/integration/rest_api/test_backtest_plot_faceting_api.py
+++ b/tests/integration/rest_api/test_backtest_plot_faceting_api.py
@@ -18,8 +18,7 @@ Expected endpoints (relative to ``/v1/visualization/backtest-plots``):
 
 from __future__ import annotations
 
-import json
-
+import pytest
 from starlette.testclient import TestClient
 
 from chap_core.rest_api.app import app
@@ -82,9 +81,10 @@ def test_subplot_endpoint_uses_container_width(override_session):
     assert "containerSize" in width_signal["init"]
 
 
-def test_subplot_endpoint_keeps_fixed_width_for_multiview_plot(override_session):
-    """horizon_location_grid renders composite (vconcat) cells; container sizing is
-    invalid on multi-view specs, so its subplot keeps the plot's fixed widths."""
+def test_subplot_endpoint_uses_container_width_for_vconcat_plot(override_session):
+    """horizon_location_grid renders composite (vconcat) cells whose rows share one
+    width; the API replaces the hoisted top-level width with a containerSize signal
+    so the whole stack fills the frontend container."""
     coords_resp = client.get("/v1/visualization/backtest-plots/horizon_location_grid/1/facet-coords")
     assert coords_resp.status_code == 200, coords_resp.text
     payload = coords_resp.json()
@@ -92,7 +92,40 @@ def test_subplot_endpoint_keeps_fixed_width_for_multiview_plot(override_session)
 
     response = client.post("/v1/visualization/backtest-plots/horizon_location_grid/1/subplot", json=body)
     assert response.status_code == 200, response.text
-    assert "containerSize" not in json.dumps(response.json())
+    spec = response.json()
+    assert "width" not in spec
+    assert spec["autosize"]["type"] == "fit-x"
+    width_signal = next(s for s in spec["signals"] if s["name"] == "width")
+    assert "containerSize" in width_signal["init"]
+
+
+def test_catalogue_lists_split_sample_bias_plots(override_session):
+    response = client.get("/v1/visualization/backtest-plots/")
+    assert response.status_code == 200, response.text
+    plots = {entry["id"]: entry for entry in response.json()}
+    assert "ratio_of_samples_above_truth" not in plots
+    for plot_id in ("sample_bias_by_horizon", "sample_bias_by_time_period"):
+        assert plot_id in plots
+        assert plots[plot_id]["displayName"]
+        assert plots[plot_id]["description"]
+
+
+@pytest.mark.parametrize("plot_id", ["sample_bias_by_horizon", "sample_bias_by_time_period"])
+def test_sample_bias_facet_coords_are_empty(plot_id, override_session):
+    response = client.get(f"/v1/visualization/backtest-plots/{plot_id}/1/facet-coords")
+    assert response.status_code == 200, response.text
+    assert response.json() == {}
+
+
+@pytest.mark.parametrize("plot_id", ["sample_bias_by_horizon", "sample_bias_by_time_period"])
+def test_sample_bias_subplot_returns_single_view_container_spec(plot_id, override_session):
+    """Each split plot must return a single-view spec sized to fill the container width."""
+    response = client.post(f"/v1/visualization/backtest-plots/{plot_id}/1/subplot", json={})
+    assert response.status_code == 200, response.text
+    spec = response.json()
+    assert "layout" not in spec
+    assert spec["autosize"]["type"] == "fit-x"
+    assert isinstance(spec["height"], (int, float))
 
 
 def test_subplots_endpoint_returns_one_entry_per_coord_combination(override_session):


### PR DESCRIPTION
## Summary

The `ratio_of_samples_above_truth` plot returned a multi-chart dashboard (vconcat with in-chart title/prose text blocks plus two charts), which does not fit the frontend's one-chart-per-selection model and cannot be responsively sized. This PR replaces it with two separately registered single-view backtest plots:

- `sample_bias_by_horizon` ("Sample Bias by Horizon") — bar chart of the ratio of forecast samples above truth per forecast horizon.
- `sample_bias_by_time_period` ("Sample Bias by Time Period") — line chart of the ratio over time periods, one line per location.

Both follow the single-view spec conventions: numeric `height` (300), no `layout`/concat groups, and the subplot endpoint's container width handling compiles them to `autosize: {type: fit-x, contains: padding}` so they fill the widget. The explanatory prose moved from in-chart text marks into each catalogue entry's `description`. Both declare no facet dimensions, so `facet-coords` returns `{}` and `POST .../subplot` works with an empty `{}` body.

### Responsive width for vconcat subplots (Forecast Grid)

The Forecast Grid (`horizon_location_grid`) subplot is a vconcat (forecast band stacked over per-metric line charts), so `_fill_container_width` skipped it — Vega-Lite rejects `width="container"` on multi-view specs — and each cell stayed at its fixed 250px width in the frontend. That restriction does not carry over to the compiled Vega output: because every row shares the same width, the compiler hoists it to a single top-level `width` that all row groups reference as a signal. `_fill_container_width` now compiles the chart first and, for vertical concats with a hoisted width, replaces it with the same `containerSize()`-driven signal that `width="container"` produces (plus `autosize: fit-x`), keeping the original width as fallback when there is no sized DOM container. Single-view charts behave exactly as before; hconcat and faceted specs keep their fixed widths. The helper now returns the compiled spec dict, so the endpoint call sites dropped their own `to_dict(format="vega")` calls.

Docs and the generated plot id lock-in file are updated accordingly.

## Test plan

- New REST tests: catalogue lists both new plots (and no longer lists `ratio_of_samples_above_truth`), `facet-coords` returns `{}`, and `subplot` with body `{}` returns a single-view spec with `autosize.type == fit-x` and numeric height.
- Flipped the lock-in test that asserted `horizon_location_grid` subplots keep fixed widths: it now asserts the served spec has no fixed top-level width, uses `fit-x` autosize, and drives the `width` signal from `containerSize()`.
- Updated unit tests for registry, lookup, direct rendering (single-view, height 300), and the no-dimension faceting interface.
- Rendered both compiled sample-bias specs with vega-embed in a fixed-size container harness to confirm they display correctly standalone.
- Rendered the actual spec served by `/backtest-plots/horizon_location_grid/1/subplot` with vega-embed in a 1000px container and confirmed the composite cell fills the width edge to edge and resizes with the container.
- `make lint` and `make test` pass (1174 passed).
