### PR TITLE
fix: keep the service proxy out of the OpenAPI schema

### DIFF
--- a/chap_core/rest_api/v2/routers/proxy.py
+++ b/chap_core/rest_api/v2/routers/proxy.py
@@ -14,6 +14,11 @@ boundary first.
 The path below ``run/`` is forwarded verbatim from the raw request path so reserved
 characters in artifact ids and filenames survive, and upstream redirects are followed so a
 relative ``Location`` resolves against the service rather than CHAP Core's own origin.
+
+The route is excluded from the OpenAPI schema. A pass-through proxy has no response schema
+(it returns whatever the service returns) and no declarable query parameters, so a generated
+client can only be an untyped URL builder that decodes binary bodies as text and cannot
+forward a query string. Callers build proxy URLs directly instead.
 """
 
 import logging
@@ -86,10 +91,15 @@ def _raw_subpath(request: Request, service_id: str) -> str:
     return text[index + len(marker) :]
 
 
+# include_in_schema=False keeps this out of the generated client (see module docstring). It
+# also sidesteps FastAPI deriving one operation id per route rather than per method: exposing
+# a multi-method route emits the same operationId for every verb, and since methods is a set,
+# a non-deterministic one. Register one route per method if this is ever put in the schema.
 @router.api_route(
     "/{service_id}/run/{path:path}",
     methods=PROXY_METHODS,
     summary="Proxy a read-only request to a registered chapkit service",
+    include_in_schema=False,
 )
 async def proxy_to_service(
     service_id: str,

--- a/tests/integration/rest_api/test_app_mounting.py
+++ b/tests/integration/rest_api/test_app_mounting.py
@@ -180,6 +180,37 @@ class TestOpenAPITags:
                         assert tag in defined_tags, f"{method.upper()} {path} uses undefined tag '{tag}'"
 
 
+class TestOpenAPIOperationIds:
+    """A duplicate operationId silently breaks generated clients, so lock uniqueness in."""
+
+    HTTP_METHODS = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+
+    def _operations(self, schema):
+        for path, methods in schema["paths"].items():
+            for method, details in methods.items():
+                if method in self.HTTP_METHODS:
+                    yield path, method, details
+
+    def test_operation_ids_are_unique(self, client):
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        schema = response.json()
+
+        seen = {}
+        for path, method, details in self._operations(schema):
+            operation_id = details["operationId"]
+            assert operation_id not in seen, (
+                f"{method.upper()} {path} reuses operationId '{operation_id}' from {seen[operation_id]}"
+            )
+            seen[operation_id] = f"{method.upper()} {path}"
+
+    def test_proxy_route_is_not_in_the_schema(self, client):
+        """A pass-through proxy has no describable schema, so it stays out of the generated client."""
+        schema = client.get("/openapi.json").json()
+
+        assert "/v2/services/{service_id}/run/{path}" not in schema["paths"]
+
+
 class TestDocs:
     def test_docs_accessible(self, client):
         response = client.get("/docs")


### PR DESCRIPTION
The v2 service proxy was the only duplicate operationId in the OpenAPI spec. Rather than make the generated client correct, this excludes the route from the schema: a pass-through proxy is not describable in OpenAPI, and the client codegen produces for it is actively misleading.

CLIM-932

## The bug

`proxy.py` registered a single route for two methods:

```python
PROXY_METHODS = ["GET", "HEAD"]

@router.api_route("/{service_id}/run/{path:path}", methods=PROXY_METHODS, ...)
```

FastAPI computes a route's operation id **once per route**, not per method (`fastapi/utils.py:95`):

```python
operation_id = f"{operation_id}_{list(route.methods)[0].lower()}"
```

`get_openapi_operation_metadata` then reuses that single `route.unique_id` for every method the route serves, so GET and HEAD shared one ID and FastAPI warned during spec generation. Since `route.methods` is a set, `list(...)[0]` also depends on string hash randomization: six fresh processes on unchanged code produced `_get`, `_head`, `_head`, `_get`, `_get`, `_get`.

## Why the route leaves the schema instead

chap-frontend generates its client with `openapi-typescript-codegen` (`packages/ui/package.json:15`). Running it against the real spec shows the generated proxy method is not usable for what the proxy is for:

- **No types.** `CancelablePromise<any>` — the proxy returns whatever the upstream service returns, so there is no schema to generate from.
- **Binary downloads are corrupted.** `getResponseBody` (`core/request.ts:232`) branches on runtime Content-Type: JSON gets `.json()`, everything else gets `await response.text()`. An `application/octet-stream` artifact comes back decoded as UTF-8 text — precisely the case the module docstring names as the point of the proxy. The spec also mis-declares the response as `application/json`, because the handler is annotated `-> StreamingResponse`.
- **Query parameters are unreachable.** `proxy.py` forwards the raw query string and `test_query_string_forwarded` covers it, but the spec declares no query params (it cannot; they are arbitrary and upstream-defined), so the generated method has no way to pass one.
- **Path encoding fights `_raw_subpath`.** The default encoder is `encodeURI` (`request.ts:85`). `_raw_subpath` exists so percent-encoded reserved characters survive to the upstream service, but `artifacts/a%2Fb` becomes `artifacts/a%252Fb` (double-encoded) and `artifacts/a/b` keeps the slash as a separator. The case the server bends over backwards to support is unreachable through the client.

No identifiers were ever at risk of being baked into generated code — the operation id derives from the path template, so only parameter names appear, and `serviceId` is a runtime argument. The problem is that the endpoint is untypeable, not that it leaks values.

## Change

`include_in_schema=False` on the proxy route, with the reasoning recorded in the module docstring and a comment noting that re-exposing it requires one route registration per method.

Adds `TestOpenAPIOperationIds` to `test_app_mounting.py`, reusing that file's existing `client` fixture:

- `test_operation_ids_are_unique` over the whole spec.
- `test_proxy_route_is_not_in_the_schema`.

## Verification

- Spec: 71 operations, all operation ids unique, proxy path absent, no duplicate-ID warnings.
- Removing `include_in_schema=False` fails **both** tests, so the comment's warning about re-exposing a multi-method route is backed by a test rather than trust.
- The 14 existing proxy tests still pass unchanged — GET 200, HEAD 200, POST 405, query-string forwarding, binary downloads, redirects — confirming routing is untouched and only the schema changed.
- `make lint` clean (ruff, mypy, pyright). `make test`: 1242 passed, 117 skipped, 4 xfailed, 1 xpassed.

## Trade-off

The proxy is no longer discoverable in `/docs`. That is the cost of not shipping a generated method that silently corrupts binary responses. If it is ever put back in the schema, it must be registered one route per method, and the uniqueness test enforces that.
