### PR TITLE
fix(assessment): keep usable splits when a backtest split fails

### DIFF
--- a/chap_core/assessment/prediction_evaluator.py
+++ b/chap_core/assessment/prediction_evaluator.py
@@ -24,11 +24,19 @@ from chap_core.assessment.dataset_splitting import (
 )
 from chap_core.data.gluonts_adaptor.dataset import ForecastAdaptor
 from chap_core.datatypes import Samples, SamplesWithTruth, TimeSeriesData
+from chap_core.exceptions import ModelFailedException
+from chap_core.log_config import get_status_logger
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 from chap_core.time_period import PeriodRange
 
 plt.set_loglevel(level="WARNING")
 logger = logging.getLogger(__name__)
+status_logger = get_status_logger()
+
+# With no successful split yet, this many consecutive failures is treated as a
+# systemically broken model and aborts the backtest instead of retrying every
+# remaining split.
+_MAX_INITIAL_FAILURES = 2
 
 
 FeatureType = TypeVar("FeatureType", bound=TimeSeriesData)
@@ -95,23 +103,64 @@ def backtest(
     DataSet[SamplesWithTruth]
         For each test split, a dataset mapping locations to
         ``SamplesWithTruth`` (predicted samples merged with observed values).
+
+    Raises
+    ------
+    ModelFailedException
+        If no split has succeeded yet and ``_MAX_INITIAL_FAILURES`` splits in
+        a row have failed (the model is considered systemically broken), or if
+        every split failed to predict. Individual split failures are logged
+        and skipped so that one unstable split does not discard the results of
+        all the others; training failures are always fatal.
     """
     train_set, test_generator = train_test_generator(
         data, prediction_length, n_test_sets, stride=stride, future_weather_provider=weather_provider
     )
     retrain_at = _retrain_split_indices(n_test_sets, n_retrain)
     predictor: Predictor | None = None
+    n_failed = 0
+    n_predicted = 0
+    last_error: Exception | None = None
     for i, (historic_data, future_data, future_truth) in enumerate(test_generator):
         if i in retrain_at:
             # Split 0 trains on the dedicated train_set (preserving the single-train
             # behaviour exactly); later retrains use the expanding historic window.
             predictor = estimator.train(train_set if i == 0 else historic_data)
         assert predictor is not None, "First split must trigger training"
-        r = predictor.predict(historic_data, future_data)
+        try:
+            r = predictor.predict(historic_data, future_data)
+        except Exception as e:
+            # A model can fail on a single split (numerical instability, a
+            # degenerate window) while succeeding on the rest. Keep the usable
+            # splits instead of discarding the whole backtest. The catch is
+            # deliberately broad: chapkit and in-process models raise raw
+            # exceptions rather than ModelFailedException.
+            n_failed += 1
+            last_error = e
+            logger.exception("Model failed on evaluation split %d, skipping it", i)
+            status_logger.warning(f"Model failed on evaluation split {i}, skipping it")
+            if not n_predicted and n_failed >= min(_MAX_INITIAL_FAILURES, n_test_sets):
+                # No split has succeeded yet: the model is likely broken for
+                # this dataset, not unstable on one window. Fail fast instead
+                # of paying for a full model run per remaining split.
+                raise ModelFailedException(
+                    f"The first {n_failed} evaluation split(s) failed, aborting the backtest. Last error: {e}"
+                ) from e
+            continue
         if r is None:
             continue
+        n_predicted += 1
         samples_with_truth = future_truth.merge(r, result_dataclass=SamplesWithTruth)  # type: ignore[arg-type]
         yield samples_with_truth
+
+    if n_failed:
+        if not n_predicted:
+            raise ModelFailedException(
+                f"All {n_failed} evaluation splits failed. Last error: {last_error}"
+            ) from last_error
+        message = f"{n_failed} of {n_failed + n_predicted} evaluation splits failed and were skipped"
+        logger.warning(message)
+        status_logger.warning(message)
 
 
 def evaluate_model(

--- a/chap_core/docker_helper_functions.py
+++ b/chap_core/docker_helper_functions.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import docker
 
-from chap_core.exceptions import DockerUnavailableError
+from chap_core.exceptions import CommandLineException, DockerUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -86,8 +86,17 @@ def run_command_through_docker_container(
 
     result = container.wait()
     exit_code = result["StatusCode"]
-    log_output = container.logs().decode("utf-8")
-    assert exit_code == 0, f"Command failed with exit code {exit_code}: {log_output}"
+    log_output = container.logs().decode("utf-8", errors="replace")
+    if exit_code != 0:
+        # Raise the same exception type as CommandLineRunner so callers
+        # (e.g. the per-split backtest error handling) treat a failed
+        # container like any other failed model command.
+        message = (
+            f"Command '{command}' in docker image {docker_image_name} failed with exit code {exit_code}, "
+            f"Full output from command below: \n ----- \n{log_output} \n--------"
+        )
+        logger.error(message)
+        raise CommandLineException(message)
     container.remove()
 
     return log_output

--- a/tests/evaluation/test_prediction_evaluator.py
+++ b/tests/evaluation/test_prediction_evaluator.py
@@ -1,6 +1,9 @@
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from chap_core.assessment.prediction_evaluator import backtest
+from chap_core.exceptions import ModelFailedException
 
 
 def test_backtest_passes_stride_to_train_test_generator():
@@ -45,3 +48,94 @@ def test_backtest_retrains_at_evenly_spaced_splits():
     trained_on = [call.args[0] for call in mock_estimator.train.call_args_list]
     # Split 0 uses train_set; the halfway retrain (split 2) uses its expanding historic window.
     assert trained_on == ["train_set", "historic2"]
+
+
+def test_backtest_skips_failing_split_and_keeps_the_rest():
+    """One split failing must not discard the splits that succeeded."""
+    mock_estimator = MagicMock()
+    predictor = mock_estimator.train.return_value
+    predictor.predict.side_effect = [
+        "prediction0",
+        ModelFailedException("inla segfaulted"),
+        "prediction2",
+    ]
+    splits = _splits(3)
+
+    with patch("chap_core.assessment.prediction_evaluator.train_test_generator") as mock_ttg:
+        mock_ttg.return_value = ("train_set", iter(splits))
+
+        results = list(backtest(mock_estimator, MagicMock(), prediction_length=3, n_test_sets=3, stride=1))
+
+    assert len(results) == 2
+    merged_predictions = [split[2].merge.call_args.args[0] for split in splits if split[2].merge.called]
+    assert merged_predictions == ["prediction0", "prediction2"]
+
+
+def test_backtest_skips_raw_exception_split_and_keeps_the_rest():
+    """Chapkit and in-process models raise raw exceptions (RuntimeError,
+    LinAlgError, ...) rather than ModelFailedException; those splits must be
+    skipped the same way."""
+    mock_estimator = MagicMock()
+    predictor = mock_estimator.train.return_value
+    predictor.predict.side_effect = [
+        "prediction0",
+        RuntimeError("Prediction failed: chapkit job died"),
+        "prediction2",
+    ]
+    splits = _splits(3)
+
+    with patch("chap_core.assessment.prediction_evaluator.train_test_generator") as mock_ttg:
+        mock_ttg.return_value = ("train_set", iter(splits))
+
+        results = list(backtest(mock_estimator, MagicMock(), prediction_length=3, n_test_sets=3, stride=1))
+
+    assert len(results) == 2
+
+
+def test_backtest_tolerates_one_initial_failure():
+    """A failure on the very first split alone must not abort the backtest."""
+    mock_estimator = MagicMock()
+    predictor = mock_estimator.train.return_value
+    predictor.predict.side_effect = [
+        ModelFailedException("inla segfaulted"),
+        "prediction1",
+        "prediction2",
+    ]
+
+    with patch("chap_core.assessment.prediction_evaluator.train_test_generator") as mock_ttg:
+        mock_ttg.return_value = ("train_set", iter(_splits(3)))
+
+        results = list(backtest(mock_estimator, MagicMock(), prediction_length=3, n_test_sets=3, stride=1))
+
+    assert len(results) == 2
+
+
+def test_backtest_aborts_early_when_no_split_succeeds():
+    """With no successful split yet, repeated failures mean the model is
+    systemically broken; abort instead of retrying every remaining split, and
+    chain the underlying model error so job errors stay diagnosable."""
+    mock_estimator = MagicMock()
+    error = ModelFailedException("inla segfaulted")
+    predictor = mock_estimator.train.return_value
+    predictor.predict.side_effect = error
+
+    with patch("chap_core.assessment.prediction_evaluator.train_test_generator") as mock_ttg:
+        mock_ttg.return_value = ("train_set", iter(_splits(10)))
+
+        with pytest.raises(ModelFailedException, match="inla segfaulted") as exc_info:
+            list(backtest(mock_estimator, MagicMock(), prediction_length=3, n_test_sets=10, stride=1))
+
+    assert exc_info.value.__cause__ is error
+    assert predictor.predict.call_count == 2
+
+
+def test_backtest_does_not_swallow_training_failures():
+    """A model that cannot train at all is fatal; there is nothing to fall back on."""
+    mock_estimator = MagicMock()
+    mock_estimator.train.side_effect = ModelFailedException("training blew up")
+
+    with patch("chap_core.assessment.prediction_evaluator.train_test_generator") as mock_ttg:
+        mock_ttg.return_value = ("train_set", iter(_splits(3)))
+
+        with pytest.raises(ModelFailedException, match="training blew up"):
+            list(backtest(mock_estimator, MagicMock(), prediction_length=3, n_test_sets=3, stride=1))

--- a/tests/external/test_docker.py
+++ b/tests/external/test_docker.py
@@ -1,10 +1,12 @@
+from unittest.mock import MagicMock
+
 import docker.errors
 import pytest
 from chap_core.docker_helper_functions import (
     create_docker_image,
     run_command_through_docker_container,
 )
-from chap_core.exceptions import DockerUnavailableError
+from chap_core.exceptions import CommandLineException, DockerUnavailableError
 from chap_core.util import docker_available
 
 
@@ -62,3 +64,21 @@ def test_docker_unavailable_locally(monkeypatch):
         run_command_through_docker_container("some_model", "./", "echo hi")
     msg = str(excinfo.value)
     assert "Docker Desktop" in msg or "systemctl start docker" in msg
+
+
+def test_failed_container_raises_command_line_exception(monkeypatch):
+    """A non-zero container exit must raise CommandLineException (like
+    CommandLineRunner) so the per-split backtest error handling applies to
+    docker-backed models too."""
+    client = MagicMock()
+    container = client.containers.run.return_value
+    container.wait.return_value = {"StatusCode": 137}
+    container.logs.return_value = b"inla segfaulted"
+    monkeypatch.setattr("chap_core.docker_helper_functions.docker.from_env", lambda: client)
+
+    with pytest.raises(CommandLineException) as excinfo:
+        run_command_through_docker_container("some_image", "./", "Rscript train.R")
+
+    msg = str(excinfo.value)
+    assert "exit code 137" in msg
+    assert "inla segfaulted" in msg


### PR DESCRIPTION
Jira: [CLIM-930](https://dhis2.atlassian.net/browse/CLIM-930)

Split out of #528, which bundled this with an unrelated error-reporting fix. The other half is #536.

## The problem

`chap_core/assessment/prediction_evaluator.py:backtest` let a per-split `predict` exception escape the generator. A model that fails on a single split -- numerical instability, a degenerate window -- took all the other splits down with it. In a reported EWARS backtest (9 provinces, 10 years, 5 covariates), split 0 of 10 failed and the run produced nothing at all.

The model bug itself -- a rank-deficient dlnm lag basis at `n_lags = 3` -- lives in the model repos and is not addressed here; it is tracked in [CLIM-929](https://dhis2.atlassian.net/browse/CLIM-929).

## The change

- Failed splits are logged and skipped instead of aborting the run.
- While no split has yet succeeded, two consecutive failures abort the backtest, so a model that is broken for the whole dataset does not pay for a full model run per remaining split.
- A run where every split failed raises `ModelFailedException`, so an empty backtest is never silently persisted.
- Training failures remain fatal; there is no predictor to fall back on.
- `run_command_through_docker_container` raised a bare `AssertionError` on a non-zero container exit. It now raises `CommandLineException` like `CommandLineRunner`, so docker-backed model failures reach the same per-split handling, and its logs decode with `errors="replace"`.

## Tests

- `test_backtest_skips_failing_split_and_keeps_the_rest`
- `test_backtest_skips_raw_exception_split_and_keeps_the_rest`
- `test_backtest_tolerates_one_initial_failure`
- `test_backtest_aborts_early_when_no_split_succeeds`
- `test_backtest_does_not_swallow_training_failures`
- `test_failed_container_raises_command_line_exception`

ruff and mypy clean; the two touched test modules pass (11 passed, 3 skipped).

## Related

- Supersedes half of #528
- #536 -- the error-reporting half
- [CLIM-929](https://dhis2.atlassian.net/browse/CLIM-929) -- the EWARS model bug that surfaced this


[CLIM-930]: https://dhis2.atlassian.net/browse/CLIM-930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-929]: https://dhis2.atlassian.net/browse/CLIM-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-929]: https://dhis2.atlassian.net/browse/CLIM-929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