### PR TITLE
feat(compose): make compose.ghcr.yml a self-contained deployment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ REDIS_PASSWORD=your_secure_redis_password
 # CHAP_API_TOKEN=
 # Shared secret for chapkit service registration (optional, separate from CHAP_API_TOKEN).
 # SERVICEKIT_REGISTRATION_KEY=
+
+# Docker image tag used by compose.ghcr.yml. Defaults to `latest`; set it to a
+# release tag (e.g. v1.2.3) to deploy a specific version.
+# CHAP_IMAGE_TAG=

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,10 @@ POSTGRES_USER=chap
 POSTGRES_PASSWORD=chap
 POSTGRES_DB=chap_core
 
-# Valkey/Redis
-REDIS_PASSWORD=your_secure_redis_password
+# Valkey/Redis. Leave unset for compose and host tests: their valkey has no
+# password and rejects AUTH. The k8s chart does use one, and `skaffold run` reads
+# it from the shell instead (see charts/chap/README.md).
+# REDIS_PASSWORD=
 
 # API authentication (optional). Unset means no authentication.
 # Generate with `openssl rand -hex 32`; use at least 32 characters.
@@ -12,11 +14,8 @@ REDIS_PASSWORD=your_secure_redis_password
 # Shared secret for chapkit service registration (optional, separate from CHAP_API_TOKEN).
 # SERVICEKIT_REGISTRATION_KEY=
 
-# Docker image tag used by compose.ghcr.yml. Defaults to `latest`; set it to a
-# release tag (e.g. v1.2.3) to deploy a specific version. Set it here rather
-# than inline, so every later compose command keeps the same pin.
+# Image tag for compose.ghcr.yml. Set a release tag (e.g. v1.2.3) to pin a version.
 # CHAP_IMAGE_TAG=
 
-# Full database URL, overriding the one composed from the POSTGRES_* values.
-# Needed when POSTGRES_PASSWORD is not URL-safe; percent-encode it here.
+# Overrides the URL composed from POSTGRES_*. Needed for a non-URL-safe password.
 # CHAP_DATABASE_URL=

--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,10 @@ REDIS_PASSWORD=your_secure_redis_password
 # SERVICEKIT_REGISTRATION_KEY=
 
 # Docker image tag used by compose.ghcr.yml. Defaults to `latest`; set it to a
-# release tag (e.g. v1.2.3) to deploy a specific version.
+# release tag (e.g. v1.2.3) to deploy a specific version. Set it here rather
+# than inline, so every later compose command keeps the same pin.
 # CHAP_IMAGE_TAG=
+
+# Full database URL, overriding the one composed from the POSTGRES_* values.
+# Needed when POSTGRES_PASSWORD is not URL-safe; percent-encode it here.
+# CHAP_DATABASE_URL=

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -84,9 +84,4 @@ jobs:
       - name: Run
         run: |
           cp .env.example .env
-          # The placeholder REDIS_PASSWORD from .env.example gets loaded via
-          # load_dotenv() at import time and makes the redis client send AUTH
-          # to the unauthenticated CI valkey service. Strip it so the host
-          # tests match the no-password setup.
-          sed -i '/^REDIS_PASSWORD=/d' .env
           make test-all

--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -1,11 +1,17 @@
 # Deployment file. Download this file on its own and run `docker compose up -d`:
 # it pulls prebuilt images from GHCR and needs no source checkout and no .env.
 #
-# Pin a release with CHAP_IMAGE_TAG, which defaults to `latest`:
-#   CHAP_IMAGE_TAG=v1.2.3 docker compose -f compose.ghcr.yml up -d
+# Pin a release with CHAP_IMAGE_TAG, which defaults to `latest`. Put it in an
+# .env file next to this one rather than on the command line -- it is read on
+# every compose command, so a later `pull` or `up` cannot silently fall back to
+# `latest` and replace the pinned release:
+#   echo CHAP_IMAGE_TAG=v1.2.3 > .env
+#   docker compose -f compose.ghcr.yml up -d
 #
 # Every variable below has a default so the file runs as downloaded. Override
-# POSTGRES_PASSWORD for anything but a local trial.
+# POSTGRES_PASSWORD for anything but a local trial. It is interpolated into a
+# database URI, so it must be URL-safe (no @ : / ? # or %); for anything else,
+# set CHAP_DATABASE_URL to a full, percent-encoded URL, which takes precedence.
 #
 # Use this file INSTEAD OF compose.yml, not layered on top of it. The two files
 # define the same services -- compose.yml builds chap+worker from the local
