### PR TITLE
fix: point MLflow at a writable tracking store in the worker

### DIFF
--- a/chap_core/runners/mlflow_runner.py
+++ b/chap_core/runners/mlflow_runner.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import mlflow.exceptions
 import mlflow.projects
@@ -10,8 +11,27 @@ from chap_core.runners.runner import TrainPredictRunner
 logger = logging.getLogger(__name__)
 
 
+def _set_default_tracking_uri():
+    """Point MLflow at a writable tracking store when the deployment has not configured one.
+
+    MLflow defaults its tracking store to the relative URI ``sqlite:///mlflow.db``, which it
+    resolves against the process working directory. In the worker container that directory is
+    ``/app`` on a read-only filesystem, so creating a run fails with "unable to open database
+    file". CHAP_RUNS_DIR is writable in every deployment, so use it as the fallback location.
+    """
+    if os.environ.get("MLFLOW_TRACKING_URI"):
+        return
+
+    from chap_core.models.utils import CHAP_RUNS_DIR
+
+    db_path = (CHAP_RUNS_DIR / "mlflow.db").absolute()
+    logger.debug(f"MLFLOW_TRACKING_URI not set, defaulting MLflow tracking store to {db_path}")
+    mlflow.set_tracking_uri(f"sqlite:///{db_path}")
+
+
 class MlFlowTrainPredictRunner(TrainPredictRunner):
     def __init__(self, model_path, model_configuration_filename=None, train_params=None):
+        _set_default_tracking_uri()
         self.model_path = model_path
         self.model_configuration_filename = model_configuration_filename
 

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -1,6 +1,8 @@
+import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock, ANY
 
+import mlflow
 import yaml
 
 from chap_core.exceptions import CommandLineException, ModelFailedException
@@ -19,6 +21,18 @@ from chap_core.external.model_configuration import (
 import pytest
 
 from chap_core.util import docker_available
+
+
+@pytest.fixture
+def mlflow_tracking_uri_reset():
+    """Undo the global tracking URI, which set_tracking_uri also mirrors into the environment."""
+    original_env = os.environ.get("MLFLOW_TRACKING_URI")
+    yield
+    mlflow.set_tracking_uri(None)
+    if original_env is None:
+        os.environ.pop("MLFLOW_TRACKING_URI", None)
+    else:
+        os.environ["MLFLOW_TRACKING_URI"] = original_env
 
 
 def test_command_line_runner():
@@ -326,7 +340,29 @@ def test_command_line_runner_report_raises_when_no_command():
         runner.report("model.pkl", "historic.csv", "report.pdf")
 
 
-def test_mlflow_runner_report_invokes_report_entry_point(tmp_path):
+def test_mlflow_runner_defaults_tracking_uri_to_runs_dir(tmp_path, monkeypatch, mlflow_tracking_uri_reset):
+    """MLflow defaults its tracking store to a sqlite file in the working directory, which is
+    read-only in the worker container. Fall back to the runs directory, which is writable."""
+    mlflow.set_tracking_uri(None)
+    os.environ.pop("MLFLOW_TRACKING_URI", None)
+    monkeypatch.setattr("chap_core.models.utils.CHAP_RUNS_DIR", tmp_path)
+
+    MlFlowTrainPredictRunner(model_path=tmp_path)
+
+    assert mlflow.get_tracking_uri() == f"sqlite:///{tmp_path / 'mlflow.db'}"
+
+
+def test_mlflow_runner_keeps_configured_tracking_uri(tmp_path, mlflow_tracking_uri_reset):
+    """A tracking URI configured by the deployment must win over the fallback."""
+    mlflow.set_tracking_uri(None)
+    os.environ["MLFLOW_TRACKING_URI"] = "http://mlflow.example:5000"
+
+    MlFlowTrainPredictRunner(model_path=tmp_path)
+
+    assert mlflow.get_tracking_uri() == "http://mlflow.example:5000"
+
+
+def test_mlflow_runner_report_invokes_report_entry_point(tmp_path, mlflow_tracking_uri_reset):
     runner = MlFlowTrainPredictRunner(model_path=tmp_path)
     with patch("mlflow.projects.run") as mock_run:
         mock_run.return_value = MagicMock()
@@ -345,7 +381,7 @@ def test_mlflow_runner_report_invokes_report_entry_point(tmp_path):
         }
 
 
