### PR TITLE
docs: write the minimalist eval example output directly to /tmp

### DIFF
--- a/docs/chap-cli/minimalist-example.md
+++ b/docs/chap-cli/minimalist-example.md
@@ -10,7 +10,7 @@ Run an evaluation against the minimalist example model, using an example dataset
 chap eval \
     --model-name https://github.com/dhis2-chap/minimalist_example_uv \
     --dataset-csv https://raw.githubusercontent.com/dhis2-chap/chap-core/master/example_data/laos_subset.csv \
-    --output-file /tmp/chap/temp/eval.nc \
+    --output-file /tmp/eval.nc \
     --backtest-params.n-splits 2 \
     --backtest-params.n-periods 1 \
     --plot
@@ -18,6 +18,6 @@ chap eval \
 
 ## Verification
 
-If the command completes and writes `/tmp/chap/temp/eval.nc` and `/tmp/chap/temp/eval.html`, your Chap installation is working: it can resolve a GitHub-hosted model, set up its environment, run a rolling-origin backtest on a remote dataset, and plot the results.
+If the command completes and writes `/tmp/eval.nc` and `/tmp/eval.html`, your Chap installation is working: it can resolve a GitHub-hosted model, set up its environment, run a rolling-origin backtest on a remote dataset, and plot the results.
 
 The next step is to integrate your own model into Chap.


### PR DESCRIPTION
Fixes [CLIM-1013](https://dhis2.atlassian.net/browse/CLIM-1013).

## Summary

- Write the minimalist eval example output to `/tmp/eval.nc` instead of `/tmp/chap/temp/eval.nc`, and adjust the verification text in `docs/chap-cli/minimalist-example.md` to match.

## Context

Nothing creates `/tmp/chap/temp` unless Chap's own temp-dir helper has already run, so on a fresh machine and on the CI runner the netCDF writer fails with a misleading `PermissionError: [Errno 13] Permission denied`. The path was introduced in April to keep test runs from writing into the repo root, and it worked locally only because an earlier run had created the directory. This is why the weekly `Documentation slow tests` workflow has failed on every run since.

`/tmp` always exists on Linux and macOS, so the example works without a setup step. Docs-only change; `chap_core` is untouched.

## Testing

- `uv run pytest tests/test_documentation_slow.py --run-slow -k minimalist-example` passes on a clean `/tmp` and produces `/tmp/eval.nc` and `/tmp/eval.html`.


[CLIM-1013]: https://dhis2.atlassian.net/browse/CLIM-1013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