### PR TITLE
chore(chart): index chap 1.1.0

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -21,6 +21,23 @@ entries:
       category: Application
     apiVersion: v2
     appVersion: v2.1.0
+    created: "2026-08-17T15:00:00.000000000+02:00"
+    dependencies:
+    - condition: valkey.enabled
+      name: valkey
+      repository: https://valkey.io/valkey-helm
+      version: 0.9.2
+    description: CHAP (Climate Health Analysis Platform)
+    digest: 239136f7b5ac07178b640a7dd9767598d78a2d46ec6df42148493d28f15a5418
+    name: chap
+    type: application
+    urls:
+    - https://github.com/dhis2-chap/chap-core/releases/download/chap-1.1.0/chap-1.1.0.tgz
+    version: 1.1.0
+  - annotations:
+      category: Application
+    apiVersion: v2
+    appVersion: v2.1.0
     created: "2026-08-10T18:30:52.221740286+02:00"
     dependencies:
     - condition: valkey.enabled


### PR DESCRIPTION
The chart is bumped to 1.1.0 on master and the release chap-1.1.0 exists with the packaged chart attached, but chart-releaser could not add it to the index: pushing index.yaml to master fails with GH013 because the branch ruleset does not list the GitHub Actions app as a bypass actor. This adds the entry by hand so the version is resolvable from https://dhis2-chap.github.io/chap-core/.

The digest matches the release asset, verified by downloading it. Adding the Actions app (id 15368) as a bypass actor is the real fix and would have made this unnecessary.

Instance Manager needs 1.1.0 to track the registration job as a component (dhis2-sre/im-manager#1704).