-def test_mlflow_runner_report_wraps_execution_errors(tmp_path):
+def test_mlflow_runner_report_wraps_execution_errors(tmp_path, mlflow_tracking_uri_reset):
     import mlflow.exceptions
 
     runner = MlFlowTrainPredictRunner(model_path=tmp_path)


### PR DESCRIPTION
## Problem

Model runs in the worker container fail with:

```
mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
sqlite3.OperationalError: unable to open database file
```

MLflow defaults its tracking store to the relative URI `sqlite:///mlflow.db` (`mlflow/store/tracking/__init__.py`, `DEFAULT_TRACKING_URI`) and resolves it against the process working directory. The worker has `WORKDIR /app` and runs with `read_only: true`, so the file cannot be created.

This is not a dependency drift. The sqlite default landed in mlflow-skinny 3.7.0 and is present in every version our range allows, including the 3.11.1 the lockfile pins. Downgrading does not help either: 3.6.0 defaults to `./mlruns`, which resolves to the same read-only `/app`. The variable is the working directory, not the version.

The failure is not cosmetic. `create_sqlalchemy_engine_with_retry` retries 10 times with exponential backoff, roughly 100 seconds, and then raises.

Only models whose MLproject declares `python_env` are affected. `helper_functions.py` maps those to `MlFlowTrainPredictRunner`, which calls `mlflow.projects.run` and therefore creates a tracking run. Models using `docker_env`, `uv_env`, `renv_env`, or `conda_env` go through `CommandLineTrainPredictRunner` and never touch MLflow tracking. Reproduced with https://github.com/chap-models/minimal_template_example.

## Fix

When `MLFLOW_TRACKING_URI` is unset, default the tracking store to a sqlite file under `CHAP_RUNS_DIR`, which is writable in every deployment (`/data/runs` in the worker, already `chown chap:chap` in `Dockerfile.worker`). A tracking URI configured by the deployment is left untouched.

This lives in code rather than in `compose.yml` so it also covers `compose.ghcr.yml` and the skaffold deployment. MLflow's own `_make_parent_dirs_if_sqlite` creates the parent directory, so the helper has no filesystem side effects, and `set_tracking_uri` mirrors the value into the environment so the project subprocess inherits it.

## Tests

Two tests in `tests/runners/test_runners.py`: the fallback lands under `CHAP_RUNS_DIR`, and a deployment-configured URI wins. Added a `mlflow_tracking_uri_reset` fixture since `set_tracking_uri` mutates process-global state, and applied it to the two existing mlflow runner tests so they no longer leak into the rest of the session.

`tests/runners/test_runners.py`: 24 passed, 1 skipped.

Full `make test`: 798 passed, 1 failed. The failure is `test_db_endpoints.py::test_make_prediction_with_data_source_nonexistent_id` (`NameError: name 'MakePredictionWithDataSourceRequest' is not defined`), which fails identically on `feat/hpo-rest-api` with this branch's changes stashed. `make lint` reports 2 mypy errors in the same file, also pre-existing on the base.

## Not covered

`_get_sqlalchemy_store` falls back to `DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH` for the artifact root, so artifacts still target `/app/mlruns`. `minimal_template_example` logs no artifacts so this is not hit today, but a model that does will fail the same way. The only override is the private `_MLFLOW_SERVER_ARTIFACT_ROOT`; the real fix is moving the worker's `working_dir` off `/app`, which has a wider blast radius and is left for a separate change.
