### PR TITLE
fix(tests): stop chapkit e2e fixture deadlocking on full stdout pipe

### DIFF
--- a/tests/integration/test_chapkit_e2e.py
+++ b/tests/integration/test_chapkit_e2e.py
@@ -72,6 +72,13 @@ def chapkit_service(tmp_path_factory):
         "CHAPKIT_DATABASE_URL": f"sqlite+aiosqlite:///{data_dir}/chapkit.db",
     }
 
+    # Log to files rather than pipes: chapkit logs every request, and an
+    # unread pipe fills up, blocking the server so it can never shut down.
+    stdout_path = data_dir / "stdout.log"
+    stderr_path = data_dir / "stderr.log"
+    stdout_file = stdout_path.open("wb")
+    stderr_file = stderr_path.open("wb")
+
     proc = subprocess.Popen(
         [
             "uv",
@@ -86,19 +93,25 @@ def chapkit_service(tmp_path_factory):
             str(port),
         ],
         env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=stdout_file,
+        stderr=stderr_file,
     )
 
     try:
         if not _wait_for_health(url):
-            stdout = proc.stdout.read().decode() if proc.stdout else ""
-            stderr = proc.stderr.read().decode() if proc.stderr else ""
+            stdout = stdout_path.read_text()
+            stderr = stderr_path.read_text()
             pytest.fail(f"Chapkit service failed to start:\nstdout: {stdout}\nstderr: {stderr}")
         yield url
     finally:
         proc.send_signal(signal.SIGTERM)
-        proc.wait(timeout=10)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        stdout_file.close()
+        stderr_file.close()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

The module-scoped `chapkit_service` fixture in `tests/integration/test_chapkit_e2e.py` started the chapkit subprocess with stdout and stderr set to `subprocess.PIPE` and never read them. Chapkit 2 logs a structured line for every request start and end to stdout, and a full module run writes about 61 KB, just under the 64 KB pipe buffer. When timing on CI adds a few more job-status polls, the buffer fills, the server blocks on its next log write and can no longer handle SIGTERM, and the fixture teardown fails with `subprocess.TimeoutExpired` after 10 seconds.

Seen in https://github.com/dhis2-chap/chap-core/actions/runs/34206595994/job/101997409428 on an unrelated PR.

## Changes

- Write the service's stdout and stderr to files under the fixture's temp directory instead of pipes, and read those files for the startup failure message.
- Kill the process if it does not exit within 10 seconds of SIGTERM so it does not leak.

## Testing

- `make lint`
- `uv run pytest tests/integration/test_chapkit_e2e.py --run-slow` (4 passed)