### PR TITLE
fix: use chap_core as coverage target in make test-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ test-all: ## run comprehensive test suite with examples and coverage
 	./tests/test_docker_compose_integration_flow.sh
 
 	#./tests/test_docker_compose_flow.sh   # this runs pytests inside a docker container, can be skipped
-	CHAP_DEBUG=true uv run pytest --log-cli-level=INFO -o log_cli=true -v --durations=0 --cov=climate_health --cov-report html --run-slow
-	CHAP_DEBUG=true uv run pytest --log-cli-level=INFO -o log_cli=true -v --durations=0 --cov=climate_health --cov-report html --cov-append scripts/*_example.py
+	CHAP_DEBUG=true uv run pytest --log-cli-level=INFO -o log_cli=true -v --durations=0 --cov=chap_core --cov-report html --run-slow
+	CHAP_DEBUG=true uv run pytest --log-cli-level=INFO -o log_cli=true -v --durations=0 --cov=chap_core --cov-report html --cov-append scripts/*_example.py
 
 coverage: ## run tests with coverage reporting
 	@echo ">>> Running tests with coverage"


### PR DESCRIPTION
## Summary

`make test-all` passed `--cov=climate_health`, the pre-rename package name. Since no such module exists, coverage collected nothing and both pytest invocations ended with:

```
CoverageWarning: Module climate_health was never imported. (module-not-imported)
CoverageWarning: No data was collected. (no-data-collected)
CovReportWarning: Failed to generate report: No data to report.
```

Switched both invocations to `--cov=chap_core`.

## Test plan

- `make lint` clean (ruff, mypy, pyright)
- Full slow suite green: `pytest --run-slow` -> 1247 passed, 75 skipped, 4 xfailed, 1 xpassed
- Re-ran the examples step from `test-all` with the corrected target; coverage data is now collected and the HTML report is written without warnings