@@ -20,7 +26,7 @@ services:
     environment:
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      CHAP_DATABASE_URL: postgresql://${POSTGRES_USER:-chap}:${POSTGRES_PASSWORD:-chap}@postgres:5432/${POSTGRES_DB:-chap_core}
+      CHAP_DATABASE_URL: ${CHAP_DATABASE_URL:-postgresql://${POSTGRES_USER:-chap}:${POSTGRES_PASSWORD:-chap}@postgres:5432/${POSTGRES_DB:-chap_core}}
       CELERY_BROKER: redis://redis:6379/0
       CHAP_LOGS_DIR: /data/logs
       CHAP_RUNS_DIR: /data/runs
@@ -72,7 +78,7 @@ services:
       IS_IN_DOCKER: 1
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      CHAP_DATABASE_URL: postgresql://${POSTGRES_USER:-chap}:${POSTGRES_PASSWORD:-chap}@postgres:5432/${POSTGRES_DB:-chap_core}
+      CHAP_DATABASE_URL: ${CHAP_DATABASE_URL:-postgresql://${POSTGRES_USER:-chap}:${POSTGRES_PASSWORD:-chap}@postgres:5432/${POSTGRES_DB:-chap_core}}
       CELERY_BROKER: redis://redis:6379
       RENV_PATHS_ROOT: /data/renv
       UV_CACHE_DIR: /data/uv
@@ -81,6 +87,14 @@ services:
       PYTENSOR_FLAGS: "base_compiledir=/data/pytensor"
     command: "/app/.venv/bin/celery -A chap_core.rest_api.celery_tasks worker --loglevel=info"
     working_dir: /app
+    # Declared here rather than relied on from the image: CHAP_IMAGE_TAG can select a
+    # release older than the worker HEALTHCHECK, which images before v2.2 do not carry.
+    healthcheck:
+      test: ["CMD-SHELL", "/app/.venv/bin/celery -A chap_core.rest_api.celery_tasks inspect ping || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     extra_hosts:
       - "host.docker.internal:host-gateway"
     read_only: true

--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -1,22 +1,17 @@
-# Deployment file. Download this file on its own and run `docker compose up -d`:
-# it pulls prebuilt images from GHCR and needs no source checkout and no .env.
+# Standalone deployment file: download it on its own and `docker compose up -d`.
+# It pulls prebuilt images from GHCR and every setting below has a default.
 #
-# Pin a release with CHAP_IMAGE_TAG, which defaults to `latest`. Put it in an
-# .env file next to this one rather than on the command line -- it is read on
-# every compose command, so a later `pull` or `up` cannot silently fall back to
-# `latest` and replace the pinned release:
-#   echo CHAP_IMAGE_TAG=v1.2.3 > .env
-#   docker compose -f compose.ghcr.yml up -d
+# Optional, best set in an .env file beside this one so later commands keep them:
+#   CHAP_IMAGE_TAG     tag for both images                  (default: latest)
+#   POSTGRES_USER      database user                        (default: chap)
+#   POSTGRES_PASSWORD  database password, must be URL-safe  (default: chap)
+#   POSTGRES_DB        database name                        (default: chap_core)
+#   CHAP_DATABASE_URL  full percent-encoded URL, overrides the POSTGRES_* values
+#   CHAP_ROOT_PATH     path prefix when served behind a reverse proxy
+#   CHAP_API_TOKEN     API token; unset means no authentication
 #
-# Every variable below has a default so the file runs as downloaded. Override
-# POSTGRES_PASSWORD for anything but a local trial. It is interpolated into a
-# database URI, so it must be URL-safe (no @ : / ? # or %); for anything else,
-# set CHAP_DATABASE_URL to a full, percent-encoded URL, which takes precedence.
-#
-# Use this file INSTEAD OF compose.yml, not layered on top of it. The two files
-# define the same services -- compose.yml builds chap+worker from the local
-# source, this one pulls them. Layering breaks compose validation with duplicate
-# security_opt / cap_drop entries because compose appends list fields on overlay.
+# An alternative to compose.yml, not an overlay: layering the two duplicates
+# security_opt / cap_drop entries and fails validation.
 services:
   chap:
     restart: unless-stopped
@@ -87,8 +82,7 @@ services:
       PYTENSOR_FLAGS: "base_compiledir=/data/pytensor"
     command: "/app/.venv/bin/celery -A chap_core.rest_api.celery_tasks worker --loglevel=info"
     working_dir: /app
-    # Declared here rather than relied on from the image: CHAP_IMAGE_TAG can select a
-    # release older than the worker HEALTHCHECK, which images before v2.2 do not carry.
+    # Declared here, not inherited: a pinned tag may predate the image's HEALTHCHECK.
     healthcheck:
       test: ["CMD-SHELL", "/app/.venv/bin/celery -A chap_core.rest_api.celery_tasks inspect ping || exit 1"]
       interval: 30s

--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -1,20 +1,30 @@
-# Use this file INSTEAD OF compose.yml, not layered on top of it.
-# The two files define the same services -- compose.yml builds chap+worker
-# from the local source, compose.ghcr.yml pulls prebuilt images from GHCR.
-# Layering them breaks compose validation with duplicate security_opt /
-# cap_drop entries because compose appends list fields on overlay.
+# Deployment file. Download this file on its own and run `docker compose up -d`:
+# it pulls prebuilt images from GHCR and needs no source checkout and no .env.
+#
+# Pin a release with CHAP_IMAGE_TAG, which defaults to `latest`:
+#   CHAP_IMAGE_TAG=v1.2.3 docker compose -f compose.ghcr.yml up -d
+#
+# Every variable below has a default so the file runs as downloaded. Override
+# POSTGRES_PASSWORD for anything but a local trial.
+#
+# Use this file INSTEAD OF compose.yml, not layered on top of it. The two files
+# define the same services -- compose.yml builds chap+worker from the local
+# source, this one pulls them. Layering breaks compose validation with duplicate
+# security_opt / cap_drop entries because compose appends list fields on overlay.
 services:
   chap:
     restart: unless-stopped
-    image: ghcr.io/dhis2-chap/chap-core:latest
+    image: ghcr.io/dhis2-chap/chap-core:${CHAP_IMAGE_TAG:-latest}
     platform: linux/amd64
+    init: true
     environment:
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      CHAP_DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      CHAP_DATABASE_URL: postgresql://${POSTGRES_USER:-chap}:${POSTGRES_PASSWORD:-chap}@postgres:5432/${POSTGRES_DB:-chap_core}
       CELERY_BROKER: redis://redis:6379/0
       CHAP_LOGS_DIR: /data/logs
       CHAP_RUNS_DIR: /data/runs
+      CHAP_ROOT_PATH: ${CHAP_ROOT_PATH:-}
       CHAP_API_TOKEN: ${CHAP_API_TOKEN:-}
     read_only: true
     security_opt:
@@ -34,6 +44,12 @@ services:
       - "host.docker.internal:host-gateway"
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     depends_on:
       redis:
         condition: service_healthy
@@ -49,13 +65,14 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    image: ghcr.io/dhis2-chap/chap-worker:latest
+    image: ghcr.io/dhis2-chap/chap-worker:${CHAP_IMAGE_TAG:-latest}
     platform: linux/amd64
+    init: true
     environment:
       IS_IN_DOCKER: 1
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      CHAP_DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      CHAP_DATABASE_URL: postgresql://${POSTGRES_USER:-chap}:${POSTGRES_PASSWORD:-chap}@postgres:5432/${POSTGRES_DB:-chap_core}
       CELERY_BROKER: redis://redis:6379
       RENV_PATHS_ROOT: /data/renv
       UV_CACHE_DIR: /data/uv
@@ -106,11 +123,11 @@ services:
     restart: unless-stopped
     image: postgres:17
     environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER:-chap}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-chap}
+      POSTGRES_DB: ${POSTGRES_DB:-chap_core}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-chap} -d ${POSTGRES_DB:-chap_core}"]
       interval: 10s
       timeout: 10s
       retries: 10

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      CHAP_DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      CHAP_DATABASE_URL: ${CHAP_DATABASE_URL:-postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}}
       CELERY_BROKER: redis://redis:6379/0
       CHAP_LOGS_DIR: /data/logs
       CHAP_RUNS_DIR: /data/runs
