### PR TITLE
chore: add CODEOWNERS for docker/k8s/compose infra

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS
+# Docker / Kubernetes / Compose infrastructure is owned by the DevOps team.
+# Pattern syntax: https://docs.github.com/articles/about-code-owners
+
+# Docker build files (root only)
+/Dockerfile*            @dhis2-chap/devops
+
+# Docker Compose stacks (incl. compose.override.yml.example)
+/compose.*              @dhis2-chap/devops
+
+# Docker build context
+/.dockerignore          @dhis2-chap/devops
+
+# Helm charts / Kubernetes manifests
+/charts/                @dhis2-chap/devops
+
+# Docker image + Helm chart CI workflows
+/.github/workflows/ci-build-docker-images.yml                   @dhis2-chap/devops
+/.github/workflows/build_chap_worker_docker_image.yml.disabled  @dhis2-chap/devops
+/.github/workflows/release-chart.yaml                           @dhis2-chap/devops


### PR DESCRIPTION
## What

Adds `.github/CODEOWNERS` so the DevOps team (`@dhis2-chap/devops`) is automatically requested as a reviewer for changes to the container/deployment infrastructure.

## Scope (infra files only)

Ownership is anchored to the repo root via leading-slash patterns:

- `/Dockerfile*` — root Dockerfiles (excludes `external_models/` and `tests/` Dockerfiles)
- `/compose.*` — all Compose stacks, incl. `compose.override.yml.example`
- `/.dockerignore`
- `/charts/` — the full Helm chart tree (`chap`, `chap-api`, `chap-db`, `chap-worker`)
- The docker/chart CI workflows: `ci-build-docker-images.yml`, `build_chap_worker_docker_image.yml.disabled`, `release-chart.yaml`

Python source (`docker_runner.py` etc.) and `tests/*docker*` scripts are intentionally not covered.

## Note

For GitHub to honor the entries, `@dhis2-chap/devops` must have at least write access to this repo. If it doesn't, GitHub will flag a CODEOWNERS validity warning on the file — that's an org-level setting, not part of this change.