### PR TITLE
docs: open pull requests in draft mode by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,3 +16,4 @@
 14. When creating Jira issues, always set at least one component
 15. When adding or removing a `@backtest_plot(...)` registration under `chap_core/assessment/backtest_plots/`, run `make regen-plot-help` and commit the regenerated `chap_core/cli_endpoints/generated_plot_ids.py`. The `tests/test_generated_plot_ids.py` lock-in test will fail otherwise.
 16. `chap_core/__init__.py` exposes `data`, `fetch`, `ModelTemplateInterface`, and `is_debug_mode` lazily via PEP 562 `__getattr__` to keep CLI startup fast. When adding a new public re-export at the package root, register it in the lazy table (`_LAZY_SUBMODULES` or `_LAZY_FROM`) rather than as an eager top-level import, and make sure the symbol is also reachable under `if TYPE_CHECKING:` so static type checkers still see it.
+17. Unless told otherwise, always open pull requests in draft mode (`gh pr create --draft`). Mark a PR ready for review only when asked to.


### PR DESCRIPTION
Adds workflow rule 17 to `CLAUDE.md`:

> Unless told otherwise, always open pull requests in draft mode (`gh pr create --draft`). Mark a PR ready for review only when asked to.

Drafts make the default explicit rather than relying on it being remembered per PR, and keep review requests and CI notifications from firing before a change is actually ready to look at.

Docs-only change, no code affected. Opened as a draft itself, per the rule it adds.