@@ -60,7 +60,7 @@ services:
       IS_IN_DOCKER: 1
       REDIS_HOST: redis
       REDIS_PORT: 6379
-      CHAP_DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      CHAP_DATABASE_URL: ${CHAP_DATABASE_URL:-postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}}
       CELERY_BROKER: redis://redis:6379
       RENV_PATHS_ROOT: /data/renv
       UV_CACHE_DIR: /data/uv

--- a/docs/modeling-app/fresh-installation.md
+++ b/docs/modeling-app/fresh-installation.md
@@ -45,7 +45,7 @@ cp .env.example .env
 This creates a `.env` file with default database credentials used by Docker Compose.
 
 !!! tip "Production deployments"
-    For production, open `.env` and change at least `POSTGRES_PASSWORD` to a strong, unique value. You can optionally change `POSTGRES_USER` as well. These credentials are set permanently when the database volume is first created, so choose them before running `docker compose up` for the first time.
+    For production, open `.env` and change at least `POSTGRES_PASSWORD` to a strong, unique value. The password is interpolated into a database URL, so keep it URL-safe -- no `@`, `:`, `/`, `?`, `#` or `%` -- or set `CHAP_DATABASE_URL` to a full percent-encoded URL instead. You can optionally change `POSTGRES_USER` as well. These credentials are set permanently when the database volume is first created, so choose them before running `docker compose up` for the first time.
 
     If Chap Core will be reachable from outside your internal network, also set `CHAP_API_TOKEN` to require an API token on every request. See [API Authentication](../webapi/api-authentication.md).
 

