### PR TITLE
ci: stop passing skip_packaging to chart-releaser

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -29,24 +29,25 @@ jobs:
           helm repo update
           helm dep update charts/chap
 
+      # skip_upload skips only the index push, which the default branch rejects; the pull request
+      # below replaces it.
+      - name: Release charts
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          config: cr.yaml
+          skip_upload: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      # cr index builds the index from the packages it finds, and chart-releaser only packages what
+      # changed since the last tag. Packaging every chart here means a rerun still indexes a release
+      # that already happened, which is the state a failed index step leaves behind.
       - name: Package charts
         run: |
           mkdir -p .cr-release-packages
           for chart in charts/*/; do
             helm package "$chart" --destination .cr-release-packages
           done
-
-      # skip_packaging uses the packages above rather than chart-releaser's own tag diffing, so a
-      # rerun of this workflow reaches the index step even when no chart changed. skip_upload skips
-      # only the index push, which the default branch rejects; the pull request below replaces it.
-      - name: Release charts
-        uses: helm/chart-releaser-action@v1.7.0
-        with:
-          config: cr.yaml
-          skip_packaging: true
-          skip_upload: true
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Rebuild the chart index
         run: |


### PR DESCRIPTION
The Release Charts run on #504 failed with `cr.sh: line 111: latest_tag: unbound variable`. chart-releaser's wrapper declares `latest_tag` as a local inside the branch it takes when packaging, then reads it unconditionally at the end, so `skip_packaging` always kills the step. It died after uploading and after correctly skipping the index, so the two steps that rebuild and propose the index never ran.

Packaging every chart now happens after chart-releaser rather than instead of it. That keeps the reason it was there, letting a rerun index a release that already happened, which is exactly the state chap 1.0.0 is in.

Worth recording why this repo needs any of this while dhis2-sre/dhis2-core-chart runs the same plain chart-releaser successfully: that repo's master has classic protection with no required reviews and no required signatures, so cr can push the index straight to it. This repo's ruleset requires a pull request, one approving review and verified signatures, which a direct push cannot satisfy. Aligning the rules would let this go back to the plain push.