### PR TITLE
docs: add prerequisites section to configurable model tutorial

### DIFF
--- a/docs/dac2026/configurable-model.md
+++ b/docs/dac2026/configurable-model.md
@@ -16,6 +16,37 @@ We build on the example model
 Open its `README.md` first -- it explains how the pieces fit together. This guide is the
 hands-on exercise that goes with it.
 
+## Prerequisites
+
+This tutorial is a continuation of the
+[Modeling Webinar Series](../kigali-workshop/kigali-webinar-series/index.md) and the
+[Kigali workshop material](../kigali-workshop/kigali-workshop-material/index.md). Before
+starting, you should have worked through the following:
+
+- **[Webinar Session 2](../kigali-workshop/kigali-webinar-series/session-2/index.md)** --
+  you are comfortable on the [command line](../kigali-workshop/kigali-webinar-series/session-2/terminal.md),
+  with [git and GitHub](../kigali-workshop/kigali-webinar-series/session-2/git-github.md)
+  (forking and cloning), and with
+  [virtual environments](../kigali-workshop/kigali-webinar-series/session-2/virtual-environments.md).
+- **[Webinar Session 3](../kigali-workshop/kigali-webinar-series/session-3/index.md)** --
+  you have [installed Chap](../kigali-workshop/kigali-webinar-series/session-3/install-chap.md)
+  and have
+  [run a minimalist example model](../kigali-workshop/kigali-webinar-series/session-3/fork-example.md)
+  both in isolation and through Chap.
+- **[Monday Afternoon workshop material](../kigali-workshop/kigali-workshop-material/monday-afternoon.md)** --
+  you have run a backtest with `chap eval` and looked at the results.
+
+It also helps (but is not required) to have gone through the
+[Pre-session on working with datasets](../kigali-workshop/kigali-workshop-material/11_feb_presession.md),
+so you understand the Chap-compatible CSV format (`time_period`, `location`,
+`disease_cases`, plus covariate columns).
+
+Concretely, you need:
+
+- [uv](https://docs.astral.sh/uv/) installed.
+- The Chap CLI installed and working (`chap --help` runs).
+- A GitHub account, so you can fork the example model.
+
 ## What "configurable" means here
 
 The example model fits a linear regression per location, predicting `disease_cases` from:


### PR DESCRIPTION
## Summary

Adds a **Prerequisites** section to the DAC2026 *Make your model configurable* tutorial, framing it as a continuation of the Kigali workshop material as intended:

- Webinar [Session 2](https://chap.dhis2.org/chap-modeling-platform/kigali-workshop/kigali-webinar-series/) (terminal, git/GitHub, virtual environments) and [Session 3](https://chap.dhis2.org/chap-modeling-platform/kigali-workshop/kigali-webinar-series/) (install Chap, fork & run a minimalist model).
- [Monday Afternoon workshop material](https://chap.dhis2.org/chap-modeling-platform/kigali-workshop/kigali-workshop-material/monday-afternoon/) (running a backtest with `chap eval`).
- The [11 Feb pre-session on working with datasets](https://chap.dhis2.org/chap-modeling-platform/kigali-workshop/kigali-workshop-material/11_feb_presession/) (Chap-compatible CSV format) as helpful-but-optional background.

It also lists the concrete tooling needed: `uv`, the Chap CLI, and a GitHub account.

## Notes

- All internal links validated with `mkdocs build --strict` (passes).
- Doc lives under `docs/dac2026`, which is excluded from the doctest suites, so this does not affect documentation tests.