### PR TITLE
fix: restrict all locations dataset when last_n is set for explain-lime

### DIFF
--- a/chap_core/cli_endpoints/explain.py
+++ b/chap_core/cli_endpoints/explain.py
@@ -6,7 +6,7 @@ import logging
 from typing import Annotated
 
 from cyclopts import Parameter
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from chap_core.api_types import RunConfig
 from chap_core.cli_endpoints._args import (  # noqa: TC001 — used at runtime via cyclopts get_type_hints()
@@ -36,7 +36,16 @@ class LimeParams(BaseModel):
     seed: int | None = None
     timed: bool = False
     adaptive: bool = False
-    last_n: int | None = None
+    last_n: int | None = Field(
+        default=None,
+        description=(
+            "If set, restricts every location's historical data fed to the model to the last "
+            "last_n time steps of the explained location's own timeline (other locations may end "
+            "up with fewer steps, or be dropped, if their range doesn't reach that far back). Does "
+            "not affect the background sampler's pool or the per-feature global means, which still "
+            "draw from the full unrestricted dataset."
+        ),
+    )
     with_metrics: bool = False
 
 

--- a/chap_core/cli_endpoints/explain.py
+++ b/chap_core/cli_endpoints/explain.py
@@ -39,7 +39,7 @@ class LimeParams(BaseModel):
     last_n: int | None = Field(
         default=None,
         description=(
-            "If set, restricts every location's historical data fed to the model to the last "
+            "If set, restricts every location's historical data fed to the model to the "
             "last_n time steps of the explained location's own timeline (other locations may end "
             "up with fewer steps, or be dropped, if their range doesn't reach that far back). Does "
             "not affect the background sampler's pool or the per-feature global means, which still "

--- a/chap_core/explainability/lime.py
+++ b/chap_core/explainability/lime.py
@@ -977,8 +977,8 @@ def _prepare_lime_inputs(
     climate_predictor = get_climate_predictor(climate_data)
     full_future_weather = climate_predictor.predict(prediction_range)
 
-    # Restrict every location's history to each locations own last last_n
-    # periods, so the dataset later spliced into model.predict() (see produce_lime_dataset)
+    # Restricts every location's history to each locations own last_n periods,
+    # so that the datasets can later be spliced into model.predict() (see produce_lime_dataset)
     restricted_dataset = dataset
     if last_n is not None:
         assert last_n > 0, f"last_n must be positive, got {last_n}"
@@ -992,7 +992,8 @@ def _prepare_lime_inputs(
             loc for loc in restricted_dataset.locations() if len(restricted_dataset[loc].time_period) != window
         ]
 
-        assert location not in mismatched_locations, f"{location} is missing its own last_n window"
+        # Target location's cant be part of mismatched_locations, since the window is based on
+        # target location's own timer period.
 
         if mismatched_locations:
             logger.warning(

--- a/chap_core/explainability/lime.py
+++ b/chap_core/explainability/lime.py
@@ -923,6 +923,7 @@ class _LimeInputs:
     """Prepared inputs shared by explain() and explain_adaptive() before they
     diverge into standard vs. adaptive mask selection."""
 
+    dataset: DataSet
     full_future_weather: DataSet
     hist_type: type
     fut_type: type
@@ -976,6 +977,14 @@ def _prepare_lime_inputs(
     climate_predictor = get_climate_predictor(climate_data)
     full_future_weather = climate_predictor.predict(prediction_range)
 
+    # Restricts every locations dataset to last_n periods if set.
+    if last_n is not None:
+        assert last_n > 0, f"last_n must be positive, got {last_n}"
+
+        window = min(last_n, len(dataset.period_range))
+        start_period = dataset.period_range[-window]
+        dataset = dataset.restrict_time_period(slice(start_period, None))
+
     # Isolate the target location and fetch its dataframe classes for later instantiation
     dataset_loc = dataset.filter_locations([location])
     future_weather = full_future_weather.filter_locations([location])
@@ -998,13 +1007,7 @@ def _prepare_lime_inputs(
     ]
     assert len(features_hist) > 0, "No numeric historical features found in dataset"
 
-    # Optionally restrict explanation to the most recent time steps
     hist_df = hist_df.copy()
-    if last_n is not None:
-        assert last_n > 0, f"last_n must be positive, got {last_n}"
-        hist_df = hist_df.iloc[-last_n:].reset_index(drop=True)
-        assert len(hist_df) > 0, f"No data remaining after selecting last {last_n} steps"
-
     nan_counts = hist_df[features_hist].isna().sum()
     if nan_counts.any():
         logger.warning(
@@ -1035,6 +1038,7 @@ def _prepare_lime_inputs(
     )
 
     return _LimeInputs(
+        dataset=dataset,
         full_future_weather=full_future_weather,
         hist_type=hist_type,
         fut_type=fut_type,
@@ -1111,6 +1115,7 @@ def explain(
         timed=timed,
         start=start,
     )
+    dataset = inputs.dataset
     full_future_weather = inputs.full_future_weather
     hist_type = inputs.hist_type
     fut_type = inputs.fut_type
@@ -1395,6 +1400,7 @@ def explain_adaptive(
         timed=timed,
         start=start,
     )
+    dataset = inputs.dataset
     full_future_weather = inputs.full_future_weather
     hist_type = inputs.hist_type
     fut_type = inputs.fut_type

--- a/chap_core/explainability/lime.py
+++ b/chap_core/explainability/lime.py
@@ -992,6 +992,8 @@ def _prepare_lime_inputs(
             loc for loc in restricted_dataset.locations() if len(restricted_dataset[loc].time_period) != window
         ]
 
+        assert location not in mismatched_locations, f"{location} is missing its own last_n window"
+
         if mismatched_locations:
             logger.warning(
                 "Dropping location(s) that don't fully cover %s's last_n window: %s",
@@ -1001,8 +1003,6 @@ def _prepare_lime_inputs(
             restricted_dataset = restricted_dataset.filter_locations(
                 [loc for loc in restricted_dataset.locations() if loc not in mismatched_locations]
             )
-
-        assert location not in mismatched_locations, f"{location} is missing its own last_n window"
 
     # Isolate the target location and fetch its dataframe classes for later instantiation
     dataset_loc = restricted_dataset.filter_locations([location])

--- a/chap_core/explainability/lime.py
+++ b/chap_core/explainability/lime.py
@@ -977,16 +977,35 @@ def _prepare_lime_inputs(
     climate_predictor = get_climate_predictor(climate_data)
     full_future_weather = climate_predictor.predict(prediction_range)
 
-    # Restricts every locations dataset to last_n periods if set.
+    # Restrict every location's history to each locations own last last_n
+    # periods, so the dataset later spliced into model.predict() (see produce_lime_dataset)
+    restricted_dataset = dataset
     if last_n is not None:
         assert last_n > 0, f"last_n must be positive, got {last_n}"
 
-        window = min(last_n, len(dataset.period_range))
-        start_period = dataset.period_range[-window]
-        dataset = dataset.restrict_time_period(slice(start_period, None))
+        target_period_range = dataset[location].time_period
+        window = min(last_n, len(target_period_range))
+        start_period = target_period_range[-window]
+        restricted_dataset = dataset.restrict_time_period(slice(start_period, None))
+
+        mismatched_locations = [
+            loc for loc in restricted_dataset.locations() if len(restricted_dataset[loc].time_period) != window
+        ]
+
+        if mismatched_locations:
+            logger.warning(
+                "Dropping location(s) that don't fully cover %s's last_n window: %s",
+                location,
+                mismatched_locations,
+            )
+            restricted_dataset = restricted_dataset.filter_locations(
+                [loc for loc in restricted_dataset.locations() if loc not in mismatched_locations]
+            )
+
+        assert location not in mismatched_locations, f"{location} is missing its own last_n window"
 
     # Isolate the target location and fetch its dataframe classes for later instantiation
-    dataset_loc = dataset.filter_locations([location])
+    dataset_loc = restricted_dataset.filter_locations([location])
     future_weather = full_future_weather.filter_locations([location])
     hist_type = dataset_loc[location].__class__
     fut_type = future_weather[location].__class__
@@ -1038,7 +1057,7 @@ def _prepare_lime_inputs(
     )
 
     return _LimeInputs(
-        dataset=dataset,
+        dataset=restricted_dataset,
         full_future_weather=full_future_weather,
         hist_type=hist_type,
         fut_type=fut_type,
@@ -1087,7 +1106,11 @@ def explain(
                               "matrix_diff", "matrix_bins", "sax", "nn"] (default uniform)
         sampler_name (str): The sampling strategy used to replace features "turned off" - one of ["background"] (default background)
         weighter_name (str): The strategy for weighting perturbations according to distance to original (default pairwise)
-        last_n (int | None): If set, only the last last_n time steps of the location's historical data are used for the explanation.
+        last_n (int | None): If set, every location's historical data fed to the model is restricted
+            to the last last_n time steps of `location`'s own timeline (other locations may end up
+            with fewer steps, or be dropped, if their range doesn't reach that far back). Does not
+            affect the background sampler's pool or the per-feature global means, which still draw
+            from the full unrestricted dataset.
         seed (int): Seeding for RNG
         timed (bool): Flag for whether to print execution time for LIME pipeline stages
         save (bool): Whether to save the calculated importance weighting
@@ -1372,7 +1395,11 @@ def explain_adaptive(
                               "matrix_diff", "matrix_bins", "sax", "nn"] (default uniform)
         sampler_name (str): The sampling strategy used to replace features "turned off" - one of ["background"] (default background)
         weighter_name (str): The strategy for weighting perturbations according to distance to original (default pairwise)
-        last_n (int | None): If set, only the last last_n time steps of the location's historical data are used for the explanation.
+        last_n (int | None): If set, every location's historical data fed to the model is restricted
+            to the last last_n time steps of `location`'s own timeline (other locations may end up
+            with fewer steps, or be dropped, if their range doesn't reach that far back). Does not
+            affect the background sampler's pool or the per-feature global means, which still draw
+            from the full, unrestricted dataset.
         seed (int): Seeding for RNG
         timed (bool): Flag for whether to print execution time for LIME pipeline stages
         save (bool): Whether to save the calculated importance weighting

--- a/tests/explainability/test_explain_integration.py
+++ b/tests/explainability/test_explain_integration.py
@@ -74,6 +74,37 @@ def small_full_dataset() -> DataSet:
     )
 
 
+@pytest.fixture
+def staggered_locations_dataset() -> DataSet:
+    """Test 4 differend locations with differend historical coverage, to exercise last_n's handling of
+    locations that don't fully overlap the explained location's restriction window.
+
+    """
+    full_range = PeriodRange.from_time_periods(Month(2020, 1), Month(2021, 8))
+    partial_range = PeriodRange.from_time_periods(Month(2021, 5), Month(2021, 8))
+    early_range = PeriodRange.from_time_periods(Month(2020, 1), Month(2020, 12))
+    rng = np.random.default_rng(0)
+
+    def _make(time_period: PeriodRange) -> FullData:
+        n = len(time_period)
+        return FullData(
+            time_period,
+            rng.normal(50, 5, n).round(1).clip(0).tolist(),
+            rng.normal(25, 3, n).round(1).tolist(),
+            rng.integers(10, 100, n).tolist(),
+            [100_000] * n,
+        )
+
+    return DataSet(
+        {
+            "alpha": _make(full_range),
+            "beta": _make(full_range),
+            "gamma": _make(partial_range),
+            "delta": _make(early_range),
+        }
+    )
+
+
 def _explain_with_defaults(model, dataset, **overrides):
     """Run explain() with sane test defaults: small budget, no I/O side effects."""
     kwargs = {
@@ -186,6 +217,51 @@ class TestLog1pHelperEndToEnd:
         assert any("non-finite" in rec.message and "dropping" in rec.message for rec in caplog.records), (
             "expected diagnostic about dropping non-finite perturbations"
         )
+
+
+class TestLastN:
+    """last_n must restrict every location consistently, not just the one
+    being explained, otherwise produce_lime_dataset() gives back datasets of different lengths
+    based on the locations, which it wont be able to splice back together.
+    """
+
+    def test_all_locations_share_the_truncated_history_length(self, small_full_dataset):
+        seen_lengths: set[int] = set()
+
+        model = MockExternalModel()
+        inner_predict = model.predict
+
+        def recording_predict(historic_data, future_data):
+            seen_lengths.update(len(historic_data[loc].time_period) for loc in historic_data.locations())
+            return inner_predict(historic_data, future_data)
+
+        model.predict = recording_predict  # type: ignore[method-assign]
+
+        last_n = 6
+        _explain_with_defaults(model, small_full_dataset, last_n=last_n)
+
+        assert seen_lengths == {last_n}, seen_lengths
+
+    def test_locations_not_fully_covering_the_window_are_dropped(self, staggered_locations_dataset):
+        """gamma and delta locations dont cover alphas last_n window, both must be dropped rather than handed to
+        the model at a shorter, mismatched length. beta (same full range as alpha) fully covers the window and must be kept.
+        """
+        seen_lengths: dict[str, set[int]] = {}
+
+        model = MockExternalModel()
+        inner_predict = model.predict
+
+        def recording_predict(historic_data, future_data):
+            for loc in historic_data.locations():
+                seen_lengths.setdefault(loc, set()).add(len(historic_data[loc].time_period))
+            return inner_predict(historic_data, future_data)
+
+        model.predict = recording_predict  # type: ignore[method-assign]
+
+        last_n = 6
+        _explain_with_defaults(model, staggered_locations_dataset, last_n=last_n)
+
+        assert seen_lengths == {"alpha": {last_n}, "beta": {last_n}}, seen_lengths
 
 
 class TestSinglePredictionPath:


### PR DESCRIPTION
Fixed a bug in producing datasets for LIME explanations when the last_n argument was set.

Only the explained locations dataset was restricted when last_n was set. The issue is that this dataset was then spliced back together with the other locations datasets, which no longer matched in dimensionality because it had been restricted.