### PR TITLE
fix(runners): report command output as text on failure

### DIFF
--- a/chap_core/runners/command_line_runner.py
+++ b/chap_core/runners/command_line_runner.py
@@ -33,41 +33,23 @@ def run_command(command: str, working_directory=Path("."), env: dict | None = No
         Environment variables to use. If None, uses the current environment.
     """
     logging.debug(f"Running command: {command}")
-    # command = command.split()
+    process = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=working_directory, shell=True, env=env
+    )
+    stdout, stderr = process.communicate()
+    # Model output is not guaranteed to be valid UTF-8 (locale-dependent R
+    # warnings, for instance); a failed model must still produce a readable
+    # error message rather than a UnicodeDecodeError.
+    output = stdout.decode(errors="replace") + "\n" + stderr.decode(errors="replace")
+    return_code = process.returncode
 
-    try:
-        process = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=working_directory, shell=True, env=env
+    if return_code != 0:
+        message = (
+            f"Command '{command}' failed with return code {return_code}, "
+            f"Full output from command below: \n ----- \n{output} \n--------"
         )
-        stdout, stderr = process.communicate()
-        output = stdout.decode() + "\n" + stderr.decode()
-        """
-        output = []
-        for c in iter(lambda: process.stdout.read(1), b""):
-            sys.stdout.buffer.write(c)
-            output.append(c.decode("utf-8"))
-        for c in iter(lambda: process.stderr.read(1), b""):
-            sys.stderr.buffer.write(c)
-            output.append(c.decode("utf-8"))
-        output = ''.join(output)
-        """
-
-        streamdata = process.communicate()[0]  # finnish before getting return code
-        return_code = process.returncode
-
-        if return_code != 0:
-            logger.error(
-                f"Command '{command}' failed with return code {return_code}, ({''.join(map(str, streamdata))}, {output}"
-            )
-            raise CommandLineException(
-                f"Command '{command}' failed with return code {return_code}, Full output from command below: \n ----- \n({''.join(map(str, streamdata))}, {output} \n--------"
-            )
-        # output = subprocess.check_output(' '.join(command), cwd=working_directory, shell=True)
-        # logging.info(output)
-    except subprocess.CalledProcessError as e:
-        error = e.output.decode()
-        logger.info(error)
-        raise e
+        logger.error(message)
+        raise CommandLineException(message)
 
     return output
 

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -67,11 +67,14 @@ def test_run_command_failure_with_non_utf8_output_is_still_readable():
     still raise CommandLineException with a readable message instead of
     crashing with UnicodeDecodeError."""
     with pytest.raises(CommandLineException) as exc_info:
-        CommandLineRunner("./").run_command("printf 'boom-\\xff-stderr' >&2; exit 1")
+        # Octal escape, not \xff: /bin/sh is dash on CI and dash's printf does not
+        # implement hex escapes, so \xff would emit literal ASCII instead of a raw byte.
+        CommandLineRunner("./").run_command("printf 'boom-\\377-stderr' >&2; exit 1")
 
     message = str(exc_info.value)
     assert "boom-" in message
     assert "-stderr" in message
+    assert "\ufffd" in message
 
 
 def test_uv_runner_prepends_uv_run():

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -46,6 +46,34 @@ def test_run_command():
     assert "test2" in output, "Output from command not as expected, output is: " + output
 
 
+def test_run_command_failure_reports_output_as_text():
+    """A failing command must report stdout/stderr as text.
+
+    The message used to include a second, byte-wise stringified copy of stdout
+    (``''.join(map(str, streamdata))``), which rendered the output as a run of
+    concatenated decimal byte values and made model failures unreadable.
+    """
+    with pytest.raises(CommandLineException) as exc_info:
+        CommandLineRunner("./").run_command("echo 'boom-stdout'; echo 'boom-stderr' >&2; exit 1")
+
+    message = str(exc_info.value)
+    assert "boom-stdout" in message
+    assert "boom-stderr" in message
+    assert "".join(str(byte) for byte in b"boom-stdout") not in message
+
+
+def test_run_command_failure_with_non_utf8_output_is_still_readable():
+    """Model output is not guaranteed to be valid UTF-8; a failing command must
+    still raise CommandLineException with a readable message instead of
+    crashing with UnicodeDecodeError."""
+    with pytest.raises(CommandLineException) as exc_info:
+        CommandLineRunner("./").run_command("printf 'boom-\\xff-stderr' >&2; exit 1")
+
+    message = str(exc_info.value)
+    assert "boom-" in message
+    assert "-stderr" in message
+
+
 def test_uv_runner_prepends_uv_run():
     """Test that UvRunner correctly prepends 'uv run' to commands"""
     with patch.object(UvRunner, "_execute") as mock_execute:


### PR DESCRIPTION
Jira: [CLIM-930](https://dhis2.atlassian.net/browse/CLIM-930)

Split out of #528, which bundled this with an unrelated backtest resilience change. The other half is in the companion PR linked below.

## The problem

`chap_core/runners/command_line_runner.py` called `process.communicate()` a second time after the first call had already consumed the streams, then embedded the result with `''.join(map(str, streamdata))`. Iterating `bytes` yields `int`, so each byte was rendered as a decimal number:

```
>>> out, err = p.communicate()
>>> ''.join(map(str, p.communicate()[0]))
'10410510'          # this is b'hi\n'
```

In a reported EWARS failure this produced a 12,167-digit run of concatenated ASCII codes carrying no information that the decoded output did not already contain. Combined with the exception being re-wrapped into `ModelFailedException` and printed in both halves of the `__cause__` chain, the R log appeared four times in what should have been a ~50 line report.

## The change

- Drop the redundant `communicate()` call; build the message once from the already decoded stdout/stderr.
- Decode with `errors="replace"`. Model output is not guaranteed to be valid UTF-8 (locale-dependent R warnings, for instance), and a failed model must still produce a readable error rather than a `UnicodeDecodeError`.
- Remove the commented-out streaming block and the `except subprocess.CalledProcessError` handler, which could never fire since `Popen` does not raise it.

## Tests

- `test_run_command_failure_reports_output_as_text` -- stdout and stderr appear as text, and the byte-wise stringified form does not.
- `test_run_command_failure_with_non_utf8_output_is_still_readable`

`make lint` clean; `tests/runners/test_runners.py` 25 passed, 1 skipped.

## Related

- Supersedes half of #528
- [CLIM-929](https://dhis2.atlassian.net/browse/CLIM-929) -- the EWARS model bug that surfaced this


[CLIM-930]: https://dhis2.atlassian.net/browse/CLIM-930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-929]: https://dhis2.atlassian.net/browse/CLIM-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