### PR TITLE
docs: correct X-Service-Key scope in the API authentication page

### DIFF
--- a/docs/webapi/api-authentication.md
+++ b/docs/webapi/api-authentication.md
@@ -123,8 +123,9 @@ checked independently, and either can be enabled without the other. See
 [Service Registration](service-registration.md).
 
 Self-registering chapkit services need special handling because servicekit can only send the
-`X-Service-Key` header -- it has no way to send `Authorization`. So on the `/v2/services`
-paths the token is also accepted in `X-Service-Key`:
+`X-Service-Key` header -- it has no way to send `Authorization`. The API token is therefore
+accepted in `X-Service-Key` as well, on any path, and on the `/v2/services` paths a
+configured registration key is accepted there too:
 
 | Server configuration | What a chapkit service sends |
 |----------------------|------------------------------|


### PR DESCRIPTION
Follow-up to #512 and #513.

`docs/webapi/api-authentication.md` said the API token is accepted in `X-Service-Key` "on the `/v2/services` paths". That scoping only applies to the *registration key* -- `ApiTokenMiddleware._is_authorized` accepts the CHAP API token in `X-Service-Key` on any path, and only falls back to the registration key under the `/v2/services` prefix.

The page therefore understated where the token is accepted. This is the behaviour that made #513 necessary, so the docs should describe it accurately. No behaviour change; the paragraph now separates the two secrets, and the existing statement below it about the registration key being confined to `/v2/services` is unchanged and still correct.

## Verification

`mkdocs build --strict` and `make test-docs` (118 passed) are clean.