--- a/docs/webapi/docker-compose-doc.md
+++ b/docs/webapi/docker-compose-doc.md
@@ -62,18 +62,35 @@ docker compose -f compose.ghcr.yml up -d
 ```
 
 That deploys `latest`. Set `CHAP_IMAGE_TAG` to deploy a specific release
-instead, which is what you want on anything but a scratch instance:
+instead, which is what you want on anything but a scratch instance. Put it in
+an `.env` file beside the compose file rather than passing it inline:
 
 ```console
-CHAP_IMAGE_TAG=v1.2.3 docker compose -f compose.ghcr.yml up -d
+echo CHAP_IMAGE_TAG=v1.2.3 > .env
+docker compose -f compose.ghcr.yml up -d
 ```
 
-The tag must exist in [GHCR](https://github.com/orgs/dhis2-chap/packages);
-release tags are published by the image build workflow. The database
-credentials default to `chap` / `chap` / `chap_core`; Postgres is never
-published to the host, but override `POSTGRES_PASSWORD` for anything beyond a
-local trial. Pass the same `-f compose.ghcr.yml` flag to every later `down`,
-`pull` and `logs` command in that stack.
+An inline `CHAP_IMAGE_TAG=v1.2.3 docker compose ...` applies to that one
+command only, so a later `pull` or `up` would resolve back to `latest` and
+quietly replace the pinned release. Compose reads `.env` on every command, so
+the pin holds. The tag must exist in
+[GHCR](https://github.com/orgs/dhis2-chap/packages); release tags are published
+by the image build workflow.
+
+The database credentials default to `chap` / `chap` / `chap_core`. Postgres is
+never published to the host, but override `POSTGRES_PASSWORD` for anything
+beyond a local trial. The password is interpolated into a database URI, so it
+must be URL-safe -- no `@`, `:`, `/`, `?`, `#` or `%`. To use a password
+containing those, set `CHAP_DATABASE_URL` to a full percent-encoded URL, which
+takes precedence over the composed one:
+
+```console
+POSTGRES_PASSWORD='str@ng/pass'
+CHAP_DATABASE_URL='postgresql://chap:str%40ng%2Fpass@postgres:5432/chap_core'
+```
+
+Pass the same `-f compose.ghcr.yml` flag to every later `down`, `pull` and
+`logs` command in that stack.
 
 Docker Compose does not remember which overlays you used, so pass the same `-f` flags to every subsequent `down`, `build` and `logs` command in that stack. The `make restart`, `make force-restart` and `make chap-version` targets already carry the `compose.yml` + `compose.chapkit.yml` pair.
 

