### PR TITLE
chore: remove unused Google service account keys from env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,3 @@ POSTGRES_DB=chap_core
 
 # Valkey/Redis
 REDIS_PASSWORD=your_secure_redis_password
-
-# Google Cloud (required for production)
-GOOGLE_SERVICE_ACCOUNT_EMAIL=your-gcp-service-account@project.iam.gserviceaccount.com
-GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nyour-private-key\n-----END PRIVATE KEY-----\n"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -23,6 +23,4 @@ deploy:
           chap-api.image.pullPolicy: Always
           chap-worker.image.pullPolicy: Always
           valkey.auth.aclUsers.default.password: "{{.REDIS_PASSWORD}}"
-          chap-api.googleServiceAccount.email: "{{.GOOGLE_SERVICE_ACCOUNT_EMAIL}}"
-          chap-api.googleServiceAccount.privateKey: "{{.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY}}"
           chap-api.ingress.enabled: "false"


### PR DESCRIPTION
## Summary

Removes the dead `GOOGLE_SERVICE_ACCOUNT_EMAIL` / `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` config.

These were leftovers from the Google Earth Engine integration:
- `chap_core/rest_api/worker_functions.py:159` asserts GEE is no longer supported
- `charts/chap` has no `googleServiceAccount` values, so the `skaffold.yaml` `setValueTemplates` entries set values nothing consumes
- `docs/modeling-app/running-chap-on-server.md` already documents that GEE credentials are not needed anymore

The `skaffold.yaml` lines are removed alongside `.env.example`, since dropping the vars from the example while skaffold still templates them would break local deploys with a missing template variable.

## Testing

- `make lint` passes
- `make test` passes (1205 passed, 117 skipped)