### PR TITLE
fix: stop forwarding X-Service-Key in the v2 service proxy

### DIFF
--- a/chap_core/rest_api/v2/routers/proxy.py
+++ b/chap_core/rest_api/v2/routers/proxy.py
@@ -110,8 +110,9 @@ async def proxy_to_service(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
 
     # Forward request headers minus hop-by-hop, Connection-nominated, and host (httpx re-derives host).
-    # authorization is dropped too: the caller's CHAP API token must not leak to the service.
-    request_headers = _forwardable(request.headers.items(), drop={"host", "authorization"})
+    # authorization and x-service-key are dropped too: both carry the caller's CHAP API token
+    # (see rest_api/auth.py), which must not leak to the service.
+    request_headers = _forwardable(request.headers.items(), drop={"host", "authorization", "x-service-key"})
     query_string = request.scope.get("query_string") or b""
 
     try:

--- a/tests/integration/rest_api/test_services_proxy_router.py
+++ b/tests/integration/rest_api/test_services_proxy_router.py
@@ -170,14 +170,16 @@ def test_connection_nominated_request_header_dropped(client):
     assert "x-keep" in seen
 
 
-def test_authorization_header_not_forwarded(client):
+def test_credential_headers_not_forwarded(client):
     response = client.get(
         f"/v2/services/{SERVICE_ID}/run/api/v1/seen-headers",
-        headers={"Authorization": "Bearer chap-api-token"},
+        headers={"Authorization": "Bearer chap-api-token", "X-Service-Key": "chap-api-token"},
     )
 
-    # The caller's CHAP API token must not reach the registered service.
-    assert "authorization" not in response.json()["headers"]
+    # Both headers can carry the caller's CHAP API token; neither must reach the service.
+    seen = response.json()["headers"]
+    assert "authorization" not in seen
+    assert "x-service-key" not in seen
 
 
 def test_connection_nominated_response_header_dropped(client):


### PR DESCRIPTION
Follow-up to #512, addressing [ivargr's review comment](https://github.com/dhis2-chap/chap-core/pull/512#issuecomment-5277439082): `X-Service-Key` should be dropped by the proxy too.

#512 stopped the v2 proxy from forwarding the caller's `Authorization` header upstream, so a CHAP API token cannot leak to every registered chapkit service. It did not do the same for `X-Service-Key`.

That header carries the same secret. `ApiTokenMiddleware._is_authorized` accepts the CHAP API token in `X-Service-Key` as well as in `Authorization`, on any path, because servicekit can only send that header. So a caller authenticating the way #512 explicitly supports had the token forwarded verbatim to the registered service on every `GET /v2/services/{id}/run/**` request. A `SERVICEKIT_REGISTRATION_KEY` presented the same way leaked identically. Registered services are the party the secret is being kept from, so neither header belongs on the upstream hop.

`_forwardable` lower-cases each name before the exclusion check, so the drop is case-insensitive.

## Verification

The existing `test_authorization_header_not_forwarded` is widened to cover both headers and renamed `test_credential_headers_not_forwarded`. It fails on `x-service-key` with the proxy change reverted and passes with it. `make lint` and `make test` (1236 passed) are clean.

Refs CLIM-854