--- a/docs/webapi/docker-compose-doc.md
+++ b/docs/webapi/docker-compose-doc.md
@@ -26,7 +26,7 @@ The repository ships several compose files. `compose.yml` and `compose.ghcr.yml`
 | File | Kind | Purpose |
 |------|------|---------|
 | `compose.yml` | base | Builds `chap` and `worker` from local source. The default for development and for the documented server install. |
-| `compose.ghcr.yml` | base | Same services pulled as pre-built images from GHCR. Use *instead of* `compose.yml`. |
+| `compose.ghcr.yml` | base | Same services pulled as pre-built images from GHCR. Use *instead of* `compose.yml`. Self-contained: download this one file and run it without a checkout or an `.env`. |
 | `compose.chapkit.yml` | overlay | Umbrella overlay pulling in every bundled chapkit model service via the `include:` directive. Requires Compose v2.20+. |
 | `compose.ewars.yml` | overlay | The EWARS chapkit model service on its own. Already included by `compose.chapkit.yml`. |
 | `compose.override.yml.example` | overlay template | Optional extra services (`chtorch`, `ewars_plus`). Copy to `compose.override.yml`. Compose merges that file automatically **only** when no `-f` flag is used; with any `-f` flag you must list it explicitly, last. |
@@ -50,6 +50,30 @@ docker compose -f compose.yml -f compose.dev.yml up -d
 # Pre-built images instead of a local build
 docker compose -f compose.ghcr.yml up -d
 ```
+
+### Deploying a release without a checkout
+
+`compose.ghcr.yml` is the only file you need on a server. It pulls pre-built
+images and gives every variable a default, so it runs as downloaded:
+
+```console
+curl -O https://raw.githubusercontent.com/dhis2-chap/chap-core/master/compose.ghcr.yml
+docker compose -f compose.ghcr.yml up -d
+```
+
+That deploys `latest`. Set `CHAP_IMAGE_TAG` to deploy a specific release
+instead, which is what you want on anything but a scratch instance:
+
+```console
+CHAP_IMAGE_TAG=v1.2.3 docker compose -f compose.ghcr.yml up -d
+```
+
+The tag must exist in [GHCR](https://github.com/orgs/dhis2-chap/packages);
+release tags are published by the image build workflow. The database
+credentials default to `chap` / `chap` / `chap_core`; Postgres is never
+published to the host, but override `POSTGRES_PASSWORD` for anything beyond a
+local trial. Pass the same `-f compose.ghcr.yml` flag to every later `down`,
+`pull` and `logs` command in that stack.
 
 Docker Compose does not remember which overlays you used, so pass the same `-f` flags to every subsequent `down`, `build` and `logs` command in that stack. The `make restart`, `make force-restart` and `make chap-version` targets already carry the `compose.yml` + `compose.chapkit.yml` pair.
 

--- a/docs/webapi/docker-compose-doc.md
+++ b/docs/webapi/docker-compose-doc.md
@@ -54,39 +54,40 @@ docker compose -f compose.ghcr.yml up -d
 ### Deploying a release without a checkout
 
 `compose.ghcr.yml` is the only file you need on a server. It pulls pre-built
-images and gives every variable a default, so it runs as downloaded:
+images and every setting has a working default, so it runs exactly as
+downloaded -- no checkout, no `.env`, no edits:
 
 ```console
 curl -O https://raw.githubusercontent.com/dhis2-chap/chap-core/master/compose.ghcr.yml
 docker compose -f compose.ghcr.yml up -d
 ```
 
-That deploys `latest`. Set `CHAP_IMAGE_TAG` to deploy a specific release
-instead, which is what you want on anything but a scratch instance. Put it in
-an `.env` file beside the compose file rather than passing it inline:
+#### Available settings
+
+All optional. Put them in an `.env` file beside the compose file rather than
+inline on the command line: Compose reads `.env` on every command, so a later
+`pull` or `up` keeps the same values, whereas an inline `VAR=x docker compose
+...` applies to that one command and silently reverts afterwards.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CHAP_IMAGE_TAG` | `latest` | Tag for both the `chap-core` and `chap-worker` images. Set a release tag (for example `v1.2.3`) to pin a version. The tag must exist in [GHCR](https://github.com/orgs/dhis2-chap/packages); release tags are published by the image build workflow. |
+| `POSTGRES_USER` | `chap` | Database user. |
+| `POSTGRES_PASSWORD` | `chap` | Database password. Postgres is never published to the host, but override this for anything beyond a local trial. It is interpolated into a database URI, so it must be URL-safe -- no `@`, `:`, `/`, `?`, `#` or `%`. |
+| `POSTGRES_DB` | `chap_core` | Database name. |
+| `CHAP_DATABASE_URL` | composed from the three above | Full, percent-encoded database URL. Takes precedence, and is how you use a password containing reserved characters. |
+| `CHAP_ROOT_PATH` | empty | Path prefix when serving behind a reverse proxy. |
+| `CHAP_API_TOKEN` | empty | API token. Unset means no authentication. |
+
+Pinning a release and setting a password with reserved characters:
 
 ```console
-echo CHAP_IMAGE_TAG=v1.2.3 > .env
+cat > .env <<'EOF'
+CHAP_IMAGE_TAG=v1.2.3
+POSTGRES_PASSWORD=str@ng/pass
+CHAP_DATABASE_URL=postgresql://chap:str%40ng%2Fpass@postgres:5432/chap_core
+EOF
 docker compose -f compose.ghcr.yml up -d
-```
-
-An inline `CHAP_IMAGE_TAG=v1.2.3 docker compose ...` applies to that one
-command only, so a later `pull` or `up` would resolve back to `latest` and
-quietly replace the pinned release. Compose reads `.env` on every command, so
-the pin holds. The tag must exist in
-[GHCR](https://github.com/orgs/dhis2-chap/packages); release tags are published
-by the image build workflow.
-
-The database credentials default to `chap` / `chap` / `chap_core`. Postgres is
-never published to the host, but override `POSTGRES_PASSWORD` for anything
-beyond a local trial. The password is interpolated into a database URI, so it
-must be URL-safe -- no `@`, `:`, `/`, `?`, `#` or `%`. To use a password
-containing those, set `CHAP_DATABASE_URL` to a full percent-encoded URL, which
-takes precedence over the composed one:
-
-```console
-POSTGRES_PASSWORD='str@ng/pass'
-CHAP_DATABASE_URL='postgresql://chap:str%40ng%2Fpass@postgres:5432/chap_core'
 ```
 
 Pass the same `-f compose.ghcr.yml` flag to every later `down`, `pull` and

--- a/tests/test_compose_deployment.py
+++ b/tests/test_compose_deployment.py
@@ -115,6 +115,17 @@ def test_standalone_compose_needs_no_env_file():
     )
 
 
+# CHAP_IMAGE_TAG can select a release older than the healthcheck baked into the
+# current Dockerfiles, so the standalone file cannot rely on the image for one.
+@pytest.mark.parametrize("service_name", ["chap", "worker"])
+def test_standalone_compose_declares_own_healthcheck(service_name):
+    service = _services(STANDALONE_COMPOSE_FILE)[service_name]
+    assert _healthcheck_source(service) == "compose", (
+        f"{STANDALONE_COMPOSE_FILE}: service '{service_name}' inherits its healthcheck from the "
+        f"image, so pinning a tag published before that healthcheck existed leaves it unmonitored"
+    )
+
+
 @pytest.mark.parametrize("service_name", ["chap", "worker"])
 def test_standalone_compose_image_tag_is_pinnable(service_name):
     image = _services(STANDALONE_COMPOSE_FILE)[service_name]["image"]

--- a/tests/test_compose_deployment.py
+++ b/tests/test_compose_deployment.py
@@ -33,6 +33,11 @@ def _dockerfile_has_healthcheck(dockerfile):
     return re.search(r"^HEALTHCHECK\s", path.read_text(), re.MULTILINE) is not None
 
 
+def _image_repository(image):
+    """Image reference without its tag, which may itself be a ${VAR:-default}."""
+    return re.sub(r":[^/]*$", "", image)
+
+
 def _healthcheck_source(service):
     """Which file supplies this service's healthcheck, or None if nothing does."""
     if service.get("healthcheck"):
@@ -50,7 +55,7 @@ def _healthcheck_source(service):
 
     image = service.get("image")
     if image:
-        repo = image.rsplit(":", 1)[0]
+        repo = _image_repository(image)
         dockerfile = IMAGE_TO_DOCKERFILE.get(repo)
         if dockerfile and _dockerfile_has_healthcheck(dockerfile):
             return dockerfile
@@ -91,4 +96,32 @@ def test_deployed_service_reports_health(compose_file, service_name, service):
         f"{compose_file}: service '{service_name}' has no healthcheck in compose and its "
         f"image carries none either, so depends_on conditions and restart-on-unhealthy "
         f"cannot work for it"
+    )
+
+
+# compose.ghcr.yml is the file users download on its own and run without a checkout,
+# so it must render with no .env and must let a release be pinned.
+STANDALONE_COMPOSE_FILE = "compose.ghcr.yml"
+
+INTERPOLATION = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(:?-[^}]*)?\}")
+
+
+def test_standalone_compose_needs_no_env_file():
+    text = (REPO_ROOT / STANDALONE_COMPOSE_FILE).read_text()
+    missing_default = sorted({m.group(1) for m in INTERPOLATION.finditer(text) if not m.group(2)})
+    assert not missing_default, (
+        f"{STANDALONE_COMPOSE_FILE}: {missing_default} have no default, so the file cannot be "
+        f"downloaded on its own and started with `docker compose up`"
+    )
+
+
+@pytest.mark.parametrize("service_name", ["chap", "worker"])
+def test_standalone_compose_image_tag_is_pinnable(service_name):
+    image = _services(STANDALONE_COMPOSE_FILE)[service_name]["image"]
+    repo = _image_repository(image)
+    tag = image[len(repo) + 1 :]
+    assert repo in IMAGE_TO_DOCKERFILE, f"unexpected image repository {repo!r}"
+    assert tag == "${CHAP_IMAGE_TAG:-latest}", (
+        f"{STANDALONE_COMPOSE_FILE}: service '{service_name}' pins {image!r}, so a specific "
+        f"release cannot be deployed without editing the file"
     )

