### PR TITLE
feat: add restart policies and close container healthcheck gaps

### DIFF
--- a/Dockerfile.inla
+++ b/Dockerfile.inla
@@ -70,6 +70,8 @@ RUN mkdir /app/logs
 RUN chown -R chap:chap /app/logs
 # RUN chown -R chap:chap /app/*
 RUN chown -R chap:chap /pyenv
+HEALTHCHECK CMD /app/.venv/bin/celery -A chap_core.rest_api.celery_tasks inspect ping || exit 1
+
 USER chap
 
 # Ensure local venv tools are prioritized

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -33,6 +33,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN mkdir -p /data/logs /data/uv /data/renv /data/pytensor /data/runs \
   && chown chap:chap /data/logs /data/uv /data/renv /data/pytensor /data/runs
 
+HEALTHCHECK CMD /app/.venv/bin/celery -A chap_core.rest_api.celery_tasks inspect ping || exit 1
+
 USER chap
 
 # Keep the same command from the original worker image

--- a/compose.ewars.yml
+++ b/compose.ewars.yml
@@ -1,5 +1,6 @@
 services:
   ewars:
+    restart: unless-stopped
     image: ghcr.io/chap-models/chapkit_ewars_model:latest
     platform: linux/amd64
     pull_policy: always

--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -5,6 +5,7 @@
 # cap_drop entries because compose appends list fields on overlay.
 services:
   chap:
+    restart: unless-stopped
     image: ghcr.io/dhis2-chap/chap-core:latest
     platform: linux/amd64
     environment:
@@ -36,15 +37,18 @@ services:
       - "8000:8000"
     depends_on:
       redis:
-        condition: service_started
+        condition: service_healthy
       worker:
         condition: service_started
       postgres:
         condition: service_healthy
 
   worker:
+    restart: unless-stopped
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     image: ghcr.io/dhis2-chap/chap-worker:latest
     platform: linux/amd64
@@ -90,9 +94,17 @@ services:
         source: pytensor
         target: /data/pytensor
   redis:
+    restart: unless-stopped
     image: valkey/valkey:8
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   postgres:
+    restart: unless-stopped
     image: postgres:17
     environment:
       POSTGRES_USER: ${POSTGRES_USER}

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -4,6 +4,9 @@ services:
         context: .
         dockerfile: Dockerfile.test
     init: true
+    # One-shot pytest container: cancel the restart policy inherited from compose.yml,
+    # which would otherwise restart it after pytest exits and mask the exit code.
+    restart: "no"
     # multine command
     depends_on:
         -  worker

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,6 @@
 services:
   chap:
+    restart: unless-stopped
     build: .
     init: true
     environment:
@@ -40,16 +41,19 @@ services:
       start_period: 30s
     depends_on:
       redis:
-        condition: service_started
+        condition: service_healthy
       worker:
         condition: service_started
       postgres:
         condition: service_healthy
 
   worker:
+    restart: unless-stopped
     init: true
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     # NOTE: Built from Dockerfile.worker which extends the INLA worker image with chap-core
     build:
@@ -67,12 +71,6 @@ services:
       CHAP_RUNS_DIR: /data/runs
       PYTENSOR_FLAGS: "base_compiledir=/data/pytensor"
     command: "/app/.venv/bin/celery -A chap_core.rest_api.celery_tasks worker --loglevel=info"
