### PR TITLE
feat: add opt-in API token to the chap-core API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,9 @@ POSTGRES_DB=chap_core
 
 # Valkey/Redis
 REDIS_PASSWORD=your_secure_redis_password
+
+# API authentication (optional). Unset means no authentication.
+# Generate with `openssl rand -hex 32`; use at least 32 characters.
+# CHAP_API_TOKEN=
+# Shared secret for chapkit service registration (optional, separate from CHAP_API_TOKEN).
+# SERVICEKIT_REGISTRATION_KEY=

--- a/chap_core/rest_api/app.py
+++ b/chap_core/rest_api/app.py
@@ -2,12 +2,14 @@ import logging
 import os
 import traceback
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.security import HTTPBearer
 
 from chap_core import __version__ as chap_core_version
+from chap_core.rest_api.auth import ApiTokenMiddleware, warn_on_weak_token
 from chap_core.rest_api.common_routes import router as common_router
 from chap_core.rest_api.v1.rest_api import router as v1_router
 from chap_core.rest_api.v2.rest_api import router as v2_router
@@ -42,6 +44,8 @@ app = FastAPI(
     version=chap_core_version,
     openapi_tags=openapi_tags,
     root_path=os.environ.get("CHAP_ROOT_PATH", ""),
+    # Documents the bearer scheme in the OpenAPI spec; ApiTokenMiddleware does the enforcing.
+    dependencies=[Depends(HTTPBearer(auto_error=False))],
 )
 
 origins = [
@@ -49,6 +53,12 @@ origins = [
     "http://localhost:3000",
     "localhost:3000",
 ]
+
+warn_on_weak_token()
+
+# Must stay before CORSMiddleware: add_middleware inserts at the front, so this keeps CORS
+# outermost and 401 responses still carry CORS headers.
+app.add_middleware(ApiTokenMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/chap_core/rest_api/auth.py
+++ b/chap_core/rest_api/auth.py
@@ -1,0 +1,140 @@
+"""Opt-in shared-secret authentication.
+
+Two independent secrets, each configured by environment variable and each disabled when
+unset. ``CHAP_API_TOKEN`` gates the whole API, and ``SERVICEKIT_REGISTRATION_KEY`` gates
+chapkit service registration. When both are configured, the registration endpoints
+require both.
+
+The API token is normally presented as ``Authorization: Bearer <token>``, but it is also
+accepted in ``X-Service-Key`` because servicekit can only send that header. On the service
+registry paths the registration key is accepted there as well, so a chapkit service holding
+either secret can register without needing to send an ``Authorization`` header.
+"""
+
+import logging
+import os
+import secrets
+
+from fastapi.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+API_TOKEN_ENV_VAR = "CHAP_API_TOKEN"
+SERVICE_KEY_ENV_VAR = "SERVICEKIT_REGISTRATION_KEY"
+SERVICE_KEY_HEADER = "X-Service-Key"
+
+# Length of a `openssl rand -hex 32` token. The API has no rate limiting, so a short token
+# is brute-forceable by anyone who can reach the port.
+MIN_TOKEN_LENGTH = 32
+
+# /health is called without headers by the container HEALTHCHECK and the Helm probes, and
+# /system/info is how clients discover that a token is required.
+OPEN_PATHS = frozenset({"/health", "/health/ready", "/system/info"})
+
+# servicekit can only send X-Service-Key, never Authorization, so self-registering chapkit
+# services present their secret there instead. Confined to the service registry so a
+# registration key cannot be used as a general-purpose API credential.
+SERVICE_REGISTRY_PREFIX = "/v2/services"
+
+
+def get_api_token() -> str | None:
+    """The configured API token, or None when authentication is disabled."""
+    return os.getenv(API_TOKEN_ENV_VAR) or None
+
+
+def warn_on_weak_token() -> None:
+    """Log a warning at startup if the configured API token is too short to be safe."""
+    token = get_api_token()
+    if token is not None and len(token) < MIN_TOKEN_LENGTH:
+        logger.warning(
+            "%s is only %d characters and is easily guessed. Use at least %d characters, "
+            "e.g. `openssl rand -hex 32` or `uuidgen`.",
+            API_TOKEN_ENV_VAR,
+            len(token),
+            MIN_TOKEN_LENGTH,
+        )
+
+
+def get_service_key() -> str | None:
+    """The configured service registration key, or None when it is disabled."""
+    return os.getenv(SERVICE_KEY_ENV_VAR) or None
+
+
+def secret_matches(presented: str | None, expected: str) -> bool:
+    """Timing-safe comparison of a presented secret against the configured one."""
+    if not presented:
+        return False
+    # compare_digest on str raises TypeError for non-ascii, so compare encoded bytes.
+    return secrets.compare_digest(presented.encode(), expected.encode())
+
+
+def _bearer_matches(header: str | None, expected: str) -> bool:
+    if not header:
+        return False
+    scheme, _, token = header.partition(" ")
+    if scheme.lower() != "bearer":
+        return False
+    return secret_matches(token, expected)
+
+
+class ApiTokenMiddleware:
+    """Reject requests without a valid bearer token when ``CHAP_API_TOKEN`` is set.
+
+    Raw ASGI rather than ``BaseHTTPMiddleware`` so the streaming proxy in
+    ``v2/routers/proxy.py`` passes through untouched, and so ``/docs`` and ``/openapi.json``
+    are covered too -- route dependencies never reach those.
+    """
+
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        expected = get_api_token()
+        path = self._path(scope)
+        if expected is None or path in OPEN_PATHS:
+            return await self.app(scope, receive, send)
+
+        if not self._is_authorized(scope, path, expected):
+            response = JSONResponse(
+                status_code=401,
+                content={"detail": "Missing or invalid API token"},
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+            return await response(scope, receive, send)
+
+        return await self.app(scope, receive, send)
+
+    @classmethod
+    def _is_authorized(cls, scope: Scope, path: str, api_token: str) -> bool:
+        if _bearer_matches(cls._header(scope, b"authorization"), api_token):
+            return True
+
+        service_key = cls._header(scope, b"x-service-key")
+        if not service_key:
+            return False
+        if secret_matches(service_key, api_token):
+            return True
+
+        registration_key = get_service_key()
+        if registration_key is not None and path.startswith(SERVICE_REGISTRY_PREFIX):
+            return secret_matches(service_key, registration_key)
+        return False
+
+    @staticmethod
+    def _path(scope: Scope) -> str:
+        path: str = scope.get("path", "")
+        root_path: str = scope.get("root_path", "")
+        if root_path and path.startswith(root_path):
+            return path[len(root_path) :] or "/"
+        return path
+
+    @staticmethod
+    def _header(scope: Scope, name: bytes) -> str | None:
+        for key, value in scope.get("headers", []):
+            if key == name:
+                return str(value.decode("latin-1"))
+        return None

--- a/chap_core/rest_api/common_routes.py
+++ b/chap_core/rest_api/common_routes.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import text
 
 from chap_core.database.database import engine
+from chap_core.rest_api.auth import get_api_token
 from chap_core.rest_api.celery_tasks import app as celery_app
 from chap_core.rest_api.v1.routers.dependencies import get_settings
 from chap_core.util import load_redis
@@ -56,6 +57,13 @@ class SystemInfoResponse(BaseModel):
     server_date: str = Field(description="Current server time as an ISO-8601 UTC string.")
     server_time_zone_id: str = Field(description="Server timezone identifier (always `Etc/UTC`).")
     revision: str = Field(description="Git revision the running image was built from (empty if unknown).")
+    auth_required: bool = Field(
+        description=(
+            "Whether this server requires an API token. When `true`, every endpoint except "
+            "`/health`, `/health/ready` and `/system/info` needs an `Authorization: Bearer <token>` header."
+        ),
+        examples=[False],
+    )
 
 
 # --- Router ---
@@ -221,6 +229,7 @@ async def system_info() -> SystemInfoResponse:
         server_date=server_date,
         server_time_zone_id="Etc/UTC",
         revision=revision,
+        auth_required=get_api_token() is not None,
     )
 
 

--- a/chap_core/rest_api/v2/dependencies.py
+++ b/chap_core/rest_api/v2/dependencies.py
@@ -1,14 +1,11 @@
-import os
 from functools import lru_cache
 
 import httpx
 from fastapi import Header, HTTPException, status
 
+from chap_core.rest_api.auth import SERVICE_KEY_HEADER, get_service_key, secret_matches
 from chap_core.rest_api.services.orchestrator import Orchestrator
 from chap_core.util import load_redis
-
-SERVICE_KEY_HEADER = "X-Service-Key"
-SERVICE_KEY_ENV_VAR = "SERVICEKIT_REGISTRATION_KEY"
 
 # Generous read/write timeouts: proxied artifact downloads can stream large payloads.
 # Train/predict return 202 immediately, so they don't need a long window here.
@@ -43,26 +40,18 @@ def verify_service_key(
     If SERVICEKIT_REGISTRATION_KEY is not configured, authentication is skipped.
 
     Raises:
-        HTTPException 422: If key is configured but header is missing
-        HTTPException 401: If the provided key doesn't match
+        HTTPException 401: If the key is configured and the header is missing or wrong
     """
-    expected_key = os.getenv(SERVICE_KEY_ENV_VAR)
+    expected_key = get_service_key()
 
     # If no key configured on server, skip authentication
-    if not expected_key:
+    if expected_key is None:
         return None
 
-    # Key is configured, so header is required
-    if not x_service_key:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail="X-Service-Key header is required",
-        )
-
-    if x_service_key != expected_key:
+    if not secret_matches(x_service_key, expected_key):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid service key",
+            detail="Missing or invalid service key",
         )
 
     return x_service_key

--- a/chap_core/rest_api/v2/routers/proxy.py
+++ b/chap_core/rest_api/v2/routers/proxy.py
@@ -110,7 +110,8 @@ async def proxy_to_service(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
     # Forward request headers minus hop-by-hop, Connection-nominated, and host (httpx re-derives host).
-    request_headers = _forwardable(request.headers.items(), drop={"host"})
+    # authorization is dropped too: the caller's CHAP API token must not leak to the service.
+    request_headers = _forwardable(request.headers.items(), drop={"host", "authorization"})
     query_string = request.scope.get("query_string") or b""
 
     try:

--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -14,6 +14,7 @@ services:
       CELERY_BROKER: redis://redis:6379/0
       CHAP_LOGS_DIR: /data/logs
       CHAP_RUNS_DIR: /data/runs
+      CHAP_API_TOKEN: ${CHAP_API_TOKEN:-}
     container_name: chap
     read_only: true
     security_opt:

--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,7 @@ services:
       CHAP_LOGS_DIR: /data/logs
       CHAP_RUNS_DIR: /data/runs
       CHAP_ROOT_PATH: ${CHAP_ROOT_PATH:-}
+      CHAP_API_TOKEN: ${CHAP_API_TOKEN:-}
     # for now some of the tests uses hardcoded names so we need to set the container name
     # TODO: Update the tests so they don't rely on hardcoded container names
     container_name: chap

--- a/docs/modeling-app/fresh-installation.md
+++ b/docs/modeling-app/fresh-installation.md
@@ -47,6 +47,8 @@ This creates a `.env` file with default database credentials used by Docker Comp
 !!! tip "Production deployments"
     For production, open `.env` and change at least `POSTGRES_PASSWORD` to a strong, unique value. You can optionally change `POSTGRES_USER` as well. These credentials are set permanently when the database volume is first created, so choose them before running `docker compose up` for the first time.
 
+    If Chap Core will be reachable from outside your internal network, also set `CHAP_API_TOKEN` to require an API token on every request. See [API Authentication](../webapi/api-authentication.md).
+
 ## 4. Start Chap Core
 
 ```console

--- a/docs/modeling-app/running-chap-on-server.md
+++ b/docs/modeling-app/running-chap-on-server.md
@@ -7,7 +7,9 @@
 
 The Modeling App is dependent on connecting to a Chap server, as running the models is a process that needs to be handled by Chap Core. In this tutorial, we will deploy Chap Core to the same server that DHIS2 is running on, and making the Chap Core REST API available internally to the DHIS2 backend. The Modeling App will then use the DHIS2 Route API to connect to the Chap Core endpoint. We will explain the purpose of the Route API later.
 
-**IMPORTANT:** We do not want to make the Chap Core endpoint publicly available on the internet, as Chap Core does not have any method of authenticating requests.
+**IMPORTANT:** We do not want to make the Chap Core endpoint publicly available on the internet. By default Chap Core does not authenticate requests at all, so anyone who can reach the port can read and delete data.
+
+If you cannot keep Chap Core on an internal network -- for instance when connecting a cloud DHIS2 instance to a Chap Core running elsewhere through a tunnel -- enable the opt-in API token and serve it over HTTPS. See [API Authentication](../webapi/api-authentication.md). Network isolation remains the recommended setup; the token is the minimum needed to make an exposed deployment defensible, not a replacement for it.
 
 **NOTE:** Previously, Chap Core required you to configure it with Google Earth Engine Credentials. This is not needed anymore, since the Modeling App is now using climate data imported into DHIS2 by the [DHIS2 Climate App](https://apps.dhis2.org/app/effb986c-a3c7-485e-a2f6-5e54ff9df7c3). Using the DHIS2 Climate App requires you to set up [DHIS2 with Google Earth Engine](https://docs.dhis2.org/en/topics/tutorials/google-earth-engine-sign-up.html)
 

--- a/docs/webapi/api-authentication.md
+++ b/docs/webapi/api-authentication.md
@@ -1,0 +1,140 @@
+# API Authentication
+
+By default the Chap Core API has **no authentication**. This is intentional: the supported
+deployments either run DHIS2 and Chap Core together in one containerised setup, or run both
+locally during development. In both cases the API is reachable only from the machine or the
+internal network, and DHIS2 enforces authorization in front of it via the Route API.
+
+If you need to expose Chap Core beyond that -- for example connecting a cloud DHIS2 instance
+to a local Chap Core through a tunnel -- you can enable an opt-in API token. It is the bare
+minimum needed to put the API somewhere it can be reached from the internet, and it should
+always be combined with HTTPS.
+
+!!! warning "A token is not a substitute for network isolation"
+    The token is a single shared secret with no rotation, no expiry and no per-client
+    identity. Keeping Chap Core off the public internet is still the recommended setup.
+    See [Recommendation for server deployment](../modeling-app/running-chap-on-server.md).
+
+## Enabling the token
+
+Set the `CHAP_API_TOKEN` environment variable on the Chap Core server. When it is unset,
+authentication is disabled and the API behaves exactly as before.
+
+Generate a token with any of these:
+
+```console
+openssl rand -hex 32
+uuidgen
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+`uuidgen` is available on macOS and on Linux via `util-linux`, but is often missing from
+slim container images -- `openssl` is the more portable option.
+
+Use at least 32 characters. The API has no rate limiting, so a short token can be guessed by
+anyone who can reach the port. Chap Core logs a warning at startup if the token is shorter
+than that, but still starts.
+
+With Docker Compose, add it to your `.env` file and it is passed through to the `chap`
+service:
+
+```console
+CHAP_API_TOKEN=your-generated-token
+```
+
+Then restart the stack:
+
+```console
+docker compose up -d
+```
+
+## Making authenticated requests
+
+Send the token as a bearer token in the `Authorization` header:
+
+```console
+curl -H "Authorization: Bearer your-generated-token" \
+  http://localhost:8000/v1/crud/datasets
+```
+
+## Which endpoints require the token
+
+When `CHAP_API_TOKEN` is set, **every** endpoint requires it except the three below. Note
+that this includes the interactive documentation, so `/docs`, `/redoc` and `/openapi.json`
+are not browsable on a token-protected instance.
+
+| Path | Auth | Why |
+|------|------|-----|
+| `/health` | Public | Liveness probe. Called without headers by the container healthcheck and Kubernetes. |
+| `/health/ready` | Public | Readiness probe, same reason. |
+| `/system/info` | Public | Lets clients discover whether a token is required before authenticating. |
+| Everything else | Required | Includes `/v1/**`, `/v2/**`, `/docs`, `/redoc` and `/openapi.json`. |
+
+Service registration is covered too, with one accommodation for chapkit -- see
+[Relation to the service registration key](#relation-to-the-service-registration-key).
+
+## Error responses
+
+When `CHAP_API_TOKEN` is configured:
+
+| Scenario | Response |
+|----------|----------|
+| Missing `Authorization` header | 401 Unauthorized |
+| Wrong token, or a scheme other than `Bearer` | 401 Unauthorized |
+
+Both cases return the same body and a `WWW-Authenticate: Bearer` header, so a client can
+tell "this server wants a token" apart from a network failure:
+
+```json
+{"detail": "Missing or invalid API token"}
+```
+
+## Detecting whether a server requires a token
+
+`/system/info` stays public and reports `auth_required`, so a client can check before it has
+a token:
+
+```console
+curl http://localhost:8000/system/info
+```
+
+```json
+{
+    "chap_core_version": "2.2.0",
+    "python_version": "3.13.0",
+    "server_date": "2026-01-01T12:00:00+00:00",
+    "server_time_zone_id": "Etc/UTC",
+    "revision": "",
+    "auth_required": true
+}
+```
+
+## Connecting from the Modeling App
+
+The Modeling App reaches Chap Core through a DHIS2 Route. Configure the route to add the
+`Authorization` header so the token is stored in DHIS2 rather than in the browser. See the
+[DHIS2 Route API documentation](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-242/route.html)
+for the `headers` and `auth` fields.
+
+## Relation to the service registration key
+
+`CHAP_API_TOKEN` and `SERVICEKIT_REGISTRATION_KEY` are separate secrets, configured and
+checked independently, and either can be enabled without the other. See
+[Service Registration](service-registration.md).
+
+Self-registering chapkit services need special handling because servicekit can only send the
+`X-Service-Key` header -- it has no way to send `Authorization`. So on the `/v2/services`
+paths the token is also accepted in `X-Service-Key`:
+
+| Server configuration | What a chapkit service sends |
+|----------------------|------------------------------|
+| Only `CHAP_API_TOKEN` | `SERVICEKIT_REGISTRATION_KEY` set to the API token |
+| Only `SERVICEKIT_REGISTRATION_KEY` | `SERVICEKIT_REGISTRATION_KEY` set to the registration key |
+| Both | `SERVICEKIT_REGISTRATION_KEY` set to either one |
+
+A registration key is only accepted on `/v2/services` paths. It cannot be used as a
+general-purpose credential against `/v1/**`, so a model service cannot read or delete
+datasets with it.
+
+Other clients -- the Modeling App, `curl`, the Python SDK -- should use
+`Authorization: Bearer`.

--- a/docs/webapi/service-registration.md
+++ b/docs/webapi/service-registration.md
@@ -60,10 +60,15 @@ When `SERVICEKIT_REGISTRATION_KEY` is configured on the server:
 
 | Scenario | Response |
 |----------|----------|
-| Missing header | 422 Unprocessable Entity |
+| Missing header | 401 Unauthorized |
 | Invalid key | 401 Unauthorized |
 
 If the environment variable is not set, authentication is skipped and registration proceeds without requiring a key.
+
+!!! note "Changed in 2.2.0"
+    A missing `X-Service-Key` header previously returned 422 Unprocessable Entity. It now returns 401 Unauthorized, consistent with an invalid key.
+
+If the server also sets `CHAP_API_TOKEN`, the whole API is protected, including these endpoints. Because servicekit can only send `X-Service-Key`, the API token is accepted in that header too on `/v2/services` paths: set `SERVICEKIT_REGISTRATION_KEY` on the service to either the registration key or the API token. See [API Authentication](api-authentication.md).
 
 ## Registration Payload
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,7 @@ nav:
           - Overview: webapi/index.md
           - Developer Guide: webapi/developer.md
           - Docker Compose: webapi/docker-compose-doc.md
+          - API Authentication: webapi/api-authentication.md
           - Service Registration: webapi/service-registration.md
       - API Reference: api/index.md
       - Changelog: changelog.md

--- a/tests/integration/rest_api/test_api_token.py
+++ b/tests/integration/rest_api/test_api_token.py
@@ -1,0 +1,224 @@
+"""Tests for the opt-in CHAP_API_TOKEN gate."""
+
+import fakeredis
+import pytest
+from fastapi.testclient import TestClient
+
+from chap_core.rest_api.app import app
+from chap_core.rest_api.auth import (
+    API_TOKEN_ENV_VAR,
+    MIN_TOKEN_LENGTH,
+    SERVICE_KEY_ENV_VAR,
+    warn_on_weak_token,
+)
+from chap_core.rest_api.services.orchestrator import Orchestrator
+from chap_core.rest_api.v1.routers.dependencies import get_settings
+from chap_core.rest_api.v2.dependencies import get_orchestrator
+from chap_core.rest_api.worker_functions import WorkerConfig
+
+TEST_TOKEN = "test-api-token"
+TEST_SERVICE_KEY = "test-service-key"
+
+# Any gated route works here; this one needs no database.
+GATED_PATH = "/v2/services"
+
+
+@pytest.fixture
+def test_orchestrator():
+    return Orchestrator(redis_client=fakeredis.FakeRedis())
+
+
+@pytest.fixture
+def unauthenticated_client(test_orchestrator, monkeypatch):
+    monkeypatch.delenv(API_TOKEN_ENV_VAR, raising=False)
+    app.dependency_overrides[get_orchestrator] = lambda: test_orchestrator
+    app.dependency_overrides[get_settings] = lambda: WorkerConfig()
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(test_orchestrator, monkeypatch):
+    monkeypatch.setenv(API_TOKEN_ENV_VAR, TEST_TOKEN)
+    app.dependency_overrides[get_orchestrator] = lambda: test_orchestrator
+    app.dependency_overrides[get_settings] = lambda: WorkerConfig()
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def auth_headers():
+    return {"Authorization": f"Bearer {TEST_TOKEN}"}
+
+
+@pytest.fixture
+def sample_registration():
+    return {
+        "url": "http://model-service:8080",
+        "info": {
+            "id": "test-model",
+            "display_name": "Test Model",
+            "model_metadata": {"author": "Test Author"},
+            "period_type": "monthly",
+        },
+    }
+
+
+class TestTokenDisabled:
+    def test_gated_path_is_open_when_token_unset(self, unauthenticated_client):
+        assert unauthenticated_client.get(GATED_PATH).status_code == 200
+
+    def test_openapi_is_open_when_token_unset(self, unauthenticated_client):
+        assert unauthenticated_client.get("/openapi.json").status_code == 200
+
+    def test_system_info_reports_auth_not_required(self, unauthenticated_client):
+        response = unauthenticated_client.get("/system/info")
+
+        assert response.status_code == 200
+        assert response.json()["auth_required"] is False
+
+
+class TestTokenEnabled:
+    def test_missing_header_returns_401(self, client):
+        response = client.get(GATED_PATH)
+
+        assert response.status_code == 401
+        assert response.headers["WWW-Authenticate"] == "Bearer"
+        assert response.json() == {"detail": "Missing or invalid API token"}
+
+    def test_wrong_token_returns_401(self, client):
+        response = client.get(GATED_PATH, headers={"Authorization": "Bearer wrong-token"})
+
+        assert response.status_code == 401
+
+    def test_wrong_scheme_returns_401(self, client):
+        response = client.get(GATED_PATH, headers={"Authorization": f"Basic {TEST_TOKEN}"})
+
+        assert response.status_code == 401
+
+    def test_valid_token_is_accepted(self, client, auth_headers):
+        assert client.get(GATED_PATH, headers=auth_headers).status_code == 200
+
+    def test_openapi_is_gated(self, client, auth_headers):
+        assert client.get("/openapi.json").status_code == 401
+        assert client.get("/openapi.json", headers=auth_headers).status_code == 200
+
+    @pytest.mark.parametrize("path", ["/health", "/health/ready", "/system/info"])
+    def test_open_paths_need_no_token(self, client, path, monkeypatch):
+        from chap_core.rest_api import common_routes
+
+        monkeypatch.setattr(common_routes, "_check_db", lambda: "ok")
+        monkeypatch.setattr(common_routes, "_check_redis", lambda: "ok")
+        monkeypatch.setattr(common_routes, "_check_celery", lambda: "ok")
+
+        assert client.get(path).status_code == 200
+
+    def test_system_info_reports_auth_required(self, client):
+        assert client.get("/system/info").json()["auth_required"] is True
+
+    def test_401_keeps_cors_headers(self, client):
+        response = client.get(GATED_PATH, headers={"Origin": "http://localhost:3000"})
+
+        assert response.status_code == 401
+        assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+
+    def test_preflight_is_not_blocked(self, client):
+        response = client.options(
+            GATED_PATH,
+            headers={"Origin": "http://localhost:3000", "Access-Control-Request-Method": "GET"},
+        )
+
+        assert response.status_code == 200
+
+
+class TestServiceKeyHeaderCarriesTheToken:
+    """servicekit can only send X-Service-Key, so the API token is accepted there too."""
+
+    def test_api_token_in_service_key_header_is_accepted(self, client, sample_registration):
+        response = client.post(
+            "/v2/services/$register",
+            json=sample_registration,
+            headers={"X-Service-Key": TEST_TOKEN},
+        )
+
+        assert response.status_code == 200
+
+    def test_wrong_value_in_service_key_header_is_rejected(self, client):
+        response = client.get(GATED_PATH, headers={"X-Service-Key": "wrong-token"})
+
+        assert response.status_code == 401
+
+    def test_registration_key_is_accepted_on_the_service_registry(self, client, monkeypatch, sample_registration):
+        monkeypatch.setenv(SERVICE_KEY_ENV_VAR, TEST_SERVICE_KEY)
+
+        response = client.post(
+            "/v2/services/$register",
+            json=sample_registration,
+            headers={"X-Service-Key": TEST_SERVICE_KEY},
+        )
+
+        assert response.status_code == 200
+
+    def test_registration_key_is_not_a_general_api_credential(self, client, monkeypatch):
+        monkeypatch.setenv(SERVICE_KEY_ENV_VAR, TEST_SERVICE_KEY)
+
+        response = client.get("/openapi.json", headers={"X-Service-Key": TEST_SERVICE_KEY})
+
+        assert response.status_code == 401
+
+
+class TestWeakTokenWarning:
+    def test_short_token_warns(self, monkeypatch, caplog):
+        monkeypatch.setenv(API_TOKEN_ENV_VAR, "1")
+
+        with caplog.at_level("WARNING"):
+            warn_on_weak_token()
+
+        assert API_TOKEN_ENV_VAR in caplog.text
+
+    def test_long_token_does_not_warn(self, monkeypatch, caplog):
+        monkeypatch.setenv(API_TOKEN_ENV_VAR, "a" * MIN_TOKEN_LENGTH)
+
+        with caplog.at_level("WARNING"):
+            warn_on_weak_token()
+
+        assert caplog.text == ""
+
+    def test_unset_token_does_not_warn(self, monkeypatch, caplog):
+        monkeypatch.delenv(API_TOKEN_ENV_VAR, raising=False)
+
+        with caplog.at_level("WARNING"):
+            warn_on_weak_token()
+
+        assert caplog.text == ""
+
+
+class TestServiceRegistrationWithBothSecretsSet:
+    @pytest.fixture(autouse=True)
+    def service_key(self, monkeypatch):
+        monkeypatch.setenv(SERVICE_KEY_ENV_VAR, TEST_SERVICE_KEY)
+
+    def test_service_key_alone_is_accepted(self, client, sample_registration):
+        """The chapkit path: servicekit can only send X-Service-Key."""
+        response = client.post(
+            "/v2/services/$register",
+            json=sample_registration,
+            headers={"X-Service-Key": TEST_SERVICE_KEY},
+        )
+
+        assert response.status_code == 200
+
+    def test_api_token_alone_is_rejected(self, client, sample_registration, auth_headers):
+        response = client.post("/v2/services/$register", json=sample_registration, headers=auth_headers)
+
+        assert response.status_code == 401
+
+    def test_both_secrets_are_accepted(self, client, sample_registration, auth_headers):
+        response = client.post(
+            "/v2/services/$register",
+            json=sample_registration,
+            headers={**auth_headers, "X-Service-Key": TEST_SERVICE_KEY},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "registered"

--- a/tests/integration/rest_api/test_app_mounting.py
+++ b/tests/integration/rest_api/test_app_mounting.py
@@ -5,9 +5,10 @@ import pytest
 from fastapi.testclient import TestClient
 
 from chap_core.rest_api.app import app
+from chap_core.rest_api.auth import SERVICE_KEY_ENV_VAR
 from chap_core.rest_api.services.orchestrator import Orchestrator
 from chap_core.rest_api.v1.routers.dependencies import get_settings
-from chap_core.rest_api.v2.dependencies import SERVICE_KEY_ENV_VAR, get_orchestrator
+from chap_core.rest_api.v2.dependencies import get_orchestrator
 from chap_core.rest_api.worker_functions import WorkerConfig
 
 TEST_SERVICE_KEY = "test-service-key"

--- a/tests/integration/rest_api/test_services_proxy_router.py
+++ b/tests/integration/rest_api/test_services_proxy_router.py
@@ -170,6 +170,16 @@ def test_connection_nominated_request_header_dropped(client):
     assert "x-keep" in seen
 
 
+def test_authorization_header_not_forwarded(client):
+    response = client.get(
+        f"/v2/services/{SERVICE_ID}/run/api/v1/seen-headers",
+        headers={"Authorization": "Bearer chap-api-token"},
+    )
+
+    # The caller's CHAP API token must not reach the registered service.
+    assert "authorization" not in response.json()["headers"]
+
+
 def test_connection_nominated_response_header_dropped(client):
     response = client.get(f"/v2/services/{SERVICE_ID}/run/api/v1/conn-response")
 

--- a/tests/integration/rest_api/test_services_router.py
+++ b/tests/integration/rest_api/test_services_router.py
@@ -2,11 +2,9 @@ import fakeredis
 import pytest
 from fastapi.testclient import TestClient
 
+from chap_core.rest_api.auth import SERVICE_KEY_ENV_VAR
 from chap_core.rest_api.services.orchestrator import Orchestrator
-from chap_core.rest_api.v2.dependencies import (
-    SERVICE_KEY_ENV_VAR,
-    get_orchestrator,
-)
+from chap_core.rest_api.v2.dependencies import get_orchestrator
 from chap_core.rest_api.app import app
 
 TEST_SERVICE_KEY = "test-service-key"
@@ -251,10 +249,10 @@ class TestServiceKeyAuthentication:
         yield TestClient(app, raise_server_exceptions=False)
         app.dependency_overrides.clear()
 
-    def test_register_without_key_returns_422(self, client, sample_registration):
+    def test_register_without_key_returns_401(self, client, sample_registration):
         response = client.post("/v2/services/$register", json=sample_registration)
 
-        assert response.status_code == 422
+        assert response.status_code == 401
 
     def test_register_with_invalid_key_returns_401(self, client, sample_registration):
         response = client.post(
@@ -264,7 +262,7 @@ class TestServiceKeyAuthentication:
         )
 
         assert response.status_code == 401
-        assert response.json()["detail"] == "Invalid service key"
+        assert response.json()["detail"] == "Missing or invalid service key"
 
     def test_register_with_valid_key_succeeds(self, client, sample_registration, auth_headers):
         response = client.post("/v2/services/$register", json=sample_registration, headers=auth_headers)
@@ -281,13 +279,13 @@ class TestServiceKeyAuthentication:
         data = response.json()
         assert data["status"] == "registered"
 
-    def test_ping_without_key_returns_422(self, client, sample_registration, auth_headers):
+    def test_ping_without_key_returns_401(self, client, sample_registration, auth_headers):
         reg_response = client.post("/v2/services/$register", json=sample_registration, headers=auth_headers)
         service_id = reg_response.json()["id"]
 
         response = client.put(f"/v2/services/{service_id}/$ping")
 
-        assert response.status_code == 422
+        assert response.status_code == 401
 
     def test_ping_with_invalid_key_returns_401(self, client, sample_registration, auth_headers):
         reg_response = client.post("/v2/services/$register", json=sample_registration, headers=auth_headers)
@@ -297,13 +295,13 @@ class TestServiceKeyAuthentication:
 
         assert response.status_code == 401
 
-    def test_deregister_without_key_returns_422(self, client, sample_registration, auth_headers):
+    def test_deregister_without_key_returns_401(self, client, sample_registration, auth_headers):
         reg_response = client.post("/v2/services/$register", json=sample_registration, headers=auth_headers)
         service_id = reg_response.json()["id"]
 
         response = client.delete(f"/v2/services/{service_id}")
 
-        assert response.status_code == 422
+        assert response.status_code == 401
 
     def test_deregister_with_invalid_key_returns_401(self, client, sample_registration, auth_headers):
         reg_response = client.post("/v2/services/$register", json=sample_registration, headers=auth_headers)


### PR DESCRIPTION
Adds an opt-in API token to the chap-core API, so a Chap Core instance reachable from outside an internal network is at least defensible.

Today everything under `/v1/**` and `/v2/**` is unauthenticated, including `DELETE /v1/crud/datasets/{id}`. That is deliberate, and authorization is enforced by DHIS2 in front via the Route API. But users have started asking to connect a cloud DHIS2 instance to a local Chap Core over a tunnel, which puts the API directly on the public internet.

Setting `CHAP_API_TOKEN` requires `Authorization: Bearer <token>` on every endpoint except `/health`, `/health/ready` and `/system/info`. Leaving it unset disables authentication entirely, so no existing deployment changes.

## Design notes

Enforcement is an ASGI middleware rather than a route dependency, so `/docs`, `/redoc` and `/openapi.json` are covered too. It is raw ASGI rather than `BaseHTTPMiddleware` so the streaming service proxy passes through untouched, and it is registered before `CORSMiddleware` so 401 responses keep their CORS headers and preflight is answered before the token check. A non-enforcing `HTTPBearer(auto_error=False)` app dependency declares the scheme in the OpenAPI spec so generated clients pick it up.

`/system/info` stays public and now reports `auth_required`, so the Modeling App can tell "server needs a token" apart from "server unreachable" before it has one.

## Chapkit self-registration

servicekit's `registration.py` can only send `X-Service-Key` and has no way to send `Authorization`, so enabling the token would otherwise 401 every self-registering model service and make it vanish from the model list. The gate therefore also accepts the token in `X-Service-Key`, and on `/v2/services` paths a configured `SERVICEKIT_REGISTRATION_KEY` is accepted there as well. That acceptance is confined to those paths, so a registration key cannot be used as a general-purpose credential against `/v1/crud/**`.

Consequence: with both secrets set, a chapkit service sending only its registration key registers successfully.

## Included beyond the token itself

- The v2 proxy no longer forwards `Authorization` upstream, which would have leaked the caller's token to every registered service.
- The two secret checks now share helpers with a timing-safe comparison; `verify_service_key` previously used `!=`.
- **Behaviour change:** a missing `X-Service-Key` now returns 401 instead of 422, consistent with an invalid key. Documented in `service-registration.md`.
- Startup logs a warning if the token is shorter than 32 characters. There is no rate limiting, so a short token is brute-forceable.

## Not included

Helm chart plumbing, and the Modeling App changes in `chap-frontend` (token field in settings, passing it via the DHIS2 Route, and reading `auth_required` to drive `ServerSecurityNotices`, which currently hardcodes "your server is not secure"). Both want linked issues.

## Verification

`make lint`, `make test` (1232 passed), `make test-docs` (118 passed) and `mkdocs build --strict` all pass. The gate was also checked against a real uvicorn server rather than only `TestClient`: `/health` 200, `/system/info` reports `auth_required: true`, `/openapi.json` and `/v2/services` 401 with `WWW-Authenticate: Bearer`, and both a valid bearer token and the token in `X-Service-Key` pass the gate.

Refs CLIM-854
