### PR TITLE
fix: support weekly time periods in seasonal threshold strategy

### DIFF
--- a/chap_core/assessment/thresholds/seasonal.py
+++ b/chap_core/assessment/thresholds/seasonal.py
@@ -1,4 +1,4 @@
-"""Seasonal threshold strategy: mean + k*std over historical same-month values."""
+"""Seasonal threshold strategy: mean + k*std over historical same-season (month or week) values."""
 
 from __future__ import annotations
 
@@ -17,6 +17,29 @@ def _extract_month(time_period: pd.Series) -> pd.Index:
     return pd.PeriodIndex(time_period.astype(str), freq="M").month
 
 
+def _extract_week(time_period: pd.Series) -> pd.Index:
+    """Vectorised week-of-year extraction from weekly time_period strings.
+
+    Accepts every weekly format ``TimePeriod.parse`` supports (``2016W01``, ``2016-W01``,
+    ``2016SunW01``, ``2016-S01``), with both zero-padded and unpadded week numbers
+    (``2016W01`` and ``2016W1`` map to the same week).
+    """
+    values = time_period.astype(str)
+    weeks = values.str.extract(r"[WS](\d{1,2})$", expand=False)
+    if weeks.isna().any():
+        bad = values[weeks.isna()].iloc[0]
+        raise ValueError(f"Cannot parse week from time period: {bad}")
+    return pd.Index(weeks.astype(int))
+
+
+def _season_column(time_period: pd.Series) -> tuple[str, pd.Index]:
+    """Return the season bucket for a period series: ("week", week-of-year) for weekly periods, ("month", month-of-year) otherwise."""
+    first = str(time_period.iloc[0])
+    if "W" in first or "-S" in first:
+        return "week", _extract_week(time_period)
+    return "month", _extract_month(time_period)
+
+
 def compute_seasonal_thresholds(historical_observations: pd.DataFrame, k: float = 2.0) -> pd.DataFrame:
     """Compute outbreak thresholds from historical observations.
 
@@ -25,19 +48,21 @@ def compute_seasonal_thresholds(historical_observations: pd.DataFrame, k: float 
         k: Number of standard deviations above the mean (default 2.0).
 
     Returns:
-        DataFrame with columns [location, month, threshold]
+        DataFrame with columns [location, month, threshold] for monthly data,
+        or [location, week, threshold] for weekly data.
     """
     df = historical_observations.copy()
-    df["month"] = _extract_month(df["time_period"])
-    grouped = df.groupby(["location", "month"])["disease_cases"].agg(["mean", "std"]).reset_index()
+    season, buckets = _season_column(df["time_period"])
+    df[season] = buckets
+    grouped = df.groupby(["location", season])["disease_cases"].agg(["mean", "std"]).reset_index()
     grouped["threshold"] = grouped["mean"] + k * grouped["std"]
-    return grouped[["location", "month", "threshold"]]
+    return grouped[["location", season, "threshold"]]
 
 
 @threshold(
     "seasonal",
     "Seasonal mean + k*std",
-    "Outbreak threshold as mean + k standard deviations of historical same-month values.",
+    "Outbreak threshold as mean + k standard deviations of historical same-month (or same-week) values.",
 )
 class SeasonalThresholdStrategy(ThresholdStrategyBase):
     """Wraps :func:`compute_seasonal_thresholds` as a registered strategy."""
@@ -49,8 +74,11 @@ class SeasonalThresholdStrategy(ThresholdStrategyBase):
         params: dict | None = None,
     ) -> pd.DataFrame:
         k = float((params or {}).get("k", 2.0))
-        per_month = compute_seasonal_thresholds(historical_observations, k=k)
+        per_season = compute_seasonal_thresholds(historical_observations, k=k)
         requested = pd.DataFrame({"period_id": period_ids})
