### PR TITLE
feat: support name override in model config and add auto regressive models

### DIFF
--- a/chap_core/database/model_template_seed.py
+++ b/chap_core/database/model_template_seed.py
@@ -18,9 +18,13 @@ def add_model_template(model_template: ModelTemplateDB, session_wrapper: Session
     return template_id
 
 
-def add_model_template_from_url(url: str, session_wrapper: SessionWrapper, version: str) -> int:
+def add_model_template_from_url(
+    url: str, session_wrapper: SessionWrapper, version: str, name_override: str | None = None
+) -> int:
     model_template_config = ExternalModelTemplate.fetch_config_from_github_url(url)
     model_template_config.version = version
+    if name_override is not None:
+        model_template_config.name = name_override
     template_id = session_wrapper.add_model_template_from_yaml_config(model_template_config)
     return template_id
 
@@ -112,7 +116,7 @@ def seed_configured_models_from_config_dir(
             config.url = config.url.removesuffix("/")
 
             version_url = f"{config.url}@{version_commit_or_branch}"
-            template_id = add_model_template_from_url(version_url, wrapper, version)
+            template_id = add_model_template_from_url(version_url, wrapper, version, name_override=config.name)
 
             for config_name, configured_model_configuration in config.configurations.items():
                 add_configured_model(template_id, configured_model_configuration, config_name, wrapper)

--- a/chap_core/models/local_configuration.py
+++ b/chap_core/models/local_configuration.py
@@ -13,6 +13,7 @@ class LocalModelTemplateWithConfigurations(BaseModel):
     """Class only used for parsing ModelTemplate from config/models/*.yaml files."""
 
     url: str
+    name: str | None = None  # overrides the template name from the model's own config, e.g. to avoid name clashes
     uses_chapkit: bool = False
     versions: dict[str, str]
     configurations: dict[str, ModelConfiguration] = {"default": ModelConfiguration()}

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -38,6 +38,18 @@
     uv2: "@842a215551879b69bf401c86817c93380fef6fcf"
     uv3: "@ede034ac2dbf4fa3c2e96a365ccbcac63b77651d"
 
+- url: https://github.com/mortenoh/auto_regressive_monthly
+  name: auto_regressive_monthly_v2
+  versions:
+    nightly_build: "@main"
+    stable: "@62f92a792aba6a63bff25438357a0de91d73cb44"
+
+- url: https://github.com/mortenoh/auto_regressive_weekly
+  name: auto_regressive_weekly_v2
+  versions:
+    nightly_build: "@main"
+    stable: "@28cf38616aebc6938a3ebec45b9be7c20d2fbd59"
+
 - url: https://github.com/dhis2-chap/ewars_template
   versions:
     v1: "d666546c3975994183a6386468af217aba06b6c5"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -208,6 +208,19 @@ def test_add_model_template_from_url(engine, url):
         assert isinstance(external_model, ExternalModel)
 
 
+def test_add_model_template_from_url_name_override(engine, model_template_yaml_config, monkeypatch):
+    monkeypatch.setattr(
+        "chap_core.database.model_template_seed.ExternalModelTemplate.fetch_config_from_github_url",
+        lambda url: model_template_yaml_config,
+    )
+    with SessionWrapper(engine) as session:
+        template_id = add_model_template_from_url(
+            "https://github.com/example/test_model@main", session, version="test", name_override="my_distinct_name"
+        )
+        template = session.session.get(ModelTemplateDB, template_id)
+        assert template.name == "my_distinct_name"
+
+
 def test_seed_configured_models(engine):
     # make sure is clean
     SQLModel.metadata.drop_all(engine)


### PR DESCRIPTION
## Summary

- Add an optional `name` field to local model template configs (`config/configured_models/*.yaml`) that overrides the template name from the model's own MLproject file. Templates are upserted by name, so without an override, a model whose MLproject declares an already-used name would silently overwrite the existing template.
- Add https://github.com/mortenoh/auto_regressive_monthly and https://github.com/mortenoh/auto_regressive_weekly to the default configured models. Both declare MLproject names identical to the existing `sandvelab/monthly_ar_model` and `knutdrand/weekly_ar_model` entries, so they are seeded with distinct names `auto_regressive_monthly_v2` and `auto_regressive_weekly_v2`, pinned to their current latest commits.

## Test plan

- New test `test_add_model_template_from_url_name_override` covering the override.
- Verified seeding an in-memory database from the updated `default.yaml`: all four AR models coexist with distinct names.
- `make lint` and `make test` pass (1178 passed).