### PR TITLE
fix: accept provenance fields from chapkit 2.0 services in the service info parser

### DIFF
--- a/chap_core/models/chapkit_rest_api_wrapper.py
+++ b/chap_core/models/chapkit_rest_api_wrapper.py
@@ -10,9 +10,9 @@ import httpx
 import numpy as np
 import pandas as pd
 from chapkit.api import HealthStatus
-from chapkit.api.service_builder import MLServiceInfo
 from pydantic import BaseModel, Field
 
+from chap_core.rest_api.services.schemas import MLServiceInfo
 from chap_core.time_period.date_util_wrapper import pandas_period_to_string
 
 logger = logging.getLogger(__name__)

--- a/chap_core/models/utils.py
+++ b/chap_core/models/utils.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Literal
 import git
 import httpx
 import yaml
-from chapkit.api.service_builder import MLServiceInfo
 
 from chap_core.exceptions import InvalidModelException
 from chap_core.external.external_model import logger
@@ -15,6 +14,7 @@ from chap_core.external.model_configuration import ModelTemplateConfigV2
 from chap_core.models.chapkit_service_manager import is_url
 from chap_core.models.external_chapkit_model import ExternalChapkitModelTemplate
 from chap_core.models.model_template import ModelTemplate
+from chap_core.rest_api.services.schemas import MLServiceInfo
 from chap_core.util import generate_run_name
 
 CHAP_RUNS_DIR = Path(os.getenv("CHAP_RUNS_DIR", "runs/"))

--- a/chap_core/rest_api/services/schemas.py
+++ b/chap_core/rest_api/services/schemas.py
@@ -100,6 +100,10 @@ class MLServiceInfo(ServiceInfo):
     requires_geo: bool = Field(
         default=False, description="When True, the model needs a GeoJSON polygon set for spatial features."
     )
+    # Build provenance reported by chapkit 2.0 services. Optional so 1.x services still validate.
+    git_revision: str | None = Field(default=None, description="Commit the service image was built from.")
+    chapkit_version: str | None = Field(default=None, description="chapkit version installed in the service.")
+    servicekit_version: str | None = Field(default=None, description="servicekit version installed in the service.")
 
 
 class RegistrationRequest(BaseModel):

--- a/tests/test_chapkit_service_info_compat.py
+++ b/tests/test_chapkit_service_info_compat.py
@@ -1,0 +1,48 @@
+"""The service info parser must accept fields added by newer chapkit services."""
+
+from chap_core.models.external_chapkit_model import ml_service_info_to_model_template_config
+from chap_core.rest_api.services.schemas import MLServiceInfo
+
+CHAPKIT_2_INFO = {
+    "id": "chapkit-ewars-model",
+    "display_name": "CHAP-EWARS Model (chapkit)",
+    "version": "1.0.0",
+    "description": None,
+    "git_revision": "fa880a1d8621c6c5bf60c472c299c40b5568ecd0",
+    "chapkit_version": "2.0.0",
+    "servicekit_version": "2.0.2",
+    "model_metadata": {"author": "CHAP team", "author_assessed_status": "orange"},
+    "period_type": "monthly",
+    "min_prediction_periods": 0,
+    "max_prediction_periods": 100,
+    "allow_free_additional_continuous_covariates": True,
+    "required_covariates": ["population"],
+    "requires_geo": False,
+    "some_future_field": {"nested": True},
+}
+
+
+def test_service_info_accepts_provenance_and_unknown_fields():
+    info = MLServiceInfo.model_validate(CHAPKIT_2_INFO)
+
+    assert info.git_revision == CHAPKIT_2_INFO["git_revision"]
+    assert info.chapkit_version == "2.0.0"
+    assert info.servicekit_version == "2.0.2"
+    assert info.required_covariates == ["population"]
+
+
+def test_service_info_from_chapkit_1_service_still_validates():
+    payload = {
+        k: v for k, v in CHAPKIT_2_INFO.items() if k not in ("git_revision", "chapkit_version", "servicekit_version")
+    }
+    info = MLServiceInfo.model_validate(payload)
+
+    assert info.git_revision is None
+
+
+def test_provenance_fields_do_not_break_template_conversion():
+    info = MLServiceInfo.model_validate(CHAPKIT_2_INFO)
+    config = ml_service_info_to_model_template_config(info, "http://ewars:8000")
+
+    assert config.name == "chapkit-ewars-model"
+    assert config.required_covariates == ["population"]


### PR DESCRIPTION
## Summary

chapkit 2.0.0 services report three new fields on `/api/v1/info`: `git_revision`, `chapkit_version` and `servicekit_version`. `CHAPKitRestAPIWrapper.info()` and the chapkit URL probe in `chap_core/models/utils.py` validated that payload with `chapkit.api.service_builder.MLServiceInfo` from the pinned chapkit 1.x, whose base model forbids extra fields, so every 2.0 service was rejected with three `extra_forbidden` errors. This is what broke `test-all` on #563 and will break master's next run, since the e2e fixture resolves chapkit 2.0.0 now.

- Both sites now validate with `chap_core.rest_api.services.schemas.MLServiceInfo`, the local copy that `ml_service_info_to_model_template_config` already accepts and that ignores unknown fields, so future additive fields cannot break registration either.
- The three provenance fields are added to that schema as optional, so 1.x services still validate and `git_revision` becomes available for `ModelTemplateDB.source_digest` later.
- No change to the chapkit pin.

## Test plan

- [x] `make lint`
- [x] New `tests/test_chapkit_service_info_compat.py`: 2.0 payload with an extra unknown field validates, 1.x payload without the fields validates, template conversion unaffected
- [x] `tests/external/test_external_chapkit_model.py` passes
- [x] `tests/integration/test_chapkit_e2e.py --run-slow` locally with the fixture service on chapkit 2.0.0 (4 passed, including the two that fail in CI)

---

Jira: [CLIM-1051](https://dhis2.atlassian.net/browse/CLIM-1051)

[CLIM-1051]: https://dhis2.atlassian.net/browse/CLIM-1051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