-    healthcheck:
-      test: ["CMD-SHELL", "/app/.venv/bin/celery -A chap_core.rest_api.celery_tasks inspect ping"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
     working_dir: /app
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -103,9 +101,17 @@ services:
         source: pytensor
         target: /data/pytensor
   redis:
+    restart: unless-stopped
     image: valkey/valkey:8
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   postgres:
+    restart: unless-stopped
     image: postgres:17
     environment:
       POSTGRES_USER: ${POSTGRES_USER}

--- a/tests/test_compose_deployment.py
+++ b/tests/test_compose_deployment.py
@@ -1,0 +1,94 @@
+"""Every deployed service must restart unattended and report health.
+
+Health is checked as reachable at runtime, not declared in compose: chap and worker get
+theirs from the image, so a compose-only assertion would miss a worker shipped with none.
+"""
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Test and integration compose files are excluded: a restart policy there would hang CI.
+DEPLOYMENT_COMPOSE_FILES = ["compose.yml", "compose.ghcr.yml", "compose.ewars.yml"]
+
+IMAGE_TO_DOCKERFILE = {
+    "ghcr.io/dhis2-chap/chap-core": "Dockerfile",
+    "ghcr.io/dhis2-chap/chap-worker": "Dockerfile.worker",
+}
+
+
+def _services(compose_file):
+    content = yaml.safe_load((REPO_ROOT / compose_file).read_text())
+    return (content or {}).get("services", {})
+
+
+def _dockerfile_has_healthcheck(dockerfile):
+    path = REPO_ROOT / dockerfile
+    if not path.exists():
+        return False
+    return re.search(r"^HEALTHCHECK\s", path.read_text(), re.MULTILINE) is not None
+
+
+def _healthcheck_source(service):
+    """Which file supplies this service's healthcheck, or None if nothing does."""
+    if service.get("healthcheck"):
+        return "compose"
+
+    build = service.get("build")
+    if isinstance(build, dict):
+        dockerfile = build.get("dockerfile", "Dockerfile")
+    elif isinstance(build, str):
+        dockerfile = "Dockerfile"
+    else:
+        dockerfile = None
+    if dockerfile and _dockerfile_has_healthcheck(dockerfile):
+        return dockerfile
+
+    image = service.get("image")
+    if image:
+        repo = image.rsplit(":", 1)[0]
+        dockerfile = IMAGE_TO_DOCKERFILE.get(repo)
+        if dockerfile and _dockerfile_has_healthcheck(dockerfile):
+            return dockerfile
+
+    return None
+
+
+def _all_services():
+    return [(f, name, svc) for f in DEPLOYMENT_COMPOSE_FILES for name, svc in _services(f).items()]
+
+
+@pytest.mark.parametrize(
+    ("compose_file", "service_name", "service"),
+    _all_services(),
+    ids=[f"{f}:{name}" for f, name, _ in _all_services()],
+)
+def test_deployed_service_restarts_unattended(compose_file, service_name, service):
+    assert service.get("restart") == "unless-stopped", (
+        f"{compose_file}: service '{service_name}' has no restart policy, so it will not come back after a host reboot"
+    )
+
+
+@pytest.mark.parametrize(
+    ("compose_file", "service_name", "service"),
+    _all_services(),
+    ids=[f"{f}:{name}" for f, name, _ in _all_services()],
+)
+def test_deployed_service_reports_health(compose_file, service_name, service):
+    if _healthcheck_source(service) is not None:
+        return
+
+    # An image we do not build is outside this repo's control; anything we build is a gap.
+    image = service.get("image", "")
+    if not service.get("build") and not any(image.startswith(repo) for repo in IMAGE_TO_DOCKERFILE):
+        pytest.skip(f"'{service_name}' uses external image {image!r} and declares no healthcheck")
+
+    pytest.fail(
+        f"{compose_file}: service '{service_name}' has no healthcheck in compose and its "
+        f"image carries none either, so depends_on conditions and restart-on-unhealthy "
+        f"cannot work for it"
+    )

--- a/tests/test_compose_deployment.py
+++ b/tests/test_compose_deployment.py
@@ -12,8 +12,14 @@ import yaml
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
-# Test and integration compose files are excluded: a restart policy there would hang CI.
+# Test and integration compose files are excluded: they overlay compose.yml rather than
+# declaring their own services, so restart policies reach them by inheritance.
 DEPLOYMENT_COMPOSE_FILES = ["compose.yml", "compose.ghcr.yml", "compose.ewars.yml"]
+
+# Services that overlay a compose.yml service but run to completion instead of staying up.
+# They inherit its restart policy, which would restart them after they exit and mask the
+# exit code the shell scripts in tests/ read back.
+ONE_SHOT_OVERLAY_SERVICES = [("compose.test.yml", "chap")]
 
 IMAGE_TO_DOCKERFILE = {
     "ghcr.io/dhis2-chap/chap-core": "Dockerfile",
@@ -91,4 +97,14 @@ def test_deployed_service_reports_health(compose_file, service_name, service):
         f"{compose_file}: service '{service_name}' has no healthcheck in compose and its "
         f"image carries none either, so depends_on conditions and restart-on-unhealthy "
         f"cannot work for it"
+    )
+
+
+@pytest.mark.parametrize(("compose_file", "service_name"), ONE_SHOT_OVERLAY_SERVICES)
+def test_one_shot_overlay_service_cancels_inherited_restart(compose_file, service_name):
+    service = _services(compose_file)[service_name]
+    assert service.get("restart") == "no", (
+        f"{compose_file}: service '{service_name}' runs to completion but does not set "
+        f'restart: "no", so it inherits the deployment restart policy and will be restarted '
+        f"after it exits, hiding its exit code from the test scripts"
     )

--- a/tests/test_compose_deployment.py
+++ b/tests/test_compose_deployment.py
@@ -12,14 +12,8 @@ import yaml
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
-# Test and integration compose files are excluded: they overlay compose.yml rather than
-# declaring their own services, so restart policies reach them by inheritance.
+# Test and integration compose files are excluded: a restart policy there would hang CI.
 DEPLOYMENT_COMPOSE_FILES = ["compose.yml", "compose.ghcr.yml", "compose.ewars.yml"]
-
-# Services that overlay a compose.yml service but run to completion instead of staying up.
-# They inherit its restart policy, which would restart them after they exit and mask the
-# exit code the shell scripts in tests/ read back.
-ONE_SHOT_OVERLAY_SERVICES = [("compose.test.yml", "chap")]
 
 IMAGE_TO_DOCKERFILE = {
     "ghcr.io/dhis2-chap/chap-core": "Dockerfile",
@@ -97,14 +91,4 @@ def test_deployed_service_reports_health(compose_file, service_name, service):
         f"{compose_file}: service '{service_name}' has no healthcheck in compose and its "
         f"image carries none either, so depends_on conditions and restart-on-unhealthy "
         f"cannot work for it"
-    )
-
-
-@pytest.mark.parametrize(("compose_file", "service_name"), ONE_SHOT_OVERLAY_SERVICES)
-def test_one_shot_overlay_service_cancels_inherited_restart(compose_file, service_name):
-    service = _services(compose_file)[service_name]
-    assert service.get("restart") == "no", (
-        f"{compose_file}: service '{service_name}' runs to completion but does not set "
-        f'restart: "no", so it inherits the deployment restart policy and will be restarted '
-        f"after it exits, hiding its exit code from the test scripts"
     )


### PR DESCRIPTION
Adopts the two container practices the Open Climate Service assessment flags chap-core as missing, plus the adjacent gaps found while verifying them.

CLIM-933

## What the assessment said, and what is actually true

- **`restart:` is genuinely absent.** The string appears nowhere in the repository. After a host reboot or Docker daemon restart, no part of the stack comes back. Exactly as described.
- **The `HEALTHCHECK` claim is stale.** `Dockerfile:35` already had one, with `curl` installed at line 19. Worth feeding back to the assessment author. That file is unchanged by this PR.
- **The real gap was the worker.** `Dockerfile.worker` had no `HEALTHCHECK` and `compose.ghcr.yml` added none, so the worker had **no health signal at all** on the GHCR path — the only worker healthcheck in the project lived in `compose.yml`. Confirmed against the published image: `docker inspect ghcr.io/dhis2-chap/chap-worker:latest` returns `null` for `Config.Healthcheck`.
- **`redis`/valkey had no healthcheck** in either file, and dependents used `condition: service_started`, which only means the container started, not that valkey accepts connections.

## Changes

- `restart: unless-stopped` on every long-running service in `compose.yml`, `compose.ghcr.yml` and `compose.ewars.yml`. Deliberately **not** in the test/integration compose files, where it would mask failures and hang CI.
- Worker `HEALTHCHECK` moved into `Dockerfile.worker` and `Dockerfile.inla` (the latter because `compose.dev.yml` builds the worker from it), and the `compose.yml` duplicate removed. This fixes the GHCR path automatically and makes the published image self-describing, matching how `Dockerfile` already works for the API. Same bare `HEALTHCHECK CMD ... || exit 1` form used elsewhere in the repo.
- valkey healthcheck (`valkey-cli ping` — the image ships no `redis-cli`), with `chap` and `worker` now gating on `service_healthy`.

## Verification

Ran end to end, not just parsed:

- Both built images carry a healthcheck, including `chap-worker` where the published image has `null`.
- Full stack up from `compose.yml`: all four services reach `healthy`, including the worker now getting its healthcheck from the image rather than compose.
- Gating chain works: `redis Healthy -> postgres Healthy -> chap Healthy -> ewars Starting` under `-f compose.yml -f compose.chapkit.yml`.
- Restart resilience: killing the gunicorn master inside the container takes it down and `unless-stopped` brings it back (`RestartCount` 0 -> 1). Note `docker kill` does *not* demonstrate this — the daemon flags it as a manual stop and deliberately skips the restart policy.
- All four compose combinations pass `docker compose config`.
- `make lint` clean; `make test` 1259 passed, 118 skipped.

## Test

`tests/test_compose_deployment.py` asserts every deployed service has a restart policy and a healthcheck **reachable at runtime** — from compose or from the image. The second half matters: a compose-only assertion would have passed while the GHCR path shipped a worker with no health signal, which is the actual defect here. Verified it fails when either the restart policy or the `Dockerfile.worker` `HEALTHCHECK` is removed.

## Not included

- **Chapkit model images running as root.** The image is built in the `chap-models` org, not here. A compose-level `user:` is possible but needs testing against the image's write paths; the fix belongs upstream.
- **Pinning the `:latest` tags.** `ci-build-docker-images.yml` already publishes `v1.*`/`v2.*` tags so this is available whenever wanted, but it also touches `README.md` and `docs/modeling-app/fresh-installation.md` and implies a release-cadence decision.