--- a/tests/test_compose_deployment.py
+++ b/tests/test_compose_deployment.py
@@ -99,8 +99,7 @@ def test_deployed_service_reports_health(compose_file, service_name, service):
     )
 
 
-# compose.ghcr.yml is the file users download on its own and run without a checkout,
-# so it must render with no .env and must let a release be pinned.
+# The file users download on its own and run without a checkout.
 STANDALONE_COMPOSE_FILE = "compose.ghcr.yml"
 
 INTERPOLATION = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(:?-[^}]*)?\}")
@@ -115,10 +114,9 @@ def test_standalone_compose_needs_no_env_file():
     )
 
 
-# CHAP_IMAGE_TAG can select a release older than the healthcheck baked into the
-# current Dockerfiles, so the standalone file cannot rely on the image for one.
 @pytest.mark.parametrize("service_name", ["chap", "worker"])
 def test_standalone_compose_declares_own_healthcheck(service_name):
+    """A pinned tag may predate the healthcheck baked into the current Dockerfiles."""
     service = _services(STANDALONE_COMPOSE_FILE)[service_name]
     assert _healthcheck_source(service) == "compose", (
         f"{STANDALONE_COMPOSE_FILE}: service '{service_name}' inherits its healthcheck from the "
@@ -135,4 +133,20 @@ def test_standalone_compose_image_tag_is_pinnable(service_name):
     assert tag == "${CHAP_IMAGE_TAG:-latest}", (
         f"{STANDALONE_COMPOSE_FILE}: service '{service_name}' pins {image!r}, so a specific "
         f"release cannot be deployed without editing the file"
+    )
+
+
+def test_env_example_leaves_redis_password_unset():
+    """The compose valkey service takes no --requirepass, so an AUTH from the client fails."""
+    requirepass = [f for f in DEPLOYMENT_COMPOSE_FILES if "requirepass" in str(_services(f).get("redis", {}))]
+    assert not requirepass, f"{requirepass} configure a redis password; update this test"
+
+    active = [
+        line
+        for line in (REPO_ROOT / ".env.example").read_text().splitlines()
+        if line.strip().startswith("REDIS_PASSWORD=") and line.split("=", 1)[1].strip()
+    ]
+    assert not active, (
+        f".env.example sets {active}, so copying it to .env makes the redis client send AUTH "
+        f"to a valkey service that has no password configured"
     )


### PR DESCRIPTION
[CLIM-975](https://dhis2.atlassian.net/browse/CLIM-975)

## Problem

`compose.ghcr.yml` is meant to be the deployment path, but two things stopped it being one:

- The images were pinned to `chap-core:latest` / `chap-worker:latest`, so a specific release could not be deployed without editing the file.
- `POSTGRES_USER`, `POSTGRES_PASSWORD` and `POSTGRES_DB` had no defaults, so it only worked next to an `.env` from a source checkout, which is the thing a prebuilt-image deployment is supposed to avoid.

It had also drifted from `compose.yml` on three points that only affect the deployment path.

## Change

Deploying a release is now one file and one command, with nothing else to configure:

```console
curl -O https://raw.githubusercontent.com/dhis2-chap/chap-core/master/compose.ghcr.yml
docker compose -f compose.ghcr.yml up -d
```

- Image tag is `${CHAP_IMAGE_TAG:-latest}` on both services.
- Every interpolation has a default, so the file renders and runs as downloaded.
- The header and the docs list all seven supported variables with their defaults, so it is clear both that nothing is required and what can be tuned: `CHAP_IMAGE_TAG`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `CHAP_DATABASE_URL`, `CHAP_ROOT_PATH`, `CHAP_API_TOKEN`.
- `CHAP_DATABASE_URL` overrides the composed URL, for a password that is not URL-safe.
- Drift closed against `compose.yml`: `init: true` on both services, `CHAP_ROOT_PATH` on `chap`, and healthchecks declared in the file rather than inherited from the images, since a pinned tag can predate them.
- Docs get a "Deploying a release without a checkout" section with a settings table.

`compose.yml` is untouched: it stays the unambiguous build-from-source file for local development, and the two remain alternatives rather than stackable.

### Included fix: `.env.example` shipped a Redis password

Separate cause, same file set. `.env.example` set `REDIS_PASSWORD=your_secure_redis_password`, but the compose valkey service runs without `--requirepass`. `chap_core/util.py:101` reads the variable and sends AUTH to a server with no password, which valkey rejects — so the documented "copy `.env.example` to `.env`" flow was broken. CI had been deleting the line after copying (`ci-test-external-models.yml`); the cause is fixed and that workaround removed.

Leaving the compose valkey unauthenticated is tracked separately as [CLIM-977](https://dhis2.atlassian.net/browse/CLIM-977): it is not reachable from the host, but every service on the default bridge, model containers included, can reach the broker.

The Kubernetes chart is the opposite case: its valkey does require a password, and `skaffold run` reads `REDIS_PASSWORD` from the shell (`skaffold.yaml:26`). Since `.envrc` is `dotenv`, leaving the value in `.env.example` fed it to both. The comment now points the k8s flow at the shell, as `charts/chap/README.md` already does. No chart file changes.

## Review follow-ups

- **Tag persistence** — the docs recommended `CHAP_IMAGE_TAG=v1.2.3 docker compose ...`, which applies to one command, so a later `pull` or `up` fell back to `latest`. They now direct the pin to an `.env` file and say why.
- **Password in the URI** — confirmed at `chap_core/database/database.py:52`, which passes the value straight to `create_engine`. Hence the `CHAP_DATABASE_URL` override, and the URL-safe note.
- **Worker healthcheck on old tags** — `chap-worker:v2.1.0` has no HEALTHCHECK (added later, in #532), so a pinned old tag ran unmonitored. Now declared in the compose file. Note the review's premise that v2.1.0's own compose file supplied one does not hold — `git show v2.1.0:compose.ghcr.yml` has no healthcheck on the worker — so this was a gap rather than a regression.

## Tests

Four in `tests/test_compose_deployment.py`: the standalone file has no undefaulted variable, `chap` and `worker` each carry a pinnable tag and their own compose-level healthcheck, and `.env.example` leaves `REDIS_PASSWORD` unset while the compose valkey takes no password. The image-to-Dockerfile healthcheck lookup was taught to strip a templated tag.

## Verification

- `make lint` clean (ruff, mypy 416 files, pyright 0 errors)
- `make test`: 1340 passed, 120 skipped, 4 xfailed, 1 xpassed
- `docker compose -f compose.ghcr.yml config -q` exits 0
- Copied the file alone into an empty directory with no `.env`: renders and validates; `CHAP_IMAGE_TAG=v1.2.3` resolves both images to `:v1.2.3`; `CHAP_DATABASE_URL` override renders a percent-encoded password unchanged


[CLIM-975]: https://dhis2.atlassian.net/browse/CLIM-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIM-977]: https://dhis2.atlassian.net/browse/CLIM-977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