### PR TITLE
chore: add chap 1.0.0 to the chart index

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -20,6 +20,23 @@ entries:
   - annotations:
       category: Application
     apiVersion: v2
+    appVersion: v2.1.0
+    created: "2026-08-10T18:30:52.221740286+02:00"
+    dependencies:
+    - condition: valkey.enabled
+      name: valkey
+      repository: https://valkey.io/valkey-helm
+      version: 0.9.2
+    description: CHAP (Climate Health Analysis Platform)
+    digest: f7387a31e9e9a92a7a0e54b94d2a5fbe7289d5065340fc27f2d5cc9a8a7f9727
+    name: chap
+    type: application
+    urls:
+    - https://github.com/dhis2-chap/chap-core/releases/download/chap-1.0.0/chap-1.0.0.tgz
+    version: 1.0.0
+  - annotations:
+      category: Application
+    apiVersion: v2
     appVersion: 1.0.0
     created: "2026-05-07T08:56:55.578043437Z"
     dependencies:
@@ -392,4 +409,4 @@ entries:
     urls:
     - https://github.com/dhis2-chap/chap-core/releases/download/chap-worker-0.1.0/chap-worker-0.1.0.tgz
     version: 0.1.0
-generated: "2026-05-07T08:56:56.298139035Z"
+generated: "2026-08-10T18:30:52.221797121+02:00"


### PR DESCRIPTION
Publishes chap 1.0.0, which has a GitHub release but no index entry, so `helm repo add` still resolves 0.3.4 and the chart cannot be installed.

Generated with `cr index` against the published release rather than written by hand, so the digest matches the release asset exactly and a later pipeline run regenerates the same entry.

This is the quick unblock. #505 fixes the pipeline so future releases index themselves, and either can merge first.