### PR TITLE
fix: remove per-cell title from horizon grid subplots

### DIFF
--- a/chap_core/assessment/backtest_plots/horizon_location_grid.py
+++ b/chap_core/assessment/backtest_plots/horizon_location_grid.py
@@ -23,13 +23,13 @@ CELL_HEIGHT = 150
 METRIC_HEIGHT = 60
 
 
-def _empty_placeholder(width: int, height: int, title: str = "") -> ChartType:
+def _empty_placeholder(width: int, height: int) -> ChartType:
     """Return an empty chart placeholder that won't trip vegafusion's type checks."""
     return (  # type: ignore[no-any-return]
         alt.Chart(pd.DataFrame({"x": [0]}))
         .mark_point(opacity=0)
         .encode(x=alt.value(0), y=alt.value(0))
-        .properties(width=width, height=height, title=title)
+        .properties(width=width, height=height)
     )
 
 
@@ -49,7 +49,7 @@ def _build_forecast_cell(
     obs = obs[obs["time_period"].isin(fq["time_period"])]
 
     if fq.empty:
-        return _empty_placeholder(CELL_WIDTH, CELL_HEIGHT, f"{location} | horizon {horizon}")
+        return _empty_placeholder(CELL_WIDTH, CELL_HEIGHT)
 
     base_forecast = alt.Chart(fq)
 
@@ -83,9 +83,7 @@ def _build_forecast_cell(
         )
         layers = layers + obs_line
 
-    return layers.properties(  # type: ignore[no-any-return]
-        width=CELL_WIDTH, height=CELL_HEIGHT, title=f"{location} | horizon {horizon}"
-    )
+    return layers.properties(width=CELL_WIDTH, height=CELL_HEIGHT)  # type: ignore[no-any-return]
 
 
 def _build_metric_chart(
@@ -267,8 +265,14 @@ class HorizonLocationGridPlot(FacetedBacktestPlot):
 
         location_rows: list[ChartType] = []
         for loc in locations:
+            # The grid layout is the only thing identifying a cell, so label each
+            # one here; the single-cell subplot view leaves identification to the
+            # frontend's facet selection.
             horizon_cells = [
-                self._plot(df[(df["location"] == loc) & (df["horizon_distance"] == hz)]) for hz in horizons
+                self._plot(df[(df["location"] == loc) & (df["horizon_distance"] == hz)]).properties(
+                    title=f"{loc} | horizon {hz}"
+                )
+                for hz in horizons
             ]
             location_rows.append(alt.hconcat(*horizon_cells).properties(spacing=10))
 

--- a/tests/evaluation/test_backtest_plot_faceting.py
+++ b/tests/evaluation/test_backtest_plot_faceting.py
@@ -41,6 +41,7 @@ behavior.
 
 from __future__ import annotations
 
+import json
 import re
 
 import altair as alt
@@ -235,6 +236,21 @@ def test_no_dimension_plot_conforms_to_interface(plot_cls, observations_df, fore
 
     chart = plotter.get_subplot(observations_df, forecasts_df, {})
     assert isinstance(chart, alt.TopLevelMixin)
+
+
+def test_horizon_grid_cell_title_only_in_full_grid(observations_df, forecasts_df):
+    """The frontend's facet selection already identifies a single-cell subplot, so it
+    carries no '<location> | horizon <n>' title; the full grid keeps the per-cell
+    labels since its layout is the only thing identifying each cell."""
+    plotter = HorizonLocationGridPlot()
+    location = forecasts_df["location"].iloc[0]
+    horizon = int(forecasts_df["horizon_distance"].iloc[0])
+
+    subplot = plotter.get_subplot(observations_df, forecasts_df, {"location": location, "horizon_distance": horizon})
+    assert "| horizon" not in json.dumps(subplot.to_dict(format="vega"))
+
+    full_plot = plotter.get_full_plot(observations_df, forecasts_df)
+    assert f"{location} | horizon {horizon}" in json.dumps(full_plot.to_dict(format="vega"))
 
 
 def test_horizon_grid_subplot_handles_empty_forecasts(observations_df, forecasts_df):


### PR DESCRIPTION
## Summary

The Forecast Grid (`horizon_location_grid`) subplot served to the frontend carried a "`<location> | horizon <n>`" title on top of every cell (e.g. "YvLOmtTQD6b | horizon 1"). The frontend's facet selection already identifies which location and horizon the subplot shows, so the title just duplicated that with a raw org unit id.

This moves the title out of the cell renderer (`_build_forecast_cell`) and into `get_full_plot`'s assembly loop:

- The single-cell subplot served by `POST .../horizon_location_grid/{id}/subplot` no longer has the title.
- The full-grid view (CLI exports, the non-faceted plot endpoint) still labels every cell exactly as before, since there the grid layout is the only thing identifying each cell.
- `_empty_placeholder` drops its now-unused title parameter.

## Test plan

- New test `test_horizon_grid_cell_title_only_in_full_grid`: the subplot spec contains no "| horizon" title while the full-grid spec still contains the per-cell labels.
- `make lint` and `make test` pass.
