### PR TITLE
chore: pin the ewars overlay to a sha build and harden it like chap and worker (CLIM-979)

### DIFF
--- a/compose.ewars.yml
+++ b/compose.ewars.yml
@@ -1,15 +1,37 @@
 services:
   ewars:
     restart: unless-stopped
-    image: ghcr.io/chap-models/chapkit_ewars_model:latest
+    # Pinned to a specific build rather than latest so a deployment stays reproducible
+    # (CLIM-979). The model's publish workflow tags every main build as sha-<short commit>;
+    # set EWARS_IMAGE_TAG in .env to move the pin.
+    image: ghcr.io/chap-models/chapkit_ewars_model:${EWARS_IMAGE_TAG:-sha-fa880a1}
     platform: linux/amd64
-    pull_policy: always
+    init: true
     ports:
       - "5002:8000"
     environment:
       SERVICEKIT_ORCHESTRATOR_URL: http://chap:8000/v2/services/$$register
       # Uncomment if chap has SERVICEKIT_REGISTRATION_KEY set:
       # SERVICEKIT_REGISTRATION_KEY: ${SERVICEKIT_REGISTRATION_KEY:-}
+    # Same posture as chap and worker: unprivileged user, read-only root filesystem,
+    # writable only at /app/data (SQLite) and /tmp (ML workspaces).
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    user: chapkit:chapkit
+    volumes:
+      - type: tmpfs
+        target: /tmp
+        tmpfs:
+          size: 2000000000 # 2GB for model workspaces (INLA writes here)
+      - type: volume
+        source: ewars_data
+        target: /app/data
     depends_on:
       chap:
         condition: service_healthy
+
+volumes:
+  ewars_data:

--- a/docs/webapi/docker-compose-doc.md
+++ b/docs/webapi/docker-compose-doc.md
@@ -73,6 +73,7 @@ inline on the command line: Compose reads `.env` on every command, so a later
 |----------|---------|---------|
 | `CHAP_IMAGE_TAG` | `latest` | Tag for both the `chap-core` and `chap-worker` images. Set a release tag (for example `v1.2.3`) to pin a version. The tag must exist in [GHCR](https://github.com/orgs/dhis2-chap/packages); release tags are published by the image build workflow. |
 | `POSTGRES_USER` | `chap` | Database user. |
+| `EWARS_IMAGE_TAG` | a `sha-<commit>` build | Tag of the EWARS model service image in `compose.ewars.yml`. Model overlays pin a specific build so the stack stays reproducible; the model's publish workflow tags every build as `sha-<short commit>` and releases as semver. Set this to move the pin. |
 | `POSTGRES_PASSWORD` | `chap` | Database password. Postgres is never published to the host, but override this for anything beyond a local trial. It is interpolated into a database URI, so it must be URL-safe -- no `@`, `:`, `/`, `?`, `#` or `%`. |
 | `POSTGRES_DB` | `chap_core` | Database name. |
 | `CHAP_DATABASE_URL` | composed from the three above | Full, percent-encoded database URL. Takes precedence, and is how you use a password containing reserved characters. |

--- a/tests/test_compose_deployment.py
+++ b/tests/test_compose_deployment.py
@@ -136,6 +136,24 @@ def test_standalone_compose_image_tag_is_pinnable(service_name):
     )
 
 
+MODEL_OVERLAY_FILES = ["compose.ewars.yml"]
+
+
+@pytest.mark.parametrize("compose_file", MODEL_OVERLAY_FILES)
+def test_model_overlay_pins_image_by_commit(compose_file):
+    """Model overlays pin a sha-<commit> build with an overridable tag variable, never latest."""
+    for service_name, service in _services(compose_file).items():
+        image = service["image"]
+        tag = image[len(_image_repository(image)) + 1 :]
+        assert re.fullmatch(r"\$\{[A-Z_]+_IMAGE_TAG:-sha-[0-9a-f]{7}\}", tag), (
+            f"{compose_file}: service '{service_name}' uses {image!r}; expected "
+            "${<SERVICE>_IMAGE_TAG:-sha-<commit>} so the deployment is reproducible and pinnable"
+        )
+        assert service.get("pull_policy") != "always", (
+            f"{compose_file}: service '{service_name}' pulls on every up, which defeats the pin"
+        )
+
+
 def test_env_example_leaves_redis_password_unset():
     """The compose valkey service takes no --requirepass, so an AUTH from the client fails."""
     requirepass = [f for f in DEPLOYMENT_COMPOSE_FILES if "requirepass" in str(_services(f).get("redis", {}))]


### PR DESCRIPTION
## Summary

- `compose.ewars.yml` pins `ghcr.io/chap-models/chapkit_ewars_model` to its `sha-fa880a1` build behind `EWARS_IMAGE_TAG`, in the same style as `CHAP_IMAGE_TAG`, and drops `pull_policy: always`, which defeats a pin. That build is chap-models/chapkit_ewars_model#8: chapkit 2.0.0, `GIT_REVISION` reported on `/api/v1/info`, and the service running as the unprivileged `chapkit` user.
- The overlay applies the same posture as `chap` and `worker`: `init`, read-only root filesystem, `cap_drop: ALL`, `no-new-privileges`, `user: chapkit:chapkit`, a 2 GB tmpfs on `/tmp` for model workspaces (INLA writes there) and a named volume for `/app/data`.
- `tests/test_compose_deployment.py` gains a check that model overlays use the `${<SERVICE>_IMAGE_TAG:-sha-<commit>}` form and no `pull_policy: always`.
- `docs/webapi/docker-compose-doc.md` documents `EWARS_IMAGE_TAG` in the settings table.

Out of scope, still open on the ticket: the `compose.override.yml.example` entries (chtorch pinned to an old tag, `ewars_plus` on Docker Hub).

## Test plan

- [x] `pytest tests/test_compose_deployment.py`: 24 passed, 1 skipped
- [x] `docker compose -f compose.ghcr.yml -f compose.ewars.yml up -d --wait`: all four services healthy
- [x] ewars container runs as uid 1000, root filesystem read-only, `/tmp` and `/app/data` writable
- [x] `GET :5002/api/v1/info` reports `git_revision` fa880a1, chapkit 2.0.0, servicekit 2.0.2; `/health` reports the registration check healthy
- [x] `GET :8000/v2/services` on chap lists `chapkit-ewars-model`; ewars log shows `registration.success`

---

Jira: [CLIM-979](https://dhis2.atlassian.net/browse/CLIM-979)

[CLIM-979]: https://dhis2.atlassian.net/browse/CLIM-979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