### PR TITLE
ci: update the chart index through a pull request

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -11,16 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
         uses: azure/setup-helm@v5
@@ -33,9 +29,46 @@ jobs:
           helm repo update
           helm dep update charts/chap
 
-      - name: Run chart-releaser
+      - name: Package charts
+        run: |
+          mkdir -p .cr-release-packages
+          for chart in charts/*/; do
+            helm package "$chart" --destination .cr-release-packages
+          done
+
+      # skip_packaging uses the packages above rather than chart-releaser's own tag diffing, so a
+      # rerun of this workflow reaches the index step even when no chart changed. skip_upload skips
+      # only the index push, which the default branch rejects; the pull request below replaces it.
+      - name: Release charts
         uses: helm/chart-releaser-action@v1.7.0
         with:
           config: cr.yaml
+          skip_packaging: true
+          skip_upload: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Rebuild the chart index
+        run: |
+          cr index \
+            --owner "${{ github.repository_owner }}" \
+            --git-repo "${{ github.event.repository.name }}" \
+            --config cr.yaml \
+            --index-path index.yaml \
+            --token "${{ secrets.GITHUB_TOKEN }}"
+
+      # The default branch requires pull requests, an approving review and verified signatures, so
+      # chart-releaser cannot commit the index itself. sign-commits makes GitHub author the commit
+      # through its API, which is what makes the signature verified.
+      - name: Propose the chart index
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: index.yaml
+          branch: chore/chart-index
+          delete-branch: true
+          sign-commits: true
+          commit-message: "chore: update the chart index"
+          title: "chore: update the chart index"
+          body: |
+            Adds the charts released from ${{ github.sha }} to the index Helm reads from GitHub Pages.
+            Until this merges, the released chart versions exist as GitHub releases but cannot be installed.


### PR DESCRIPTION
The Release Charts workflow has been failing since the default branch ruleset landed: `cr index` pushes `index.yaml` straight to master, and master now requires pull requests, an approving review and verified signatures with no bypass actors.

That is why `chap-1.0.0` exists as a GitHub release but cannot be installed. The index Helm reads from GitHub Pages still ends at `chap-0.3.4`.

The workflow now rebuilds the index and proposes it as a pull request instead. `sign-commits` makes GitHub author the commit through its API, which is what makes the signature verified, so the proposed change satisfies the ruleset. Packaging moves into the workflow and chart-releaser runs with `skip_packaging`, because its own tag diffing finds no changed charts on a rerun and would never reach the index step for a release that already happened.

Merging this and letting the workflow run publishes 1.0.0 through one more small pull request. If the branch rules ever gain a bypass actor for Actions, or the index moves to a `gh-pages` branch, this can go back to the plain push.