### PR TITLE
feat(chart): let the registration job be tracked

### DIFF
--- a/charts/chap/templates/dhis2/register-job.yaml
+++ b/charts/chap/templates/dhis2/register-job.yaml
@@ -5,13 +5,19 @@ metadata:
   name: {{ include "chap.fullname" . }}-dhis2-register-{{ .Release.Revision }}
   labels:
     {{- include "chap.labels" . | nindent 4 }}
+    {{- with .Values.dhis2.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-  ttlSecondsAfterFinished: 3600
+  ttlSecondsAfterFinished: {{ .Values.dhis2.registerJob.ttlSecondsAfterFinished }}
   backoffLimit: {{ .Values.dhis2.registerJob.backoffLimit }}
   template:
     metadata:
       labels:
         {{- include "chap.labels" . | nindent 8 }}
+        {{- with .Values.dhis2.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       restartPolicy: OnFailure
       containers:

--- a/charts/chap/values.schema.json
+++ b/charts/chap/values.schema.json
@@ -103,10 +103,12 @@
         "apiVersion": { "type": "string" },
         "username": { "type": "string" },
         "password": { "type": "string" },
+        "labels": { "type": "object" },
         "registerJob": {
           "type": "object",
           "properties": {
-            "backoffLimit": { "type": "integer", "minimum": 0 }
+            "backoffLimit": { "type": "integer", "minimum": 0 },
+            "ttlSecondsAfterFinished": { "type": "integer", "minimum": 0 }
           }
         }
       }

--- a/charts/chap/values.yaml
+++ b/charts/chap/values.yaml
@@ -217,5 +217,11 @@ dhis2:
   username: "system"
   # -- Required when dhis2.enabled is true.
   password: ""
+  # -- Labels applied to the registration job and its pod, on top of global.commonLabels. The job is
+  # the only evidence that registration happened, so a label is what lets something track it.
+  labels: {}
   registerJob:
     backoffLimit: 10
+    # -- How long the finished job is kept. It is the record of whether registration succeeded, so it
+    # outlives the run by a day rather than the hour a job is usually worth keeping.
+    ttlSecondsAfterFinished: 86400


### PR DESCRIPTION
The DHIS 2 registration job is the only evidence that CHAP registered itself, and today nothing can find it or read it afterwards.

It carries `chap.labels`, which is the global set, but none of the per component labels, so it has no `im-type` and a label selector cannot reach it. `dhis2.labels` fixes that, applied to the job and to its pod, matching how `api.labels`, `worker.labels` and `db.labels` already work.

It also set `ttlSecondsAfterFinished` to an hour, so the job and its logs deleted themselves at about the point someone would go looking for them, particularly since the job retries while DHIS 2 is still starting and can take a while to succeed. That is now a value, defaulting to a day.

Together these let Instance Manager show the job as a component of the chap stack, so whether registration succeeded is visible without reaching for kubectl.