### PR TITLE
refactor(compose): remove hardcoded container_name from chap service

### DIFF
--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -16,7 +16,6 @@ services:
       CHAP_LOGS_DIR: /data/logs
       CHAP_RUNS_DIR: /data/runs
       CHAP_API_TOKEN: ${CHAP_API_TOKEN:-}
-    container_name: chap
     read_only: true
     security_opt:
       - no-new-privileges:true

--- a/compose.yml
+++ b/compose.yml
@@ -12,9 +12,6 @@ services:
       CHAP_RUNS_DIR: /data/runs
       CHAP_ROOT_PATH: ${CHAP_ROOT_PATH:-}
       CHAP_API_TOKEN: ${CHAP_API_TOKEN:-}
-    # for now some of the tests uses hardcoded names so we need to set the container name
-    # TODO: Update the tests so they don't rely on hardcoded container names
-    container_name: chap
     read_only: true
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## Problem

`compose.yml` sets `container_name: chap` on the `chap` service (and `compose.ghcr.yml` does the same). Container names are host-global, so two chap-core deployments cannot run on the same machine — Docker refuses to start the second one. That blocks the common "stable and master side by side" arrangement, which the infrastructure example currently works around by putting each deployment in its own LXD container.

The accompanying comment claims tests depend on the hardcoded name:

```
# for now some of the tests uses hardcoded names so we need to set the container name
# TODO: Update the tests so they don't rely on hardcoded container names
```

This is stale. The only reference is `hostname = "chap"` in `tests/docker_db_flow.py`, and that is a **network** name — it resolves from the Compose service name via the project network's DNS, independent of `container_name`.

## Change

Removes `container_name: chap` from `compose.yml` and `compose.ghcr.yml`, along with the stale comment.

The one-shot test containers keep their explicit names on purpose: `test_docker_compose_integration_flow.sh` does `docker wait chap_frontend_emulator` and `test_docker_compose_flow.sh` does `docker attach chap_test`, so those names are load-bearing. They are also single-run test containers, so the two-instances-per-host argument does not apply to them.

`compose.test.yml` overrides the `chap` service with `container_name: chap_test`, which is a scalar override and still applies.

## Verification

- `make lint` — clean (ruff, mypy on 416 files, pyright 0 errors)
- `make test` — 1334 passed, 120 skipped, 4 xfailed, 1 xpassed
- `make test-all` — exit 0; 1378 passed, 76 skipped, 4 xfailed, 1 xpassed
- `tests/test_docker_compose_integration_flow.sh` re-run standalone — exit 0

The integration flow confirms the behaviour directly. The container now comes up under its Compose-generated name and the frontend emulator still reaches it:

```
NAME                     SERVICE                  STATUS
chap-core-chap-1         chap                     Up (healthy)
chap_frontend_emulator   chap_frontend_emulator   Up
...
=== Test exit code: 0 ===
=== Tests passed! ===
```

## Context

This is the first item from a review of chap-core's deployment surface. It does not address the larger finding in that review — that `compose.yml` declares `build:` with no `image:`, so a released version cannot be pulled and deployed without a source checkout and an on-server build.