### PR TITLE
chore: point auto regressive v2 models at chap-models org

### DIFF
--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -38,17 +38,17 @@
     uv2: "@842a215551879b69bf401c86817c93380fef6fcf"
     uv3: "@ede034ac2dbf4fa3c2e96a365ccbcac63b77651d"
 
-- url: https://github.com/mortenoh/auto_regressive_monthly
+- url: https://github.com/chap-models/auto_regressive_monthly_v2
   name: auto_regressive_monthly_v2
   versions:
     nightly_build: "@main"
-    stable: "@62f92a792aba6a63bff25438357a0de91d73cb44"
+    stable: "@2e067506ebb7c65694fb1da30245c8bca8540b8e"
 
-- url: https://github.com/mortenoh/auto_regressive_weekly
+- url: https://github.com/chap-models/auto_regressive_weekly_v2
   name: auto_regressive_weekly_v2
   versions:
     nightly_build: "@main"
-    stable: "@28cf38616aebc6938a3ebec45b9be7c20d2fbd59"
+    stable: "@5578dcf0a16d88d7f30d99b29b553a792cf6b437"
 
 - url: https://github.com/dhis2-chap/ewars_template
   versions:

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -42,13 +42,13 @@
   name: auto_regressive_monthly_v2
   versions:
     nightly_build: "@main"
-    stable: "@2e067506ebb7c65694fb1da30245c8bca8540b8e"
+    stable: "@d4d6b78212c7079b3d151bb8aba7e042c2393953"
 
 - url: https://github.com/chap-models/auto_regressive_weekly_v2
   name: auto_regressive_weekly_v2
   versions:
     nightly_build: "@main"
-    stable: "@5578dcf0a16d88d7f30d99b29b553a792cf6b437"
+    stable: "@55f8fa523fbf2ebd9e2f7f17358b76c66a16c2c9"
 
 - url: https://github.com/dhis2-chap/ewars_template
   versions:


### PR DESCRIPTION
## Summary

- The two new AR model repos were transferred to the chap-models organization: https://github.com/chap-models/auto_regressive_monthly_v2 and https://github.com/chap-models/auto_regressive_weekly_v2. Update `default.yaml` to the new urls.
- Bump pinned stable commits, which include two changes in the model repos: display names updated to "Monthly/Weekly Deep Auto Regressive v2 (experimental)" so they are distinguishable from the existing AR models in UI pickers, and the `chap_auto_regressive` dependency repointed from a fork feature branch to `chap-models/chap_auto_regressive@main` (the feature PRs are merged upstream).

## Test plan

- Seeded an in-memory database from the updated `default.yaml`: all four AR models coexist with distinct names (`auto_regressive_monthly_v2`, `auto_regressive_weekly_v2`) and distinct display names.
- Started the full docker compose stack and verified via `/v1/crud/model-templates` that all four AR models are seeded with correct names and display names.
- `make lint` passes.