### PR TITLE
chore: point the example dataset at the maintained branch

### DIFF
--- a/chap_core/data/datasets.py
+++ b/chap_core/data/datasets.py
@@ -1,5 +1,5 @@
 from chap_core.spatio_temporal_data.multi_country_dataset import LazyMultiCountryDataSet
 
 ISIMIP_dengue_harmonized = LazyMultiCountryDataSet(
-    "https://github.com/dhis2/chap-core/raw/dev/example_data/full_data.tar.gz"
+    "https://raw.githubusercontent.com/dhis2-chap/chap-core/master/example_data/full_data.tar.gz"
 )

--- a/chap_core/file_io/example_data_set.py
+++ b/chap_core/file_io/example_data_set.py
@@ -44,7 +44,7 @@ dataset_names = [
 ]
 local_datasets = ["laos_full_data", "uganda_data"]
 remote_datasets = {
-    "ISIMIP_dengue_harmonized": "https://github.com/dhis2/chap-core/raw/dev/example_data/full_data.tar.gz"
+    "ISIMIP_dengue_harmonized": "https://raw.githubusercontent.com/dhis2-chap/chap-core/master/example_data/full_data.tar.gz"
 }
 type DataSetType = Literal[
     "hydro_met_subset",

--- a/tests/test_multi_country_dataset.py
+++ b/tests/test_multi_country_dataset.py
@@ -6,6 +6,6 @@ from chap_core.spatio_temporal_data.multi_country_dataset import (
 
 @pytest.mark.slow
 def test_from_tar():
-    url = "https://github.com/dhis2/chap-core/raw/dev/example_data/full_data.tar.gz"
+    url = "https://raw.githubusercontent.com/dhis2-chap/chap-core/master/example_data/full_data.tar.gz"
     dataset = MultiCountryDataSet.from_tar(url)
     assert "brazil" in dataset.countries


### PR DESCRIPTION
Correcting my own framing: this does not fix an outage. I opened it believing the URL was permanently dead, because it 404d repeatedly this afternoon during a GitHub incident that also produced 503s on the API and 429s on raw.githubusercontent. It resolves fine again now, and a re-run of #522, which does not carry this change, went green on all three test jobs.

What is left is a small cleanup. The dataset is fetched from the dev branch, whose last commit is from September 2025, while the repository is maintained on master. Pointing at master means the tests read the file the repository actually maintains. Worth having, or worth closing, but nothing urgent either way.

The deeper issue this surfaced is that the suite fetches datasets and model repositories from GitHub at test time, so CI depends on GitHub rate limits and availability rather than on the code.