-        requested["month"] = _extract_month(requested["period_id"])
-        merged = requested.merge(per_month, on="month")
+        season, buckets = _season_column(requested["period_id"])
+        if season not in per_season.columns:
+            raise ValueError(f"period_ids are {season}-based but the dataset's time periods have a different frequency")
+        requested[season] = buckets
+        merged = requested.merge(per_season, on=season)
         return merged[["period_id", "location", "threshold"]]

--- a/tests/integration/rest_api/test_threshold_strategies.py
+++ b/tests/integration/rest_api/test_threshold_strategies.py
@@ -1,5 +1,7 @@
 """Tests for the threshold strategy registry and the seasonal strategy."""
 
+import pytest
+
 from chap_core.assessment.thresholds import get_threshold_strategy, list_threshold_strategies
 from chap_core.assessment.thresholds.seasonal import compute_seasonal_thresholds
 from chap_core.spatio_temporal_data.converters import observations_to_dataframe
@@ -44,3 +46,33 @@ def test_seasonal_strategy_parity_with_compute_seasonal_thresholds(dataset_obser
     for row in result.itertuples():
         expected = january[january["location"] == row.location]["threshold"].iloc[0]
         assert row.threshold == expected
+
+
+def test_seasonal_strategy_weekly(dataset_observations_weekly, org_units):
+    df = _disease_cases_df(dataset_observations_weekly)
+    period_ids = ["2023W01", "2023W02"]
+    result = _seasonal_strategy().compute(df, period_ids)
+    assert set(result.columns) == {"period_id", "location", "threshold"}
+    assert len(result) == len(period_ids) * len(org_units)
+    assert set(result["period_id"]) == set(period_ids)
+    assert result["threshold"].notna().all()
+    per_week = compute_seasonal_thresholds(df)
+    week_one = per_week[per_week["week"] == 1]
+    for row in result[result["period_id"] == "2023W01"].itertuples():
+        expected = week_one[week_one["location"] == row.location]["threshold"].iloc[0]
+        assert row.threshold == expected
+
+
+def test_seasonal_strategy_weekly_unpadded_period_ids(dataset_observations_weekly):
+    """2023W1 and 2023W01 refer to the same week and must yield identical thresholds."""
+    df = _disease_cases_df(dataset_observations_weekly)
+    strategy = _seasonal_strategy()
+    padded = strategy.compute(df, ["2023W01"]).set_index("location")["threshold"]
+    unpadded = strategy.compute(df, ["2023W1"]).set_index("location")["threshold"]
+    assert padded.equals(unpadded)
+
+
+def test_seasonal_strategy_frequency_mismatch_raises(dataset_observations_weekly):
+    df = _disease_cases_df(dataset_observations_weekly)
+    with pytest.raises(ValueError, match="frequency"):
+        _seasonal_strategy().compute(df, ["2023-01"])


### PR DESCRIPTION
## Problem

`POST /v1/analytics/thresholds` returned 500 for weekly datasets:

```
DateParseError: Unknown datetime string format, unable to parse: 2016W01
```

The seasonal strategy's month extraction fed every `time_period` string into `pd.PeriodIndex(freq="M")`, which only parses monthly strings.

## Fix

- Detect the period frequency from the period strings and bucket by week-of-year for weekly data, month-of-year for monthly data.
- Week extraction accepts all weekly formats `TimePeriod.parse` supports (`2016W01`, `2016-W01`, `2016SunW01`, `2016-S01`) and parses the week number as an integer, so padded and unpadded forms (`2023W01` vs `2023W1`) are equivalent and merge correctly.
- A frequency mismatch between `period_ids` and the dataset's time periods now raises a clear `ValueError` instead of a pandas parse error.

Monthly behavior and the `[location, month, threshold]` output contract of `compute_seasonal_thresholds` are unchanged. The outbreak detection metrics are unaffected: they are gated to monthly data via `_has_monthly_time_periods`.

## Tests

New tests in `tests/integration/rest_api/test_threshold_strategies.py` using the existing `dataset_observations_weekly` fixture: weekly shape and parity with `compute_seasonal_thresholds`, `2023W1` == `2023W01` equivalence, and the frequency-mismatch error.