### PR TITLE
docs: document compose overlays and running your own model (CLIM-504)

### DIFF
--- a/config/configured_models/README.md
+++ b/config/configured_models/README.md
@@ -8,11 +8,12 @@ On startup, the REST API calls `seed_configured_models_from_config_dir()` (in `c
 
 1. Parses `default.yaml` first, keeping only the **last version** listed for each model (earlier versions serve as historical documentation).
 2. Parses all other `*.yaml` files in this directory (e.g. `local.yaml`, `benchmark_models.yaml`), keeping **all versions** listed.
-3. For each model entry, takes the last version and constructs a GitHub URL (`{url}@{commit}`).
-4. Fetches the `MLProject.yaml` from the GitHub repository at that commit to get model metadata (name, description, covariates, user options, etc.).
-5. Inserts a `ModelTemplateDB` row (or updates it if the name already exists).
-6. For each configuration listed under `configurations:`, inserts a `ConfiguredModelDB` row with the specified user option values and additional covariates.
-7. Finally, adds a built-in naive model template used for testing.
+3. For each model entry, fetches the model metadata (name, description, covariates, user options, etc.). How this happens depends on `uses_chapkit`:
+   - **MLproject models** (`uses_chapkit: false`, the default): takes the last version, constructs a GitHub URL (`{url}@{commit}`) and fetches `MLProject.yaml` from the repository at that commit.
+   - **Chapkit models** (`uses_chapkit: true`): treats `url` as the base URL of a running chapkit service, waits up to 30 seconds for it to report healthy, and reads the template config over HTTP. `versions` is ignored. If the service does not become healthy, the model is skipped with an error in the log and seeding continues.
+4. Inserts a `ModelTemplateDB` row (or updates it if the name already exists).
+5. For each configuration listed under `configurations:`, inserts a `ConfiguredModelDB` row with the specified user option values and additional covariates.
+6. Finally, adds a built-in naive model template used for testing.
 
 Models that already exist in the database (matched by name) are updated rather than duplicated, so seeding is idempotent.
 
@@ -34,9 +35,26 @@ Models that already exist in the database (matched by name) are updated rather t
 
 ### Fields
 
-- **url**: GitHub repository URL for the model.
-- **versions**: Named versions mapping to git refs. Prefix with `@` for commits/branches. In `default.yaml`, only the last version is used; in other files, all versions are available.
+- **url**: For MLproject models, the GitHub repository URL. For chapkit models (`uses_chapkit: true`), the base URL of the running chapkit service, e.g. `http://my-model:8000` using the compose service name.
+- **name** (optional): Overrides the template name declared by the model itself. Use it to avoid name clashes when seeding two variants of the same model.
+- **uses_chapkit** (optional, default `false`): Set to `true` when `url` points at a running chapkit service rather than a GitHub repository. See [Running Your Own Model](../../docs/modeling-app/running-your-own-model.md).
+- **versions**: Named versions mapping to git refs. Prefix with `@` for commits/branches. In `default.yaml`, only the last version is used; in other files, all versions are available. Ignored for chapkit models.
 - **configurations** (optional): Named configurations for the model template. Each configuration can set `user_option_values` (model-specific parameters) and `additional_continuous_covariates`. If omitted, a single "default" configuration with empty values is created.
+
+### Chapkit service example
+
+```yaml
+# config/configured_models/local.yaml
+- url: http://my-model:8000
+  uses_chapkit: true
+  versions:
+    v1: "/v1"
+  configurations:
+    default:
+      user_option_values: {}
+```
+
+The service must be reachable from inside the `chap` container and healthy when Chap starts, so declare it in the same Docker Compose project and give the `chap` service a `depends_on` on it (or accept that the first seeding attempt may miss it and restart Chap afterwards).
 
 ## Adding models
 

--- a/config/configured_models/README.md
+++ b/config/configured_models/README.md
@@ -6,11 +6,11 @@ This directory contains YAML files that define which model templates and configu
 
 On startup, the REST API calls `seed_configured_models_from_config_dir()` (in `chap_core/database/model_template_seed.py`), which:
 
-1. Parses `default.yaml` first, keeping only the **last version** listed for each model (earlier versions serve as historical documentation).
-2. Parses all other `*.yaml` files in this directory (e.g. `local.yaml`, `benchmark_models.yaml`), keeping **all versions** listed.
+1. Parses `default.yaml` first, discarding everything but the **last version** listed for each model (earlier versions serve as historical documentation).
+2. Parses all other `*.yaml` files in this directory (e.g. `local.yaml`, `benchmark_models.yaml`). These keep all versions through parsing, but seeding still only uses the last one, so listing several has no effect.
 3. For each model entry, fetches the model metadata (name, description, covariates, user options, etc.). How this happens depends on `uses_chapkit`:
    - **MLproject models** (`uses_chapkit: false`, the default): takes the last version, constructs a GitHub URL (`{url}@{commit}`) and fetches `MLProject.yaml` from the repository at that commit.
-   - **Chapkit models** (`uses_chapkit: true`): treats `url` as the base URL of a running chapkit service, waits up to 30 seconds for it to report healthy, and reads the template config over HTTP. `versions` is ignored. If the service does not become healthy, the model is skipped with an error in the log and seeding continues.
+   - **Chapkit models** (`uses_chapkit: true`): treats `url` as the base URL of a running chapkit service, waits up to 30 seconds for it to report healthy, and reads the template config over HTTP. The `versions` values are unused here, but the field is still required. If the service does not become healthy, the model is skipped with an error in the log and seeding continues.
 4. Inserts a `ModelTemplateDB` row (or updates it if the name already exists).
 5. For each configuration listed under `configurations:`, inserts a `ConfiguredModelDB` row with the specified user option values and additional covariates.
 6. Finally, adds a built-in naive model template used for testing.
@@ -22,7 +22,7 @@ Models that already exist in the database (matched by name) are updated rather t
 ```yaml
 - url: https://github.com/org/model-repo
   versions:
-    v1: "@<commit-sha>"          # historical, ignored in default.yaml
+    v1: "@<commit-sha>"           # historical documentation only
     v2: "@<commit-sha-or-branch>" # last entry is the one that gets seeded
   configurations:                 # optional, defaults to a single "default" config
     config_name:
@@ -36,9 +36,9 @@ Models that already exist in the database (matched by name) are updated rather t
 ### Fields
 
 - **url**: For MLproject models, the GitHub repository URL. For chapkit models (`uses_chapkit: true`), the base URL of the running chapkit service, e.g. `http://my-model:8000` using the compose service name.
-- **name** (optional): Overrides the template name declared by the model itself. Use it to avoid name clashes when seeding two variants of the same model.
+- **name** (optional): Overrides the template name declared by the model itself. Use it to avoid name clashes when seeding two variants of the same model. Applies to MLproject models only -- chapkit templates always take their name from the id the service advertises.
 - **uses_chapkit** (optional, default `false`): Set to `true` when `url` points at a running chapkit service rather than a GitHub repository. See [Running Your Own Model](../../docs/modeling-app/running-your-own-model.md).
-- **versions**: Named versions mapping to git refs. Prefix with `@` for commits/branches. In `default.yaml`, only the last version is used; in other files, all versions are available. Ignored for chapkit models.
+- **versions** (required): Named versions mapping to git refs. Prefix with `@` for commits/branches. Only the last entry is seeded, in every file -- earlier entries serve as historical documentation. The value is unused for chapkit models, but the field is still required: omitting it fails validation and aborts startup, so give a placeholder such as `v1: "/v1"`.
 - **configurations** (optional): Named configurations for the model template. Each configuration can set `user_option_values` (model-specific parameters) and `additional_continuous_covariates`. If omitted, a single "default" configuration with empty values is created.
 
 ### Chapkit service example
@@ -59,6 +59,8 @@ Seed a chapkit service from configuration only when it cannot be given the regis
 ```
 
 The service must be reachable from inside the `chap` container and healthy when Chap starts, so declare it in the same Docker Compose project and give the `chap` service a `depends_on` on it (or accept that the first seeding attempt may miss it and restart Chap afterwards).
+
+The service's metadata must also leave `repository_url` unset. When it is set, the seeded template stores that GitHub address as its `source_url` and the service's own HTTP address is kept nowhere, so predictions are sent to GitHub and fail. Self-registering services avoid this because Chap resolves their live address from the service registry at prediction time; a config-seeded service is not in that registry.
 
 ## Adding models
 

--- a/config/configured_models/README.md
+++ b/config/configured_models/README.md
@@ -43,6 +43,10 @@ Models that already exist in the database (matched by name) are updated rather t
 
 ### Chapkit service example
 
+Chapkit services normally do **not** belong in these files. They register themselves with Chap on startup via `SERVICEKIT_ORCHESTRATOR_URL`, which needs no entry here and no image rebuild -- see [Running Your Own Model](../../docs/modeling-app/running-your-own-model.md).
+
+Seed a chapkit service from configuration only when it cannot be given the registration environment variables:
+
 ```yaml
 # config/configured_models/local.yaml
 - url: http://my-model:8000

--- a/config/configured_models/README.md
+++ b/config/configured_models/README.md
@@ -8,9 +8,7 @@ On startup, the REST API calls `seed_configured_models_from_config_dir()` (in `c
 
 1. Parses `default.yaml` first, discarding everything but the **last version** listed for each model (earlier versions serve as historical documentation).
 2. Parses all other `*.yaml` files in this directory (e.g. `local.yaml`, `benchmark_models.yaml`). These keep all versions through parsing, but seeding still only uses the last one, so listing several has no effect.
-3. For each model entry, fetches the model metadata (name, description, covariates, user options, etc.). How this happens depends on `uses_chapkit`:
-   - **MLproject models** (`uses_chapkit: false`, the default): takes the last version, constructs a GitHub URL (`{url}@{commit}`) and fetches `MLProject.yaml` from the repository at that commit.
-   - **Chapkit models** (`uses_chapkit: true`): treats `url` as the base URL of a running chapkit service, waits up to 30 seconds for it to report healthy, and reads the template config over HTTP. The `versions` values are unused here, but the field is still required. If the service does not become healthy, the model is skipped with an error in the log and seeding continues.
+3. For each model entry, takes the last version, constructs a GitHub URL (`{url}@{commit}`) and fetches `MLProject.yaml` from the repository at that commit to get the model metadata (name, description, covariates, user options, etc.).
 4. Inserts a `ModelTemplateDB` row (or updates it if the name already exists).
 5. For each configuration listed under `configurations:`, inserts a `ConfiguredModelDB` row with the specified user option values and additional covariates.
 6. Finally, adds a built-in naive model template used for testing.
@@ -35,32 +33,12 @@ Models that already exist in the database (matched by name) are updated rather t
 
 ### Fields
 
-- **url**: For MLproject models, the GitHub repository URL. For chapkit models (`uses_chapkit: true`), the base URL of the running chapkit service, e.g. `http://my-model:8000` using the compose service name.
-- **name** (optional): Overrides the template name declared by the model itself. Use it to avoid name clashes when seeding two variants of the same model. Applies to MLproject models only -- chapkit templates always take their name from the id the service advertises.
-- **uses_chapkit** (optional, default `false`): Set to `true` when `url` points at a running chapkit service rather than a GitHub repository. See [Running Your Own Model](../../docs/modeling-app/running-your-own-model.md).
-- **versions** (required): Named versions mapping to git refs. Prefix with `@` for commits/branches. Only the last entry is seeded, in every file -- earlier entries serve as historical documentation. The value is unused for chapkit models, but the field is still required: omitting it fails validation and aborts startup, so give a placeholder such as `v1: "/v1"`.
+- **url**: The GitHub repository URL for the model.
+- **name** (optional): Overrides the template name declared by the model itself. Use it to avoid name clashes when seeding two variants of the same model.
+- **versions** (required): Named versions mapping to git refs. Prefix with `@` for commits/branches. Only the last entry is seeded, in every file -- earlier entries serve as historical documentation.
 - **configurations** (optional): Named configurations for the model template. Each configuration can set `user_option_values` (model-specific parameters) and `additional_continuous_covariates`. If omitted, a single "default" configuration with empty values is created.
 
-### Chapkit service example
-
-Chapkit services normally do **not** belong in these files. They register themselves with Chap on startup via `SERVICEKIT_ORCHESTRATOR_URL`, which needs no entry here and no image rebuild -- see [Running Your Own Model](../../docs/modeling-app/running-your-own-model.md).
-
-Seed a chapkit service from configuration only when it cannot be given the registration environment variables:
-
-```yaml
-# config/configured_models/local.yaml
-- url: http://my-model:8000
-  uses_chapkit: true
-  versions:
-    v1: "/v1"
-  configurations:
-    default:
-      user_option_values: {}
-```
-
-The service must be reachable from inside the `chap` container and healthy when Chap starts, so declare it in the same Docker Compose project and give the `chap` service a `depends_on` on it (or accept that the first seeding attempt may miss it and restart Chap afterwards).
-
-The service's metadata must also leave `repository_url` unset. When it is set, the seeded template stores that GitHub address as its `source_url` and the service's own HTTP address is kept nowhere, so predictions are sent to GitHub and fail. Self-registering services avoid this because Chap resolves their live address from the service registry at prediction time; a config-seeded service is not in that registry.
+Chapkit model services do **not** belong in these files. They register themselves with Chap on startup via `SERVICEKIT_ORCHESTRATOR_URL`, which needs no entry here and no image rebuild -- see [Running Your Own Model](../../docs/modeling-app/running-your-own-model.md).
 
 ## Adding models
 

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -127,20 +127,5 @@
 #    v1: "@chap"
 
 
-## chtorch model (through chapkit, service defined in compose.override.yml.example)
-#- url: http://chtorch:8000
-##- url: http://193.157.251.13:5004  # for testing locally, replace with local ip
-#  uses_chapkit: true
-#  versions:
-#    v1: "/v1"
-#  configurations:
-#    debug:
-#        max_epochs: 2
-
-
-#- url: http://193.157.236.38:5003  # for testing locally, replace with local ip
-#  uses_chapkit: true
-#  versions:
-#    v1: "/v1"
-#  configurations:
-#    chapkit: {}
+# Chapkit model services are not listed here. They register themselves with Chap
+# on startup via SERVICEKIT_ORCHESTRATOR_URL, see docs/modeling-app/running-your-own-model.md

--- a/config/configured_models/default.yaml
+++ b/config/configured_models/default.yaml
@@ -127,7 +127,7 @@
 #    v1: "@chap"
 
 
-## chtorch model (thrugh chapkit, defined in compose.yml)
+## chtorch model (through chapkit, service defined in compose.override.yml.example)
 #- url: http://chtorch:8000
 ##- url: http://193.157.251.13:5004  # for testing locally, replace with local ip
 #  uses_chapkit: true

--- a/docs/modeling-app/enabling-optional-model-services.md
+++ b/docs/modeling-app/enabling-optional-model-services.md
@@ -5,6 +5,8 @@ Some models require an external service to be running alongside Chap. These serv
 !!! note
     This page covers models that are **not** part of the bundled overlay. The bundled model services started by `compose.chapkit.yml` (see [First-time Setup](fresh-installation.md)) register themselves automatically and need no config edits or rebuild. Use the steps below only for additional services like `ewars_plus` or `chtorch`.
 
+    To add a model service of your **own**, see [Running Your Own Model](running-your-own-model.md).
+
 ## Available Optional Services
 
 | Service | Image | Port | Description |

--- a/docs/modeling-app/enabling-optional-model-services.md
+++ b/docs/modeling-app/enabling-optional-model-services.md
@@ -16,7 +16,10 @@ Some models require an external service to be running alongside Chap. These serv
 
 ## Setup
 
-Chap ships with a `compose.override.yml.example` file that defines these optional services. Docker Compose automatically merges `compose.override.yml` with `compose.yml` when both are present.
+Chap ships with a `compose.override.yml.example` file that defines these optional services.
+
+!!! warning "Pass `-f compose.override.yml` explicitly"
+    Compose only merges `compose.override.yml` on its own when you run a bare `docker compose` with no `-f` flags at all. As soon as you pass any `-f` — as [First-time Setup](fresh-installation.md) does — the override file is ignored, silently and with no error, so the optional services never start. The commands below assume the `compose.chapkit.yml` overlay from that guide; adjust them to match how you started Chap, keeping `compose.override.yml` last.
 
 ### 1. Copy the overlay file
 
@@ -55,8 +58,8 @@ See [Managing models](managing-model-templates.md) for details on the configured
 After adding the overlay and the model configuration, rebuild the Chap images (so the new config is included) and start all services:
 
 ```console
-docker compose build chap worker
-docker compose up -d
+docker compose -f compose.yml -f compose.chapkit.yml -f compose.override.yml build chap worker
+docker compose -f compose.yml -f compose.chapkit.yml -f compose.override.yml up -d
 ```
 
 ### 5. Verify
@@ -64,7 +67,7 @@ docker compose up -d
 Check that the service is running and the model appears in the API:
 
 ```console
-docker compose ps
+docker compose -f compose.yml -f compose.chapkit.yml -f compose.override.yml ps
 curl http://localhost:8000/v1/crud/configured-models
 ```
 

--- a/docs/modeling-app/running-your-own-model.md
+++ b/docs/modeling-app/running-your-own-model.md
@@ -25,13 +25,16 @@ This is how the bundled model services work, and it is the way to attach a model
 
 ### 1. Create a Compose override file
 
-Chap picks up a `compose.override.yml` file automatically, with no extra `-f` flag. Start from the shipped example:
+Declare your service in a `compose.override.yml` file. Start from the shipped example:
 
 ```console
 cp compose.override.yml.example compose.override.yml
 ```
 
 Remove the sample services you do not need, and add your own.
+
+!!! warning "Pass `-f compose.override.yml` explicitly"
+    Compose only discovers `compose.override.yml` on its own when you run a bare `docker compose` with no `-f` flags at all. As soon as you pass any `-f` — as the installation guide does — the override file is ignored, silently and with no error, so your model never starts. Every command on this page therefore lists it explicitly, last, so its settings win.
 
 ### 2. Declare your service
 
@@ -56,7 +59,7 @@ The important parts:
 
 - **`SERVICEKIT_ORCHESTRATOR_URL`** points at Chap's registration endpoint using the Compose service name `chap`, not `localhost`. The `$$` is not a typo — Compose expands `$` as a variable, so `$$register` is how you write a literal `$register`.
 - **`depends_on: chap: condition: service_healthy`** makes your model wait until Chap answers its health check, so the first registration attempt succeeds.
-- **`ports`** is optional and only needed if you want to reach the model directly from the host for debugging. Chap itself reaches it over the internal network. Pick a host port that is not already taken — the bundled services use 5001 and 5002.
+- **`ports`** is optional and only needed if you want to reach the model directly from the host for debugging. Chap itself reaches it over the internal network. Pick a host port that is not already taken — the bundled stack uses 8000 for `chap` and 5002 for `ewars`, and the sample services in `compose.override.yml.example` add 5001 (`chtorch`) and 3288 (`ewars_plus`).
 - If your Chap deployment sets `SERVICEKIT_REGISTRATION_KEY` in `.env`, uncomment that line, or registration will be rejected.
 
 `compose.ewars.yml` in the repository root is a working example of exactly this shape.
@@ -64,10 +67,10 @@ The important parts:
 ### 3. Start the stack
 
 ```console
-docker compose -f compose.yml -f compose.chapkit.yml up -d
+docker compose -f compose.yml -f compose.chapkit.yml -f compose.override.yml up -d
 ```
 
-`compose.override.yml` is merged in automatically, so your service starts along with everything else. Use whichever base and overlays you normally use — see the [overlay reference](../webapi/docker-compose-doc.md#compose-file-reference).
+Your service starts along with everything else. Use whichever base and overlays you normally use, with `compose.override.yml` last — see the [overlay reference](../webapi/docker-compose-doc.md#compose-file-reference). Pass the same `-f` flags to every later `down`, `build` and `logs` command in this stack.
 
 ### 4. Verify
 
@@ -106,7 +109,8 @@ services:
 Rebuild after changing the model with:
 
 ```console
-docker compose build my-model && docker compose up -d my-model
+docker compose -f compose.yml -f compose.chapkit.yml -f compose.override.yml build my-model
+docker compose -f compose.yml -f compose.chapkit.yml -f compose.override.yml up -d my-model
 ```
 
 Note that the build context must be reachable from the Chap repository directory, and that a relative path like `../my-model` ties the deployment to your directory layout. For a server deployment, publishing an image to a registry is more robust.
@@ -131,11 +135,16 @@ Use this only if your service cannot self-register — for example a third-party
 Because this configuration is baked into the Chap image, you must rebuild after editing it:
 
 ```console
-docker compose build chap worker
-docker compose up -d
+docker compose -f compose.yml -f compose.chapkit.yml build chap worker
+docker compose -f compose.yml -f compose.chapkit.yml up -d
 ```
 
+Pass the same `-f` flags you started the stack with. A bare `docker compose up -d` here drops the overlays and recreates the project without the bundled model services.
+
 Chap waits up to 30 seconds for the service to report healthy while seeding. If it does not respond in time, the model is skipped with an error in the Chap log and startup continues — restart Chap once the service is up.
+
+!!! warning "Does not work if the service advertises a `repository_url`"
+    When a chapkit service reports a `repository_url` in its metadata, Chap stores that GitHub address as the template's source and keeps no record of the service's HTTP address. A self-registering service is unaffected, because Chap looks its live address up in the service registry — but a service seeded from configuration is by definition not registered, so the lookup falls back to the stored GitHub URL and every prediction fails. Use this fallback only with services whose metadata leaves `repository_url` unset, or give the service the registration environment variables after all.
 
 ## Lifecycle and troubleshooting
 

--- a/docs/modeling-app/running-your-own-model.md
+++ b/docs/modeling-app/running-your-own-model.md
@@ -1,0 +1,171 @@
+# Running Your Own Model
+
+This guide covers how to run a model of your own alongside Chap in a Docker Compose deployment — for example a model developed locally for your own country or programme.
+
+The supported way to do this is to package the model as a **chapkit service** and add it to your Compose stack as an extra service. Chap does not mount folders of model code into the running containers; instead your model runs as its own container with an HTTP interface, and Chap talks to it over the Compose network. This keeps the model's dependencies (R, Python, INLA, and so on) isolated from Chap's own image, and means you do not have to rebuild Chap when the model changes.
+
+!!! note "Two different ways to add a model"
+    This page is about models that run as a **service** next to Chap. If your model is an MLproject-style repository on GitHub, you do not need any of this — see [Managing models](managing-model-templates.md) instead.
+
+## Prerequisites
+
+- A working Chap installation, see [First-time Setup](fresh-installation.md)
+- Your model packaged as a chapkit service. See the [chapkit documentation](https://dhis2-chap.github.io/chapkit/) for how to wrap an existing model, and [Chapkit](../external_models/chapkit.md) for the data format Chap sends.
+
+## How model services attach to Chap
+
+There are two mechanisms, and it is worth knowing which one you are using:
+
+| | Self-registration | Seeding from config |
+|---|---|---|
+| Who initiates | The model service calls Chap on startup | Chap reads a YAML file on startup |
+| Configuration | `SERVICEKIT_ORCHESTRATOR_URL` on the model service | `config/configured_models/*.yaml` in the Chap repo |
+| Requires rebuilding Chap | No | Yes, the config is baked into the image |
+| Startup order | Model service can start at any time | Model service must be healthy before Chap seeds |
+| Survives model restarts | Yes, it re-registers | Only across a Chap restart |
+
+**Self-registration is the recommended path** and the one used by the bundled model services. Use the config-seeding path only for a service that cannot be given the registration environment variables.
+
+## Adding a self-registering model service
+
+### 1. Create a Compose override file
+
+Chap picks up a `compose.override.yml` file automatically, with no extra `-f` flag. Start from the shipped example:
+
+```console
+cp compose.override.yml.example compose.override.yml
+```
+
+Remove the sample services you do not need, and add your own.
+
+### 2. Declare your service
+
+```yaml
+# compose.override.yml
+services:
+  my-model:
+    image: ghcr.io/my-org/my-model:v1.0.0
+    restart: unless-stopped
+    ports:
+      - "5003:8000"
+    environment:
+      SERVICEKIT_ORCHESTRATOR_URL: http://chap:8000/v2/services/$$register
+      # Uncomment if chap has SERVICEKIT_REGISTRATION_KEY set:
+      # SERVICEKIT_REGISTRATION_KEY: ${SERVICEKIT_REGISTRATION_KEY:-}
+    depends_on:
+      chap:
+        condition: service_healthy
+```
+
+The important parts:
+
+- **`SERVICEKIT_ORCHESTRATOR_URL`** points at Chap's registration endpoint using the Compose service name `chap`, not `localhost`. The `$$` is not a typo — Compose expands `$` as a variable, so `$$register` is how you write a literal `$register`.
+- **`depends_on: chap: condition: service_healthy`** makes your model wait until Chap answers its health check, so the first registration attempt succeeds.
+- **`ports`** is optional and only needed if you want to reach the model directly from the host for debugging. Chap itself reaches it over the internal network. Pick a host port that is not already taken — the bundled services use 5001 and 5002.
+- If your Chap deployment sets `SERVICEKIT_REGISTRATION_KEY` in `.env`, uncomment that line, or registration will be rejected.
+
+`compose.ewars.yml` in the repository root is a working example of exactly this shape.
+
+### 3. Start the stack
+
+```console
+docker compose -f compose.yml -f compose.chapkit.yml up -d
+```
+
+`compose.override.yml` is merged in automatically, so your service starts along with everything else. Use whichever base and overlays you normally use — see the [overlay reference](../webapi/docker-compose-doc.md#compose-file-reference).
+
+### 4. Verify
+
+Check that the service registered:
+
+```console
+curl http://localhost:8000/v2/services
+```
+
+Then check that it became a usable model:
+
+```console
+curl http://localhost:8000/v1/crud/configured-models
+```
+
+Your model should appear in both, and in the model list in the modeling app. The name comes from the service's own id as advertised by the chapkit image, not from the Compose service name.
+
+## Building from a local model folder
+
+If your model is not published as an image yet, point Compose at a local build context instead of an image. This is the closest equivalent to running a model straight from a folder:
+
+```yaml
+# compose.override.yml
+services:
+  my-model:
+    build:
+      context: ../my-model     # path to your model repository
+    restart: unless-stopped
+    environment:
+      SERVICEKIT_ORCHESTRATOR_URL: http://chap:8000/v2/services/$$register
+    depends_on:
+      chap:
+        condition: service_healthy
+```
+
+Rebuild after changing the model with:
+
+```console
+docker compose build my-model && docker compose up -d my-model
+```
+
+Note that the build context must be reachable from the Chap repository directory, and that a relative path like `../my-model` ties the deployment to your directory layout. For a server deployment, publishing an image to a registry is more robust.
+
+## Alternative: seeding from configuration
+
+If your service cannot self-register, Chap can be told about it at startup. Add a YAML file to `config/configured_models/` — do **not** edit `default.yaml`, which is overwritten on upgrade:
+
+```yaml
+# config/configured_models/local.yaml
+- url: http://my-model:8000
+  uses_chapkit: true
+  versions:
+    v1: "/v1"
+  configurations:
+    default:
+      user_option_values: {}
+```
+
+`url` is the service's address on the Compose network, and `uses_chapkit: true` tells Chap to read the model template over HTTP rather than fetching an `MLProject.yaml` from GitHub. See [the configured models reference](https://github.com/dhis2-chap/chap-core/blob/master/config/configured_models/README.md) for the full file format.
+
+Because this configuration is baked into the Chap image, you must rebuild after editing it:
+
+```console
+docker compose build chap worker
+docker compose up -d
+```
+
+Chap waits up to 30 seconds for the service to report healthy while seeding. If it does not respond in time, the model is skipped with an error in the Chap log and startup continues — restart Chap once the service is up.
+
+## Lifecycle and troubleshooting
+
+**Registered services must keep pinging.** A registration is valid for 30 seconds, and the chapkit service refreshes it automatically. If your model container stops, its registration expires and Chap eventually marks the model as archived, at which point it disappears from the model list. Archiving is not deletion: existing evaluations still resolve, and the model reappears when the service comes back and re-registers.
+
+**A stopped model can linger in the list.** Expiry is only noticed the next time Chap syncs, which happens when some service registers or when the model template list is fetched. A model whose container died may stay visible until then.
+
+**The model registered but does not appear as a model.** Chap syncs the service into its database as a side effect of registration, and that step is best-effort — if it fails, registration still succeeds. Fetch the model templates to force a fresh sync:
+
+```console
+curl http://localhost:8000/v1/crud/model-templates
+```
+
+**Registration is rejected.** Check whether `SERVICEKIT_REGISTRATION_KEY` is set in Chap's `.env` but missing from your service, or whether `CHAP_API_TOKEN` is set, which protects all endpoints. See [Service Registration](../webapi/service-registration.md) and [API Authentication](../webapi/api-authentication.md).
+
+**Check the logs of both sides:**
+
+```console
+docker compose logs chap
+docker compose logs my-model
+```
+
+## See also
+
+- [Enabling Optional Model Services](enabling-optional-model-services.md) — the pre-built optional services shipped with Chap
+- [Compose file reference](../webapi/docker-compose-doc.md#compose-file-reference) — which compose files stack and which are alternatives
+- [Service Registration](../webapi/service-registration.md) — the registration and ping API
+- [Chapkit](../external_models/chapkit.md) — the data format Chap sends to chapkit models

--- a/docs/modeling-app/running-your-own-model.md
+++ b/docs/modeling-app/running-your-own-model.md
@@ -14,17 +14,12 @@ The supported way to do this is to package the model as a **chapkit service** an
 
 ## How model services attach to Chap
 
-There are two mechanisms, and it is worth knowing which one you are using:
+**Chapkit services register themselves with Chap on startup.** You give the service the address of Chap's registration endpoint, it announces itself, and Chap pulls in its model template and configurations automatically. Nothing needs to be listed in a configuration file, and Chap does not need rebuilding when you add or change a model.
 
-| | Self-registration | Seeding from config |
-|---|---|---|
-| Who initiates | The model service calls Chap on startup | Chap reads a YAML file on startup |
-| Configuration | `SERVICEKIT_ORCHESTRATOR_URL` on the model service | `config/configured_models/*.yaml` in the Chap repo |
-| Requires rebuilding Chap | No | Yes, the config is baked into the image |
-| Startup order | Model service can start at any time | Model service must be healthy before Chap seeds |
-| Survives model restarts | Yes, it re-registers | Only across a Chap restart |
+This is how the bundled model services work, and it is the way to attach a model service. The rest of this page assumes it.
 
-**Self-registration is the recommended path** and the one used by the bundled model services. Use the config-seeding path only for a service that cannot be given the registration environment variables.
+!!! note "Older configuration-based path"
+    Chap can also be told about a chapkit service up front, through a `uses_chapkit: true` entry in `config/configured_models/`. That path predates self-registration: it requires rebuilding the Chap image, and the service has to be healthy at the moment Chap starts or the model is skipped. It remains supported for services that cannot be given the registration environment variables, and is covered in [the configured models reference](https://github.com/dhis2-chap/chap-core/blob/master/config/configured_models/README.md). Prefer self-registration.
 
 ## Adding a self-registering model service
 
@@ -116,9 +111,9 @@ docker compose build my-model && docker compose up -d my-model
 
 Note that the build context must be reachable from the Chap repository directory, and that a relative path like `../my-model` ties the deployment to your directory layout. For a server deployment, publishing an image to a registry is more robust.
 
-## Alternative: seeding from configuration
+## Fallback: seeding from configuration
 
-If your service cannot self-register, Chap can be told about it at startup. Add a YAML file to `config/configured_models/` — do **not** edit `default.yaml`, which is overwritten on upgrade:
+Use this only if your service cannot self-register — for example a third-party service you cannot set environment variables on. Add a YAML file to `config/configured_models/` — do **not** edit `default.yaml`, which is overwritten on upgrade:
 
 ```yaml
 # config/configured_models/local.yaml

--- a/docs/modeling-app/running-your-own-model.md
+++ b/docs/modeling-app/running-your-own-model.md
@@ -18,9 +18,6 @@ The supported way to do this is to package the model as a **chapkit service** an
 
 This is how the bundled model services work, and it is the way to attach a model service. The rest of this page assumes it.
 
-!!! note "Older configuration-based path"
-    Chap can also be told about a chapkit service up front, through a `uses_chapkit: true` entry in `config/configured_models/`. That path predates self-registration: it requires rebuilding the Chap image, and the service has to be healthy at the moment Chap starts or the model is skipped. It remains supported for services that cannot be given the registration environment variables, and is covered in [the configured models reference](https://github.com/dhis2-chap/chap-core/blob/master/config/configured_models/README.md). Prefer self-registration.
-
 ## Adding a self-registering model service
 
 ### 1. Create a Compose override file
@@ -114,37 +111,6 @@ docker compose -f compose.yml -f compose.chapkit.yml -f compose.override.yml up 
 ```
 
 Note that the build context must be reachable from the Chap repository directory, and that a relative path like `../my-model` ties the deployment to your directory layout. For a server deployment, publishing an image to a registry is more robust.
-
-## Fallback: seeding from configuration
-
-Use this only if your service cannot self-register — for example a third-party service you cannot set environment variables on. Add a YAML file to `config/configured_models/` — do **not** edit `default.yaml`, which is overwritten on upgrade:
-
-```yaml
-# config/configured_models/local.yaml
-- url: http://my-model:8000
-  uses_chapkit: true
-  versions:
-    v1: "/v1"
-  configurations:
-    default:
-      user_option_values: {}
-```
-
-`url` is the service's address on the Compose network, and `uses_chapkit: true` tells Chap to read the model template over HTTP rather than fetching an `MLProject.yaml` from GitHub. See [the configured models reference](https://github.com/dhis2-chap/chap-core/blob/master/config/configured_models/README.md) for the full file format.
-
-Because this configuration is baked into the Chap image, you must rebuild after editing it:
-
-```console
-docker compose -f compose.yml -f compose.chapkit.yml build chap worker
-docker compose -f compose.yml -f compose.chapkit.yml up -d
-```
-
-Pass the same `-f` flags you started the stack with. A bare `docker compose up -d` here drops the overlays and recreates the project without the bundled model services.
-
-Chap waits up to 30 seconds for the service to report healthy while seeding. If it does not respond in time, the model is skipped with an error in the Chap log and startup continues — restart Chap once the service is up.
-
-!!! warning "Does not work if the service advertises a `repository_url`"
-    When a chapkit service reports a `repository_url` in its metadata, Chap stores that GitHub address as the template's source and keeps no record of the service's HTTP address. A self-registering service is unaffected, because Chap looks its live address up in the service registry — but a service seeded from configuration is by definition not registered, so the lookup falls back to the stored GitHub URL and every prediction fails. Use this fallback only with services whose metadata leaves `repository_url` unset, or give the service the registration environment variables after all.
 
 ## Lifecycle and troubleshooting
 

--- a/docs/modeling-app/upgrading-installation.md
+++ b/docs/modeling-app/upgrading-installation.md
@@ -58,19 +58,24 @@ For latest release go to: [https://github.com/dhis2-chap/chap-core/releases](htt
 
 ## 3. Upgrade Chap Core
 
+!!! warning "Pass the same `-f` flags you started with"
+    Docker Compose has no memory of the overlay files you used last time. If you started Chap with `docker compose -f compose.yml -f compose.chapkit.yml up -d` (as [First-time Setup](fresh-installation.md) instructs) and then upgrade with a bare `docker compose up`, the bundled model services are silently left out and their models disappear from the modeling app.
+
+    The commands below assume the `compose.chapkit.yml` overlay from the first-time setup guide. Adjust them to match how you started Chap — see the [overlay reference](../webapi/docker-compose-doc.md#compose-file-reference). If you use a `compose.override.yml` file, it is merged automatically and needs no flag.
+
 ```console
 # Stop all containers first
-docker compose down
+docker compose -f compose.yml -f compose.chapkit.yml down
 
 # Spin the containers up with --build to get new changes
-docker compose up --build -d
+docker compose -f compose.yml -f compose.chapkit.yml up --build -d
 ```
 
 NOTE: There might be issues with cached images. If you encounter problems, try forcing a fresh pull of all images:
 
 ```console
-docker compose build --no-cache
-docker compose up -d
+docker compose -f compose.yml -f compose.chapkit.yml build --no-cache
+docker compose -f compose.yml -f compose.chapkit.yml up -d
 ```
 
 Docker compose up will:
@@ -95,20 +100,20 @@ If you encounter issues and need to restore from your backup:
 
 ```console
 # Stop the services
-docker compose down
+docker compose -f compose.yml -f compose.chapkit.yml down
 
 # Remove the database volume to start fresh
-docker compose down --volumes
+docker compose -f compose.yml -f compose.chapkit.yml down --volumes
 
 # Start only the database
-docker compose up -d postgres
+docker compose -f compose.yml -f compose.chapkit.yml up -d postgres
 
 # Wait for postgres to initialize, then restore the backup
 
 cat backup_20241023_120000.sql | docker compose exec -T postgres psql -U ${POSTGRES_USER} chap_core
 
 # Start all services
-docker compose up --build
+docker compose -f compose.yml -f compose.chapkit.yml up --build
 ```
 
 ---
@@ -117,13 +122,13 @@ docker compose up --build
 
 ### Stopping Chap Core
 
-To stop all services:
+To stop all services (pass the same `-f` flags used to start them):
 
 ```console
-docker compose down
+docker compose -f compose.yml -f compose.chapkit.yml down
 ```
 
-This preserves your database data. To start again, simply run `docker compose up`.
+This preserves your database data. To start again, run the same `docker compose -f compose.yml -f compose.chapkit.yml up -d` command from step 3.
 
 ### Viewing Logs
 

--- a/docs/modeling-app/upgrading-installation.md
+++ b/docs/modeling-app/upgrading-installation.md
@@ -61,7 +61,7 @@ For latest release go to: [https://github.com/dhis2-chap/chap-core/releases](htt
 !!! warning "Pass the same `-f` flags you started with"
     Docker Compose has no memory of the overlay files you used last time. If you started Chap with `docker compose -f compose.yml -f compose.chapkit.yml up -d` (as [First-time Setup](fresh-installation.md) instructs) and then upgrade with a bare `docker compose up`, the bundled model services are silently left out and their models disappear from the modeling app.
 
-    The commands below assume the `compose.chapkit.yml` overlay from the first-time setup guide. Adjust them to match how you started Chap — see the [overlay reference](../webapi/docker-compose-doc.md#compose-file-reference). If you use a `compose.override.yml` file, it is merged automatically and needs no flag.
+    The commands below assume the `compose.chapkit.yml` overlay from the first-time setup guide. Adjust them to match how you started Chap — see the [overlay reference](../webapi/docker-compose-doc.md#compose-file-reference). If you use a `compose.override.yml` file, add `-f compose.override.yml` to every command below — Compose only picks that file up on its own when no `-f` flag is passed at all, so with the flags below it would otherwise be dropped and its services removed on upgrade.
 
 ```console
 # Stop all containers first

--- a/docs/webapi/docker-compose-doc.md
+++ b/docs/webapi/docker-compose-doc.md
@@ -29,7 +29,7 @@ The repository ships several compose files. `compose.yml` and `compose.ghcr.yml`
 | `compose.ghcr.yml` | base | Same services pulled as pre-built images from GHCR. Use *instead of* `compose.yml`. |
 | `compose.chapkit.yml` | overlay | Umbrella overlay pulling in every bundled chapkit model service via the `include:` directive. Requires Compose v2.20+. |
 | `compose.ewars.yml` | overlay | The EWARS chapkit model service on its own. Already included by `compose.chapkit.yml`. |
-| `compose.override.yml.example` | overlay template | Optional extra services (`chtorch`, `ewars_plus`). Copy to `compose.override.yml`, which Compose merges automatically with no `-f` flag. |
+| `compose.override.yml.example` | overlay template | Optional extra services (`chtorch`, `ewars_plus`). Copy to `compose.override.yml`. Compose merges that file automatically **only** when no `-f` flag is used; with any `-f` flag you must list it explicitly, last. |
 | `compose.dev.yml` | overlay | Bind-mounts local source into `chap`, builds the worker from `Dockerfile.inla`, and exposes the postgres port on the host. |
 | `compose.test.yml` | overlay | One-shot pytest container. |
 | `compose.integration.test.yml` | overlay | Frontend emulator running the end-to-end database flow. |
@@ -38,7 +38,7 @@ The repository ships several compose files. `compose.yml` and `compose.ghcr.yml`
 Common combinations:
 
 ```console
-# Base only
+# Base only (plus compose.override.yml, if one exists)
 docker compose up -d
 
 # With all bundled model services (what the installation guide uses)

--- a/docs/webapi/docker-compose-doc.md
+++ b/docs/webapi/docker-compose-doc.md
@@ -18,3 +18,39 @@ This is a short example for how to setup Chap-core locally as a service using do
    - `postgres` for storing chap-related data
 
 3. Check that the chap rest api works by going to http://localhost:8000/docs
+
+## Compose file reference
+
+The repository ships several compose files. `compose.yml` and `compose.ghcr.yml` are **base** files and are alternatives to each other — never stack them, because Compose appends list fields on overlay and you get duplicate `security_opt` / `cap_drop` entries that fail validation. Everything else is an overlay layered on top of a base with additional `-f` flags.
+
+| File | Kind | Purpose |
+|------|------|---------|
+| `compose.yml` | base | Builds `chap` and `worker` from local source. The default for development and for the documented server install. |
+| `compose.ghcr.yml` | base | Same services pulled as pre-built images from GHCR. Use *instead of* `compose.yml`. |
+| `compose.chapkit.yml` | overlay | Umbrella overlay pulling in every bundled chapkit model service via the `include:` directive. Requires Compose v2.20+. |
+| `compose.ewars.yml` | overlay | The EWARS chapkit model service on its own. Already included by `compose.chapkit.yml`. |
+| `compose.override.yml.example` | overlay template | Optional extra services (`chtorch`, `ewars_plus`). Copy to `compose.override.yml`, which Compose merges automatically with no `-f` flag. |
+| `compose.dev.yml` | overlay | Bind-mounts local source into `chap`, builds the worker from `Dockerfile.inla`, and exposes the postgres port on the host. |
+| `compose.test.yml` | overlay | One-shot pytest container. |
+| `compose.integration.test.yml` | overlay | Frontend emulator running the end-to-end database flow. |
+| `compose.r-model.integration.test.yml` | overlay | End-to-end flow for an R-based model. |
+
+Common combinations:
+
+```console
+# Base only
+docker compose up -d
+
+# With all bundled model services (what the installation guide uses)
+docker compose -f compose.yml -f compose.chapkit.yml up -d
+
+# Development, with local source bind-mounted
+docker compose -f compose.yml -f compose.dev.yml up -d
+
+# Pre-built images instead of a local build
+docker compose -f compose.ghcr.yml up -d
+```
+
+Docker Compose does not remember which overlays you used, so pass the same `-f` flags to every subsequent `down`, `build` and `logs` command in that stack. The `make restart`, `make force-restart` and `make chap-version` targets already carry the `compose.yml` + `compose.chapkit.yml` pair.
+
+To add a model service of your own, see [Running Your Own Model](../modeling-app/running-your-own-model.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
           - First-time Setup: modeling-app/fresh-installation.md
           - Updating to a New Version: modeling-app/upgrading-installation.md
           - Enabling Optional Model Services: modeling-app/enabling-optional-model-services.md
+          - Running Your Own Model: modeling-app/running-your-own-model.md
       - Managing models: modeling-app/managing-model-templates.md
       - Troubleshooting:
           - Viewing Logs: modeling-app/troubleshooting/logs.md


### PR DESCRIPTION
Closes the documentation follow-up on [CLIM-504](https://dhis2.atlassian.net/browse/CLIM-504). The Jira decision was that local models should be converted to chapkit rather than mounted as folders. That path is already supported in code (v2 self-registration), but it was undocumented.

## What was missing

- No end-to-end guide for attaching a model service of your own. The working pattern existed only as machine-readable YAML in `compose.ewars.yml`.
- The two overlay mechanisms (`compose.chapkit.yml` and `compose.override.yml`) were documented on separate pages and never contrasted; four other compose files were undocumented.
- `fresh-installation.md` instructs `docker compose -f compose.yml -f compose.chapkit.yml up -d`, but every command in `upgrading-installation.md` was a bare `docker compose up`. Following both pages in order silently drops the bundled model services on upgrade.
- `config/configured_models/default.yaml` carried stale commented-out `uses_chapkit` entries pointing at the wrong compose file.

## Changes

- New page `docs/modeling-app/running-your-own-model.md`: packaging a model as a chapkit service, declaring it in `compose.override.yml` with `SERVICEKIT_ORCHESTRATOR_URL` and a `depends_on` health gate, building from a local folder, and the registration lifecycle (30s TTL, archival when a service stops pinging, and the fact that a dead model can linger until the next sync).
- Compose file reference table in `docs/webapi/docker-compose-doc.md`, marking `compose.yml` and `compose.ghcr.yml` as mutually exclusive bases.
- `docs/modeling-app/upgrading-installation.md` and `docs/modeling-app/enabling-optional-model-services.md`: carry the overlay flags through, with a warning explaining why.
- `config/configured_models/README.md`: correct the seeding description, and state plainly that chapkit services do not belong in these files.

Self-registration is documented as the only way to attach a model service. Seeding a chapkit service through a `uses_chapkit` entry is deliberately left undocumented — it predates self-registration, was a stop-gap, and is not a path we want people on.

Docs-only. `make docs` (strict), `make lint`, and `make test` all pass.

## Verification

The compose and seeding claims were checked against `docker compose` (v5.4.0) and the seeding code rather than read off the source, which turned up several errors now fixed in this branch.

**`compose.override.yml` is only auto-discovered when no `-f` flag is passed.** Four places claimed it is always merged:

| command | services |
|---|---|
| `docker compose up -d` | chap, chtorch, ewars_plus, postgres, redis, worker — no `ewars` |
| `-f compose.yml -f compose.chapkit.yml` | chap, ewars, postgres, redis, worker — override dropped |
| `-f compose.yml -f compose.chapkit.yml -f compose.override.yml` | all seven |

The originally documented flow therefore started a stack with no user model service and no error, and the upgrade page would have removed the services of anyone using an override file. Every command now lists the override explicitly. The optional-services page was the worst affected, since enabling an optional service is its entire subject and its commands dropped both the bundled services and the ones it had just told you to enable.

**Only the last version is ever seeded**, in every file, not just `default.yaml` (`model_template_seed.py:114`) — the reference previously said other files keep all versions. **`versions` is a required field**, not optional; omitting it raises in `parse_local_model_config_file`, and the call site in `chap_core/database/database.py:512` has no `try`/`except`, so Chap fails to start.

Confirmed correct and left as written: the 30s registration TTL, the `$$register` escaping (a container really does receive `http://chap:8000/v2/services/$register`), stale-template archiving and un-archiving, the name-from-service-id rule, the sync trigger points, and the `compose.ghcr.yml` base being usable under the overlays (its `chap` has no healthcheck in the compose file, but the published image carries a `HEALTHCHECK`, which satisfies `condition: service_healthy`).

## Related bug, not addressed here

A chapkit service that is absent from the v2 registry at prediction time cannot serve predictions if its metadata declares a `repository_url`:

```
service reachable at : http://my-model:8000
config.source_url    : https://github.com/example/model
stored template name : test-model
stored source_url    : https://github.com/example/model
```

`external_chapkit_model.py:84` prefers `repository_url` over the service's own address, and `ModelTemplateDB` has only a `source_url` column, so the HTTP address is persisted nowhere. Self-registering services are unaffected: `_resolve_chapkit_live_source_url` (`database.py:380`) reads their live address from the registry and writes it back onto the template row, repairing the value on first use. A service seeded from configuration is never in that registry, so the lookup falls back to the stored GitHub URL and every prediction is sent to github.com.

Since that path is no longer documented, this is not user-facing — but it is worth fixing or removing in the code.

[CLIM-504]: https://dhis2.atlassian.net/browse/CLIM-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

