### PR TITLE
feat: pluggable future-weather providers with look-ahead flag

### DIFF
--- a/alembic/versions/e1f2a3b4c5d6_add_backtest_future_weather_provider.py
+++ b/alembic/versions/e1f2a3b4c5d6_add_backtest_future_weather_provider.py
@@ -1,0 +1,60 @@
+"""add_backtest_future_weather_provider
+
+Store which future-weather provider supplied the climate covariates a backtest
+ran with, on the backtest row.
+
+Existing rows are backfilled with "climatology". Every backtest row was written
+by the REST path, which hardcoded QuickForecastFetcher - a per-location seasonal
+regression fitted on the historical data, which is exactly what the climatology
+provider does. Note this differs from evaluation .nc files, which came from the
+CLI and were given the forecast window's observed weather; those are read back
+as "observed" instead.
+
+Revision ID: e1f2a3b4c5d6
+Revises: d0e1f2a3b4c5
+Create Date: 2026-09-08
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: str | Sequence[str] | None = "d0e1f2a3b4c5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+COLUMN = "future_weather_provider"
+# The provider the REST backtest path always used. Local to this migration so it
+# stays fixed even if the registry default changes later.
+LEGACY_PROVIDER = "climatology"
+
+
+def _has_column(table: str, column: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(col["name"] == column for col in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    """Add the provider column, backfill existing rows, then make it NOT NULL.
+
+    Startup runs a generic metadata migration before Alembic, so the column may
+    already exist with an empty value in every row; both shapes are backfilled
+    the same way.
+    """
+    if not _has_column("backtest", COLUMN):
+        op.add_column("backtest", sa.Column(COLUMN, sa.String(), nullable=True))
+    op.execute(
+        sa.text(f"UPDATE backtest SET {COLUMN} = :provider WHERE {COLUMN} IS NULL OR {COLUMN} = ''").bindparams(
+            provider=LEGACY_PROVIDER
+        )
+    )
+    op.alter_column("backtest", COLUMN, existing_type=sa.String(), nullable=False)
+
+
+def downgrade() -> None:
+    """Drop the provider column."""
+    op.drop_column("backtest", COLUMN)

--- a/chap_core/api_types.py
+++ b/chap_core/api_types.py
@@ -17,8 +17,9 @@ from geojson_pydantic import (
     Point,
     Polygon,
 )
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
+from chap_core.assessment.weather_providers import DEFAULT_WEATHER_PROVIDER_ID, resolve_weather_provider
 from chap_core.database.base_tables import DBModel
 
 
@@ -125,6 +126,18 @@ class BacktestParams(DBModel):
         gt=0,
         description="Number of times the model is retrained, evenly spaced across the splits. 1 means train once.",
     )
+    future_weather_provider: str = Field(
+        default=DEFAULT_WEATHER_PROVIDER_ID,
+        description="Id of the registered future-weather provider supplying climate covariates for each "
+        "forecast window. Use the same provider here and on the prediction so backtest scores reflect "
+        "what the model will see in production. See GET /v1/analytics/weather-providers.",
+    )
+
+    @field_validator("future_weather_provider")
+    @classmethod
+    def _check_weather_provider(cls, value: str) -> str:
+        resolve_weather_provider(value)
+        return value
 
     @model_validator(mode="after")
     def _check_n_retrain(self) -> "BacktestParams":

--- a/chap_core/assessment/dataset_splitting.py
+++ b/chap_core/assessment/dataset_splitting.py
@@ -10,7 +10,7 @@ slides forward.
 from collections.abc import Iterable, Iterator
 from typing import Protocol
 
-from chap_core.climate_predictor import FutureWeatherFetcher
+from chap_core.assessment.weather_providers import DEFAULT_WEATHER_PROVIDER_ID, get_future_weather
 from chap_core.datatypes import ClimateData
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 from chap_core.time_period import TimePeriod
@@ -106,7 +106,7 @@ def train_test_generator(
     prediction_length: int,
     n_test_sets: int = 1,
     stride: int = 1,
-    future_weather_provider: FutureWeatherFetcher | None = None,
+    future_weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
 ) -> tuple[DataSet, Iterator[tuple[DataSet, DataSet, DataSet]]]:
     """Generate expanding-window train/test splits for backtesting.
 
@@ -144,8 +144,9 @@ def train_test_generator(
     stride
         Number of periods to advance between successive splits.
     future_weather_provider
-        Optional callable that provides future weather data (with
-        disease_cases masked) for each test split.
+        Id of the registered future-weather provider supplying the climate
+        covariates for each test window. Providers that do not declare
+        ``leaks_future_data`` never see the window's own observations.
 
     Returns
     -------
@@ -168,13 +169,10 @@ def train_test_generator(
         )
         for i in range(n_test_sets)
     ]
-    if future_weather_provider is not None:
-        masked_future_data = [
-            future_weather_provider(hd).get_future_weather(fd.period_range)  # type: ignore[operator]
-            for (hd, fd) in zip(historic_data, future_data, strict=False)
-        ]
-    else:
-        masked_future_data = [dataset.remove_field("disease_cases") for dataset in future_data]
+    masked_future_data = [
+        get_future_weather(future_weather_provider, hd, fd.period_range, future_data=fd)
+        for (hd, fd) in zip(historic_data, future_data, strict=False)
+    ]
     train_set.metadata = dataset.metadata.model_copy()
     train_set.metadata.name += "_train_set"
     return train_set, zip(historic_data, masked_future_data, future_data, strict=False)

--- a/chap_core/assessment/dataset_splitting.py
+++ b/chap_core/assessment/dataset_splitting.py
@@ -169,10 +169,12 @@ def train_test_generator(
         )
         for i in range(n_test_sets)
     ]
-    masked_future_data = [
+    # Lazy: callers that only need the train set (or never iterate) should not
+    # pay for a provider fit per split.
+    masked_future_data = (
         get_future_weather(future_weather_provider, hd, fd.period_range, future_data=fd)
         for (hd, fd) in zip(historic_data, future_data, strict=False)
-    ]
+    )
     train_set.metadata = dataset.metadata.model_copy()
     train_set.metadata.name += "_train_set"
     return train_set, zip(historic_data, masked_future_data, future_data, strict=False)

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -19,6 +19,11 @@ import pandera.pandas as pa
 import xarray as xr
 from packaging.version import Version
 
+from chap_core.assessment.weather_providers import (
+    DEFAULT_WEATHER_PROVIDER_ID,
+    LEGACY_WEATHER_PROVIDER_ID,
+)
+
 if TYPE_CHECKING:
     from chap_core.api_types import BacktestParams
 
@@ -96,6 +101,7 @@ def _flat_data_to_xarray(flat_data: "FlatEvaluationData", model_metadata: dict) 
         "split_periods": json.dumps(model_metadata.get("split_periods", [])),
         "org_units": json.dumps(model_metadata.get("org_units", [])),
         "historical_context_periods": model_metadata.get("historical_context_periods", 0),
+        "future_weather_provider": model_metadata.get("future_weather_provider", DEFAULT_WEATHER_PROVIDER_ID),
         "chap_version": CHAP_VERSION,
     }
 
@@ -243,6 +249,7 @@ class EvaluationBase(ABC):
         info: "BacktestCreate",
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
+        future_weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
     ) -> "EvaluationBase": ...
 
 
@@ -259,6 +266,7 @@ class Evaluation(EvaluationBase):
         backtest: "Backtest",
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
+        future_weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
     ):
         """
         Initialize Evaluation with a Backtest object.
@@ -268,11 +276,19 @@ class Evaluation(EvaluationBase):
             historical_observations: Optional list of Observation objects for historical
                 context (periods before split points, for plotting)
             historical_context_periods: Number of periods of historical context stored
+            future_weather_provider: Id of the provider that supplied the climate
+                covariates for each forecast window
         """
         self._backtest = backtest
         self._historical_observations = historical_observations or []
         self._historical_context_periods = historical_context_periods
+        self._future_weather_provider = future_weather_provider
         self._flat_data_cache: FlatEvaluationData | None = None
+
+    @property
+    def future_weather_provider(self) -> str:
+        """Id of the future-weather provider these results were produced with."""
+        return self._future_weather_provider
 
     @classmethod
     def from_backtest(cls, backtest: "Backtest") -> "Evaluation":
@@ -296,6 +312,7 @@ class Evaluation(EvaluationBase):
         info: BacktestCreate,
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
+        future_weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
     ) -> "Evaluation":
         info.created = datetime.datetime.now()
         backtest = Backtest(
@@ -370,6 +387,7 @@ class Evaluation(EvaluationBase):
             backtest,
             historical_observations=historical_observations,
             historical_context_periods=historical_context_periods,
+            future_weather_provider=future_weather_provider,
         )
 
     @classmethod
@@ -411,6 +429,7 @@ class Evaluation(EvaluationBase):
             prediction_length=backtest_params.n_periods,
             n_test_sets=backtest_params.n_splits,
             stride=backtest_params.stride,
+            future_weather_provider=backtest_params.future_weather_provider,
         )
 
         # Run backtest
@@ -433,6 +452,7 @@ class Evaluation(EvaluationBase):
             n_splits=backtest_params.n_splits,
             stride=backtest_params.stride,
             n_retrain=backtest_params.n_retrain,
+            future_weather_provider=backtest_params.future_weather_provider,
         )
 
         # Calculate number of periods based on dataset period type
@@ -456,6 +476,7 @@ class Evaluation(EvaluationBase):
             info=backtest_info,
             historical_observations=historical_observations,
             historical_context_periods=historical_context_periods,
+            future_weather_provider=backtest_params.future_weather_provider,
         )
 
     @classmethod
@@ -634,6 +655,7 @@ class Evaluation(EvaluationBase):
             "split_periods": self.get_split_periods(),
             "org_units": self.get_org_units(),
             "historical_context_periods": self._historical_context_periods,
+            "future_weather_provider": self._future_weather_provider,
         }
 
         if model_info is not None:
@@ -664,6 +686,7 @@ class Evaluation(EvaluationBase):
         split_periods = json.loads(ds.attrs.get("split_periods", "[]"))
         org_units = json.loads(ds.attrs.get("org_units", "[]"))
         historical_context_periods = int(ds.attrs.get("historical_context_periods", 0))
+        future_weather_provider = str(ds.attrs["future_weather_provider"])
 
         backtest = Backtest(
             name=f"Loaded from {Path(filepath).name}",
@@ -744,6 +767,7 @@ class Evaluation(EvaluationBase):
             backtest,
             historical_observations=historical_observations,
             historical_context_periods=historical_context_periods,
+            future_weather_provider=future_weather_provider,
         )
 
     @staticmethod
@@ -752,10 +776,19 @@ class Evaluation(EvaluationBase):
         Ensure backwards compatibility for datasets created with older CHAP versions.
 
         Update horizon_distance coordinate in older datasets where it was stored as 0-based instead of 1-based.
+
+        Fill in future_weather_provider for files written before the provider was
+        recorded. Those evaluations were run with the observed weather of each
+        forecast window, so they are labelled accordingly rather than inheriting
+        today's default.
         """
 
         if Version(ds.attrs.get("chap_version", "0.0.0")) <= Version("1.1.1"):
             ds = ds.assign_coords(horizon_distance=ds.horizon_distance + 1)
+        if "future_weather_provider" not in ds.attrs and Version(ds.attrs.get("chap_version", "0.0.0")) <= Version(
+            CHAP_VERSION
+        ):
+            ds.attrs["future_weather_provider"] = LEGACY_WEATHER_PROVIDER_ID
         return ds
 
 

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -249,7 +249,6 @@ class EvaluationBase(ABC):
         info: "BacktestCreate",
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
-        future_weather_provider: str | None = None,
     ) -> "EvaluationBase": ...
 
 
@@ -266,7 +265,6 @@ class Evaluation(EvaluationBase):
         backtest: "Backtest",
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
-        future_weather_provider: str | None = None,
     ):
         """
         Initialize Evaluation with a Backtest object.
@@ -276,24 +274,20 @@ class Evaluation(EvaluationBase):
             historical_observations: Optional list of Observation objects for historical
                 context (periods before split points, for plotting)
             historical_context_periods: Number of periods of historical context stored
-            future_weather_provider: Id of the provider that supplied the climate
-                covariates. Written onto the backtest row, which is the single
-                source of truth; `None` keeps whatever the row already carries.
         """
         self._backtest = backtest
         self._historical_observations = historical_observations or []
         self._historical_context_periods = historical_context_periods
         self._flat_data_cache: FlatEvaluationData | None = None
-        # Store the override on the row rather than beside it. Holding it in a
-        # second field let the two disagree, so a round trip through
-        # to_backtest()/from_backtest() silently reverted the provider.
-        if future_weather_provider is not None:
-            backtest.future_weather_provider = future_weather_provider
 
     @property
     def future_weather_provider(self) -> str:
-        """Id of the future-weather provider these results were produced with."""
-        return getattr(self._backtest, "future_weather_provider", None) or DEFAULT_WEATHER_PROVIDER_ID
+        """Id of the future-weather provider these results were produced with.
+
+        The backtest row is the single source of truth, so database persistence
+        and NetCDF exports cannot disagree.
+        """
+        return self._backtest.future_weather_provider
 
     @classmethod
     def from_backtest(cls, backtest: "Backtest") -> "Evaluation":
@@ -306,7 +300,6 @@ class Evaluation(EvaluationBase):
         Returns:
             Evaluation instance wrapping the Backtest
         """
-        # The row is the source of truth for the provider, so no override here.
         return cls(backtest)
 
     @classmethod
@@ -318,13 +311,7 @@ class Evaluation(EvaluationBase):
         info: BacktestCreate,
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
-        future_weather_provider: str | None = None,
     ) -> "Evaluation":
-        # The Backtest row is built from `info`, so `info` is the source of truth
-        # for the provider; an explicit argument only overrides it.
-        future_weather_provider = (
-            future_weather_provider or getattr(info, "future_weather_provider", None) or DEFAULT_WEATHER_PROVIDER_ID
-        )
         info.created = datetime.datetime.now()
         backtest = Backtest(
             **info.model_dump()
@@ -398,7 +385,6 @@ class Evaluation(EvaluationBase):
             backtest,
             historical_observations=historical_observations,
             historical_context_periods=historical_context_periods,
-            future_weather_provider=future_weather_provider,
         )
 
     @classmethod
@@ -487,7 +473,6 @@ class Evaluation(EvaluationBase):
             info=backtest_info,
             historical_observations=historical_observations,
             historical_context_periods=historical_context_periods,
-            future_weather_provider=backtest_params.future_weather_provider,
         )
 
     @classmethod
@@ -697,7 +682,6 @@ class Evaluation(EvaluationBase):
         split_periods = json.loads(ds.attrs.get("split_periods", "[]"))
         org_units = json.loads(ds.attrs.get("org_units", "[]"))
         historical_context_periods = int(ds.attrs.get("historical_context_periods", 0))
-        future_weather_provider = str(ds.attrs["future_weather_provider"])
 
         backtest = Backtest(
             name=f"Loaded from {Path(filepath).name}",
@@ -705,7 +689,7 @@ class Evaluation(EvaluationBase):
             split_periods=split_periods,
             forecasts=[],
             dataset_id=0,
-            future_weather_provider=future_weather_provider,
+            future_weather_provider=str(ds.attrs["future_weather_provider"]),
         )
 
         forecasts_df = pd.DataFrame(cast("pd.DataFrame", flat_data.forecasts))
@@ -779,7 +763,6 @@ class Evaluation(EvaluationBase):
             backtest,
             historical_observations=historical_observations,
             historical_context_periods=historical_context_periods,
-            future_weather_provider=future_weather_provider,
         )
 
     @staticmethod
@@ -797,9 +780,10 @@ class Evaluation(EvaluationBase):
 
         if Version(ds.attrs.get("chap_version", "0.0.0")) <= Version("1.1.1"):
             ds = ds.assign_coords(horizon_distance=ds.horizon_distance + 1)
-        if "future_weather_provider" not in ds.attrs and Version(ds.attrs.get("chap_version", "0.0.0")) <= Version(
-            CHAP_VERSION
-        ):
+        # A file without the attribute is legacy by definition; gating on the
+        # writer's version would break on dev checkouts whose CHAP_VERSION is
+        # "unknown" and on files written by a newer release than the reader.
+        if "future_weather_provider" not in ds.attrs:
             ds.attrs["future_weather_provider"] = LEGACY_WEATHER_PROVIDER_ID
         return ds
 

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -266,7 +266,7 @@ class Evaluation(EvaluationBase):
         backtest: "Backtest",
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
-        future_weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
+        future_weather_provider: str | None = None,
     ):
         """
         Initialize Evaluation with a Backtest object.
@@ -277,18 +277,23 @@ class Evaluation(EvaluationBase):
                 context (periods before split points, for plotting)
             historical_context_periods: Number of periods of historical context stored
             future_weather_provider: Id of the provider that supplied the climate
-                covariates for each forecast window
+                covariates. Written onto the backtest row, which is the single
+                source of truth; `None` keeps whatever the row already carries.
         """
         self._backtest = backtest
         self._historical_observations = historical_observations or []
         self._historical_context_periods = historical_context_periods
-        self._future_weather_provider = future_weather_provider
         self._flat_data_cache: FlatEvaluationData | None = None
+        # Store the override on the row rather than beside it. Holding it in a
+        # second field let the two disagree, so a round trip through
+        # to_backtest()/from_backtest() silently reverted the provider.
+        if future_weather_provider is not None:
+            backtest.future_weather_provider = future_weather_provider
 
     @property
     def future_weather_provider(self) -> str:
         """Id of the future-weather provider these results were produced with."""
-        return self._future_weather_provider
+        return getattr(self._backtest, "future_weather_provider", None) or DEFAULT_WEATHER_PROVIDER_ID
 
     @classmethod
     def from_backtest(cls, backtest: "Backtest") -> "Evaluation":
@@ -301,10 +306,8 @@ class Evaluation(EvaluationBase):
         Returns:
             Evaluation instance wrapping the Backtest
         """
-        # Read the provider off the row rather than inheriting the constructor
-        # default, or an `observed` backtest would export as `climatology`.
-        provider = getattr(backtest, "future_weather_provider", None) or DEFAULT_WEATHER_PROVIDER_ID
-        return cls(backtest, future_weather_provider=provider)
+        # The row is the source of truth for the provider, so no override here.
+        return cls(backtest)
 
     @classmethod
     def from_samples_with_truth(
@@ -663,7 +666,7 @@ class Evaluation(EvaluationBase):
             "split_periods": self.get_split_periods(),
             "org_units": self.get_org_units(),
             "historical_context_periods": self._historical_context_periods,
-            "future_weather_provider": self._future_weather_provider,
+            "future_weather_provider": self.future_weather_provider,
         }
 
         if model_info is not None:

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -249,7 +249,7 @@ class EvaluationBase(ABC):
         info: "BacktestCreate",
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
-        future_weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
+        future_weather_provider: str | None = None,
     ) -> "EvaluationBase": ...
 
 
@@ -301,7 +301,10 @@ class Evaluation(EvaluationBase):
         Returns:
             Evaluation instance wrapping the Backtest
         """
-        return cls(backtest)
+        # Read the provider off the row rather than inheriting the constructor
+        # default, or an `observed` backtest would export as `climatology`.
+        provider = getattr(backtest, "future_weather_provider", None) or DEFAULT_WEATHER_PROVIDER_ID
+        return cls(backtest, future_weather_provider=provider)
 
     @classmethod
     def from_samples_with_truth(
@@ -312,8 +315,13 @@ class Evaluation(EvaluationBase):
         info: BacktestCreate,
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
-        future_weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
+        future_weather_provider: str | None = None,
     ) -> "Evaluation":
+        # The Backtest row is built from `info`, so `info` is the source of truth
+        # for the provider; an explicit argument only overrides it.
+        future_weather_provider = (
+            future_weather_provider or getattr(info, "future_weather_provider", None) or DEFAULT_WEATHER_PROVIDER_ID
+        )
         info.created = datetime.datetime.now()
         backtest = Backtest(
             **info.model_dump()
@@ -694,6 +702,7 @@ class Evaluation(EvaluationBase):
             split_periods=split_periods,
             forecasts=[],
             dataset_id=0,
+            future_weather_provider=future_weather_provider,
         )
 
         forecasts_df = pd.DataFrame(cast("pd.DataFrame", flat_data.forecasts))

--- a/chap_core/assessment/forecast.py
+++ b/chap_core/assessment/forecast.py
@@ -2,9 +2,7 @@ import logging
 
 from chap_core.assessment.dataset_splitting import train_test_split_with_weather
 from chap_core.assessment.prediction_evaluator import Estimator, Predictor
-from chap_core.climate_predictor import (
-    get_climate_predictor,
-)
+from chap_core.assessment.weather_providers import DEFAULT_WEATHER_PROVIDER_ID, get_future_weather
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 from chap_core.time_period.date_util_wrapper import Month, PeriodRange, TimeDelta
 from chap_core.validators import validate_training_data
@@ -48,7 +46,12 @@ def multi_forecast(model, dataset: DataSet, prediction_lenght: TimeDelta, pre_tr
     return (forecast(model, dataset, prediction_lenght) for dataset in datasets[::-1])
 
 
-def forecast_ahead(estimator: Estimator, dataset: DataSet, prediction_length: int):
+def forecast_ahead(
+    estimator: Estimator,
+    dataset: DataSet,
+    prediction_length: int,
+    weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
+):
     """
     Forecast n_months into the future using the model
     """
@@ -60,6 +63,7 @@ def forecast_ahead(estimator: Estimator, dataset: DataSet, prediction_length: in
         predictor,
         train_data,
         prediction_length,
+        weather_provider=weather_provider,
     )
 
 
@@ -67,6 +71,7 @@ def forecast_with_predicted_weather(
     predictor: Predictor,
     historic_data: DataSet,
     prediction_length: int,
+    weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
 ):
     delta = historic_data.period_range[0].time_delta
     prediction_range = PeriodRange(
@@ -74,7 +79,8 @@ def forecast_with_predicted_weather(
         historic_data.end_timestamp + delta * prediction_length,
         delta,
     )
-    climate_predictor = get_climate_predictor(historic_data)
-    future_weather = climate_predictor.predict(prediction_range)
+    # No future_data exists when predicting ahead for real, so a provider that
+    # declares leaks_future_data will correctly refuse here.
+    future_weather = get_future_weather(weather_provider, historic_data, prediction_range)
     predictions = predictor.predict(historic_data, future_weather)
     return predictions

--- a/chap_core/assessment/prediction_evaluator.py
+++ b/chap_core/assessment/prediction_evaluator.py
@@ -22,6 +22,7 @@ from chap_core import get_temp_dir
 from chap_core.assessment.dataset_splitting import (
     train_test_generator,
 )
+from chap_core.assessment.weather_providers import DEFAULT_WEATHER_PROVIDER_ID
 from chap_core.data.gluonts_adaptor.dataset import ForecastAdaptor
 from chap_core.datatypes import Samples, SamplesWithTruth, TimeSeriesData
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
@@ -116,7 +117,7 @@ def evaluate_model(
     prediction_length=3,
     n_test_sets=4,
     report_filename=None,
-    weather_provider=None,
+    weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
 ):
     """
     Evaluate a model on a dataset on a held out test set, making multiple predictions on the test set

--- a/chap_core/assessment/weather_providers/__init__.py
+++ b/chap_core/assessment/weather_providers/__init__.py
@@ -106,6 +106,7 @@ def get_future_weather(
 def _discover_providers():
     from chap_core.assessment.weather_providers import (
         climatology,
+        damped_persistence,
         mstl_arima,
         observed,
     )

--- a/chap_core/assessment/weather_providers/__init__.py
+++ b/chap_core/assessment/weather_providers/__init__.py
@@ -106,6 +106,7 @@ def get_future_weather(
 def _discover_providers():
     from chap_core.assessment.weather_providers import (
         climatology,
+        mstl_arima,
         observed,
     )
 

--- a/chap_core/assessment/weather_providers/__init__.py
+++ b/chap_core/assessment/weather_providers/__init__.py
@@ -1,0 +1,113 @@
+"""Future-weather provider plugin system.
+
+Each provider is a single class registered with the :func:`weather_provider`
+decorator, mirroring the ``@threshold`` and ``@backtest_plot`` registries. New
+providers are added by writing a class and importing its module from
+:func:`_discover_providers` - the evaluation and endpoint code never needs
+editing.
+
+Providers declare whether they read the forecast window's own observations via
+``leaks_future_data``. :func:`get_future_weather` forwards ``future_data`` only
+to providers that declare it, so look-ahead is an explicit property of a named
+provider instead of an accident of which code path ran.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from chap_core.assessment.weather_providers.base import FutureWeatherProviderBase
+
+if TYPE_CHECKING:
+    from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+    from chap_core.time_period import PeriodRange
+
+#: Provider used when a caller does not name one.
+DEFAULT_WEATHER_PROVIDER_ID = "climatology"
+
+#: Provider that results predate the provider field are attributed to. Evaluations
+#: written before providers were recorded ran against the forecast window's own
+#: observations, so that is what they are labelled with on read.
+LEGACY_WEATHER_PROVIDER_ID = "observed"
+
+# Global registry for future weather providers
+_weather_providers_registry: dict[str, type[FutureWeatherProviderBase]] = {}
+
+
+def weather_provider(provider_id: str, name: str, description: str = "", leaks_future_data: bool = False):
+    """Decorator to register a future-weather provider class."""
+
+    def decorator(cls: type[FutureWeatherProviderBase]) -> type[FutureWeatherProviderBase]:
+        if not issubclass(cls, FutureWeatherProviderBase):
+            raise TypeError(f"{cls.__name__} must inherit from FutureWeatherProviderBase")
+
+        cls.id = provider_id
+        cls.name = name
+        cls.description = description
+        cls.leaks_future_data = leaks_future_data
+
+        _weather_providers_registry[provider_id] = cls
+        return cls
+
+    return decorator
+
+
+def get_weather_providers_registry() -> dict[str, type[FutureWeatherProviderBase]]:
+    return _weather_providers_registry.copy()
+
+
+def get_weather_provider(provider_id: str) -> type[FutureWeatherProviderBase] | None:
+    return _weather_providers_registry.get(provider_id)
+
+
+def list_weather_providers() -> list[dict]:
+    return [
+        {
+            "id": cls.id,
+            "name": cls.name,
+            "description": cls.description,
+            "leaks_future_data": cls.leaks_future_data,
+        }
+        for cls in _weather_providers_registry.values()
+    ]
+
+
+def resolve_weather_provider(provider_id: str) -> type[FutureWeatherProviderBase]:
+    """Look up ``provider_id``, raising a ValueError listing the alternatives."""
+    provider_cls = _weather_providers_registry.get(provider_id)
+    if provider_cls is None:
+        available = ", ".join(_weather_providers_registry)
+        raise ValueError(f"Unknown future weather provider: {provider_id!r}. Available: {available}")
+    return provider_cls
+
+
+def get_future_weather(
+    provider_id: str,
+    historical_data: DataSet,
+    period_range: PeriodRange,
+    future_data: DataSet | None = None,
+    params: dict | None = None,
+) -> DataSet:
+    """Produce future weather for ``period_range`` using the named provider.
+
+    ``future_data`` is forwarded only when the provider declares
+    ``leaks_future_data``, so a non-leaking provider never sees the forecast
+    window's observations even if the caller has them.
+    """
+    provider_cls = resolve_weather_provider(provider_id)
+    return provider_cls().get_future_weather(
+        historical_data,
+        period_range,
+        future_data=future_data if provider_cls.leaks_future_data else None,
+        params=params,
+    )
+
+
+def _discover_providers():
+    from chap_core.assessment.weather_providers import (
+        climatology,
+        observed,
+    )
+
+
+_discover_providers()

--- a/chap_core/assessment/weather_providers/__init__.py
+++ b/chap_core/assessment/weather_providers/__init__.py
@@ -10,11 +10,19 @@ Providers declare whether they read the forecast window's own observations via
 ``leaks_future_data``. :func:`get_future_weather` forwards ``future_data`` only
 to providers that declare it, so look-ahead is an explicit property of a named
 provider instead of an accident of which code path ran.
+
+Only seasonal numeric covariates are handed to a forecasting provider. String
+columns and non-seasonal numerics such as ``population`` are split off once here
+and carried forward from their last observation, so every provider is a pure
+forecaster and none has to re-implement that rule.
 """
 
 from __future__ import annotations
 
+import dataclasses
 from typing import TYPE_CHECKING
+
+import numpy as np
 
 from chap_core.assessment.weather_providers.base import FutureWeatherProviderBase
 
@@ -29,6 +37,13 @@ DEFAULT_WEATHER_PROVIDER_ID = "climatology"
 #: written before providers were recorded ran against the forecast window's own
 #: observations, so that is what they are labelled with on read.
 LEGACY_WEATHER_PROVIDER_ID = "observed"
+
+#: The field the models forecast; never a covariate to be provided.
+TARGET_FIELD = "disease_cases"
+
+#: Numeric covariates that carry no seasonal signal. Regressing them on
+#: month-of-year would hand the model a climatological population.
+NON_SEASONAL_FIELDS = frozenset({"population"})
 
 # Global registry for future weather providers
 _weather_providers_registry: dict[str, type[FutureWeatherProviderBase]] = {}
@@ -52,14 +67,6 @@ def weather_provider(provider_id: str, name: str, description: str = "", leaks_f
     return decorator
 
 
-def get_weather_providers_registry() -> dict[str, type[FutureWeatherProviderBase]]:
-    return _weather_providers_registry.copy()
-
-
-def get_weather_provider(provider_id: str) -> type[FutureWeatherProviderBase] | None:
-    return _weather_providers_registry.get(provider_id)
-
-
 def list_weather_providers() -> list[dict]:
     return [
         {
@@ -81,6 +88,16 @@ def resolve_weather_provider(provider_id: str) -> type[FutureWeatherProviderBase
     return provider_cls
 
 
+def _carried_forward_fields(historical_data: DataSet) -> list[str]:
+    sample = next(iter(historical_data.values()))
+    return [
+        field.name
+        for field in dataclasses.fields(sample)
+        if field.name != "time_period"
+        and (field.name in NON_SEASONAL_FIELDS or getattr(sample, field.name).dtype.kind not in ("f", "i"))
+    ]
+
+
 def get_future_weather(
     provider_id: str,
     historical_data: DataSet,
@@ -93,14 +110,34 @@ def get_future_weather(
     ``future_data`` is forwarded only when the provider declares
     ``leaks_future_data``, so a non-leaking provider never sees the forecast
     window's observations even if the caller has them.
+
+    A forecasting provider receives only the seasonal numeric covariates. The
+    remaining columns are carried forward from their last observation and
+    re-attached here, so the result has every field of the input except the target.
     """
     provider_cls = resolve_weather_provider(provider_id)
-    return provider_cls().get_future_weather(
-        historical_data,
-        period_range,
-        future_data=future_data if provider_cls.leaks_future_data else None,
-        params=params,
-    )
+    provider = provider_cls()
+    if provider_cls.leaks_future_data:
+        return provider.get_future_weather(historical_data, period_range, future_data=future_data, params=params)
+
+    covariates = historical_data.remove_field(TARGET_FIELD)
+    carried = _carried_forward_fields(covariates)
+    forecastable = covariates
+    for name in carried:
+        forecastable = forecastable.remove_field(name)
+    predicted = provider.get_future_weather(forecastable, period_range, params=params)
+    if not carried:
+        return predicted
+
+    # Repeat the final observation by index so the column keeps its original
+    # container type (bionumpy encodes string columns as ragged arrays).
+    repeat = np.zeros(len(period_range), dtype=int)
+    prediction_dict = {}
+    for location, data in covariates.items():
+        fields = {name: getattr(predicted[location], name) for name in predicted.field_names()}
+        fields |= {name: getattr(data, name)[-1:][repeat] for name in carried}
+        prediction_dict[location] = data.__class__(period_range, **fields)
+    return covariates.__class__(prediction_dict)  # type: ignore[no-any-return]
 
 
 def _discover_providers():

--- a/chap_core/assessment/weather_providers/base.py
+++ b/chap_core/assessment/weather_providers/base.py
@@ -1,0 +1,55 @@
+"""Base class for future-weather providers.
+
+A provider supplies the climate covariates a model needs for the periods it is
+forecasting into - data that does not exist yet at prediction time. Subclasses
+implement :meth:`get_future_weather`; registration happens via the
+:func:`weather_provider` decorator.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+    from chap_core.time_period import PeriodRange
+
+
+class FutureWeatherProviderBase(ABC):
+    """Base class for future-weather providers.
+
+    Subclasses implement :meth:`get_future_weather`, which receives the data
+    available up to the prediction point and the periods it must fill.
+
+    A provider that needs the observations from the forecast window itself must
+    declare ``leaks_future_data = True``; only then does the caller pass
+    ``future_data``. A provider leaving the flag at ``False`` is therefore
+    structurally unable to look ahead, rather than merely trusted not to.
+    """
+
+    id: str = ""
+    name: str = ""
+    description: str = ""
+    leaks_future_data: bool = False
+
+    @abstractmethod
+    def get_future_weather(
+        self,
+        historical_data: DataSet,
+        period_range: PeriodRange,
+        future_data: DataSet | None = None,
+        params: dict | None = None,
+    ) -> DataSet:
+        """Produce future weather covariates covering ``period_range``.
+
+        Args:
+            historical_data: Data available up to the prediction point.
+            period_range: The periods to produce covariates for.
+            future_data: Observations from the forecast window. Passed only to
+                providers declaring ``leaks_future_data``; ``None`` otherwise.
+            params: Optional provider-specific parameters.
+
+        Returns:
+            DataSet covering ``period_range``, with the target field removed.
+        """

--- a/chap_core/assessment/weather_providers/climatology.py
+++ b/chap_core/assessment/weather_providers/climatology.py
@@ -1,0 +1,20 @@
+"""Seasonal climatology provider: the historical seasonal signal, projected forward."""
+
+from __future__ import annotations
+
+from chap_core.assessment.weather_providers import weather_provider
+from chap_core.assessment.weather_providers.base import FutureWeatherProviderBase
+
+
+@weather_provider(
+    "climatology",
+    "Seasonal climatology",
+    "Per-location regression on month- or week-of-year, fitted on the historical data.",
+)
+class ClimatologyWeatherProvider(FutureWeatherProviderBase):
+    def get_future_weather(self, historical_data, period_range, future_data=None, params=None):
+        # Imported lazily: chap_core.climate_predictor pulls in sklearn, which
+        # would otherwise be paid on every import of the registry.
+        from chap_core.climate_predictor import get_climate_predictor
+
+        return get_climate_predictor(historical_data).predict(period_range)

--- a/chap_core/assessment/weather_providers/damped_persistence.py
+++ b/chap_core/assessment/weather_providers/damped_persistence.py
@@ -1,0 +1,88 @@
+"""Damped persistence provider.
+
+The forecast is the seasonal climatology plus the current anomaly, damped toward
+zero as the horizon grows::
+
+    y(T+h) = climatology(T+h) + phi**h * (y(T) - climatology(T))
+
+With ``phi = 0`` this is exactly the climatology provider; with ``phi = 1`` it is
+undamped anomaly persistence. The damping factor defaults to the lag-1
+autocorrelation of the location's own anomaly series, which is the optimal
+coefficient if anomalies follow an AR(1).
+
+Forecast verification treats plain climatology and persistence as benchmarks
+that are too easy - neither uses the observations well, so both flatter whatever
+is compared against them. Damped persistence combines the two and is the
+reference the sub-seasonal literature recommends instead.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+
+from chap_core.assessment.weather_providers import weather_provider
+from chap_core.assessment.weather_providers.base import FutureWeatherProviderBase
+
+
+def _lag1_autocorrelation(x: np.ndarray) -> float:
+    """Lag-1 autocorrelation of ``x``, clipped to [0, 1].
+
+    A negative estimate would make the forecast oscillate about the climatology
+    and one above 1 would make it diverge; neither is a sensible damping factor,
+    so both are clipped away.
+    """
+    if len(x) < 3:
+        return 0.0
+    centred = x - x.mean()
+    denominator = float(np.dot(centred, centred))
+    if denominator <= 0.0:
+        return 0.0
+    return float(np.clip(np.dot(centred[:-1], centred[1:]) / denominator, 0.0, 1.0))
+
+
+@weather_provider(
+    "damped_persistence",
+    "Damped persistence",
+    "Seasonal climatology plus the current anomaly, damped toward zero as the horizon grows. "
+    "The reference forecast recommended over plain climatology or persistence at sub-seasonal range.",
+)
+class DampedPersistenceWeatherProvider(FutureWeatherProviderBase):
+    def get_future_weather(self, historical_data, period_range, future_data=None, params=None):
+        # Imported lazily: temporal_dataclass imports api_types, which imports this
+        # registry for the BacktestParams default, and climate_predictor pulls in sklearn.
+        from chap_core.climate_predictor import get_climate_predictor
+        from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+
+        params = params or {}
+        damping = params.get("damping")
+        n_periods = len(period_range)
+        steps = np.arange(1, n_periods + 1)
+
+        historical_data = historical_data.remove_field("disease_cases")
+        predictor = get_climate_predictor(historical_data)
+        # The same seasonal fit evaluated over the future window and over the
+        # history, so the anomaly is measured against the curve it decays back to.
+        climatology_future = predictor.predict(period_range)
+        climatology_history = predictor.predict(historical_data.period_range)
+
+        prediction_dict = {}
+        for location, data in historical_data.items():
+            fields = {}
+            for field in dataclasses.fields(data):
+                if field.name == "time_period":
+                    continue
+                future_seasonal = getattr(climatology_future[location], field.name)
+                observed = getattr(data, field.name)
+                if observed.dtype.kind not in ("f", "i"):
+                    # No anomaly to persist; take climatology's carried-forward value.
+                    fields[field.name] = future_seasonal
+                    continue
+                anomaly = np.asarray(observed, dtype=float) - np.asarray(
+                    getattr(climatology_history[location], field.name), dtype=float
+                )
+                phi = _lag1_autocorrelation(anomaly) if damping is None else float(damping)
+                fields[field.name] = np.asarray(future_seasonal, dtype=float) + phi**steps * anomaly[-1]
+            prediction_dict[location] = data.__class__(period_range, **fields)
+        return DataSet(prediction_dict)

--- a/chap_core/assessment/weather_providers/damped_persistence.py
+++ b/chap_core/assessment/weather_providers/damped_persistence.py
@@ -60,7 +60,6 @@ class DampedPersistenceWeatherProvider(FutureWeatherProviderBase):
         n_periods = len(period_range)
         steps = np.arange(1, n_periods + 1)
 
-        historical_data = historical_data.remove_field("disease_cases")
         predictor = get_climate_predictor(historical_data)
         # The same seasonal fit evaluated over the future window and over the
         # history, so the anomaly is measured against the curve it decays back to.
@@ -74,12 +73,7 @@ class DampedPersistenceWeatherProvider(FutureWeatherProviderBase):
                 if field.name == "time_period":
                     continue
                 future_seasonal = getattr(climatology_future[location], field.name)
-                observed = getattr(data, field.name)
-                if observed.dtype.kind not in ("f", "i"):
-                    # No anomaly to persist; take climatology's carried-forward value.
-                    fields[field.name] = future_seasonal
-                    continue
-                anomaly = np.asarray(observed, dtype=float) - np.asarray(
+                anomaly = np.asarray(getattr(data, field.name), dtype=float) - np.asarray(
                     getattr(climatology_history[location], field.name), dtype=float
                 )
                 phi = _lag1_autocorrelation(anomaly) if damping is None else float(damping)

--- a/chap_core/assessment/weather_providers/mstl_arima.py
+++ b/chap_core/assessment/weather_providers/mstl_arima.py
@@ -39,7 +39,9 @@ FALLBACK_ARIMA_ORDER = (0, 0, 0)
 #: of series. auto.arima applies the same guard.
 MIN_ROOT_MODULUS = 1.001
 
-#: MSTL needs a couple of full cycles before a seasonal component is meaningful.
+#: History must be longer than this many full cycles. MSTL discards any period
+#: that is not shorter than half the series, so exactly two cycles yields no
+#: seasonal component at all.
 MIN_SEASONAL_CYCLES = 2
 
 
@@ -119,10 +121,14 @@ def _forecast_series(
     from statsmodels.tsa.arima.model import ARIMA
     from statsmodels.tsa.seasonal import MSTL
 
-    if len(y) < MIN_SEASONAL_CYCLES * seasonal_period:
+    if len(y) <= MIN_SEASONAL_CYCLES * seasonal_period:
+        # MSTL discards any period that is not shorter than half the series, so at
+        # exactly two cycles it produces no seasonal component at all and raises an
+        # UnboundLocalError from inside statsmodels. Reject that boundary here with
+        # a message the caller can act on.
         raise ValueError(
-            f"mstl_arima needs at least {MIN_SEASONAL_CYCLES} full seasonal cycles "
-            f"({MIN_SEASONAL_CYCLES * seasonal_period} periods) of history, got {len(y)}. "
+            f"mstl_arima needs more than {MIN_SEASONAL_CYCLES} full seasonal cycles "
+            f"(more than {MIN_SEASONAL_CYCLES * seasonal_period} periods) of history, got {len(y)}. "
             "Use the 'climatology' provider for shorter series."
         )
 
@@ -157,8 +163,8 @@ def _forecast_series(
     "mstl_arima",
     "MSTL + ARIMA",
     "Seasonal-trend decomposition (LOESS) with an automatically ordered ARIMA on the "
-    "deseasonalised series and the seasonal component continued forward. Needs at least "
-    "two full seasonal cycles.",
+    "deseasonalised series and the seasonal component continued forward. Needs more than "
+    "two full seasonal cycles of history.",
 )
 class MstlArimaWeatherProvider(FutureWeatherProviderBase):
     def get_future_weather(self, historical_data, period_range, future_data=None, params=None):

--- a/chap_core/assessment/weather_providers/mstl_arima.py
+++ b/chap_core/assessment/weather_providers/mstl_arima.py
@@ -1,0 +1,189 @@
+"""MSTL + ARIMA provider.
+
+Decomposes each covariate into seasonal, trend and remainder components with
+MSTL (multiple seasonal-trend decomposition using LOESS), forecasts the
+deseasonalised series with an ARIMA, and adds the seasonal component back by
+continuing it forward. This follows nixtla's MSTL model, including automatic
+ARIMA order selection.
+
+Orders are chosen per series the way Hyndman-Khandakar's auto.arima does: the
+number of differences from a KPSS stationarity test, then a search over (p, q)
+scored by AICc. Pass ``params={"order": (p, d, q)}`` to skip the search and fit
+a fixed order, which is much faster.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import warnings
+
+import numpy as np
+
+from chap_core.assessment.weather_providers import weather_provider
+from chap_core.assessment.weather_providers.base import FutureWeatherProviderBase
+
+#: Largest AR and MA orders considered by the automatic search.
+MAX_P = 3
+MAX_Q = 3
+
+#: Largest number of differences the KPSS test may ask for.
+MAX_D = 2
+
+#: Fallback when no candidate order can be fitted at all.
+FALLBACK_ARIMA_ORDER = (0, 0, 0)
+
+#: Candidate models whose characteristic roots sit this close to the unit circle
+#: are rejected. Their forecasts oscillate explosively - on Vietnam admin1 data a
+#: handful of such models produced rainfall forecasts of +-5000 against a
+#: historical range of 1-18, and 77% of all forecast error came from the worst 1%
+#: of series. auto.arima applies the same guard.
+MIN_ROOT_MODULUS = 1.001
+
+#: MSTL needs a couple of full cycles before a seasonal component is meaningful.
+MIN_SEASONAL_CYCLES = 2
+
+
+def _seasonal_period(period_range) -> int:
+    from chap_core.time_period import Month, Week
+
+    first = period_range[0]
+    if isinstance(first, Month):
+        return 12
+    if isinstance(first, Week):
+        return 52
+    raise ValueError(f"mstl_arima does not know the seasonal period for {type(first).__name__} data.")
+
+
+def _n_differences(y: np.ndarray, max_d: int = MAX_D) -> int:
+    """Number of differences needed for stationarity, per a KPSS test.
+
+    KPSS tests the null that the series is stationary, so a p-value above the
+    5% level means we stop differencing.
+    """
+    from statsmodels.tsa.stattools import kpss
+
+    series = y
+    for d in range(max_d):
+        if len(series) < 10 or np.allclose(series, series[0]):
+            return d
+        try:
+            p_value = kpss(series, regression="c", nlags="auto")[1]
+        except (ValueError, OverflowError):
+            return d
+        if p_value > 0.05:
+            return d
+        series = np.diff(series)
+    return max_d
+
+
+def _is_well_conditioned(fitted) -> bool:
+    """Reject models with characteristic roots on or near the unit circle.
+
+    Stationarity only requires the roots to lie outside the unit circle; one
+    sitting arbitrarily close to it satisfies the constraint while forecasting an
+    explosive oscillation.
+    """
+    for roots in (fitted.arroots, fitted.maroots):
+        if len(roots) and np.min(np.abs(roots)) < MIN_ROOT_MODULUS:
+            return False
+    return True
+
+
+def _select_order(y: np.ndarray) -> tuple[int, int, int]:
+    """Pick (p, d, q) by AICc over a bounded grid, as auto.arima does."""
+    from statsmodels.tsa.arima.model import ARIMA
+
+    d = _n_differences(y)
+    best_order = None
+    best_score = np.inf
+    for p in range(MAX_P + 1):
+        for q in range(MAX_Q + 1):
+            try:
+                fitted = ARIMA(y, order=(p, d, q)).fit()
+            except Exception:
+                continue
+            if not _is_well_conditioned(fitted):
+                continue
+            score = fitted.aicc
+            if np.isfinite(score) and score < best_score:
+                best_score, best_order = score, (p, d, q)
+    return best_order or FALLBACK_ARIMA_ORDER
+
+
+def _forecast_series(
+    y: np.ndarray,
+    n_periods: int,
+    seasonal_period: int,
+    order: tuple[int, int, int] | None,
+) -> np.ndarray:
+    from statsmodels.tsa.arima.model import ARIMA
+    from statsmodels.tsa.seasonal import MSTL
+
+    if len(y) < MIN_SEASONAL_CYCLES * seasonal_period:
+        raise ValueError(
+            f"mstl_arima needs at least {MIN_SEASONAL_CYCLES} full seasonal cycles "
+            f"({MIN_SEASONAL_CYCLES * seasonal_period} periods) of history, got {len(y)}. "
+            "Use the 'climatology' provider for shorter series."
+        )
+
+    with warnings.catch_warnings():
+        # Short climate series routinely trip convergence and p-value-bound
+        # warnings; one per location per covariate per split would drown the
+        # evaluation log.
+        warnings.simplefilter("ignore")
+        decomposition = MSTL(y, periods=seasonal_period).fit()
+        seasonal = np.asarray(decomposition.seasonal, dtype=float)
+        if seasonal.ndim > 1:
+            seasonal = seasonal.sum(axis=1)
+        deseasonalised = y - seasonal
+        chosen = order if order is not None else _select_order(deseasonalised)
+        trend_forecast = np.asarray(ARIMA(deseasonalised, order=chosen).fit().forecast(n_periods), dtype=float)
+
+    # Continue the seasonal component by averaging every complete cycle rather
+    # than replaying the most recent one. MSTL's seasonal component varies over
+    # time, so a single cycle is one year of noise, and it is the cycle at the
+    # series edge where the LOESS fit is weakest. Averaging is what makes
+    # climatology's pooled month-of-year mean hard to beat; taking only the last
+    # cycle cost 10-27% MAE against it on Vietnam and Malawi admin data.
+    n_cycles = len(seasonal) // seasonal_period
+    cycles = seasonal[len(seasonal) - n_cycles * seasonal_period :].reshape(n_cycles, seasonal_period)
+    # Row 0 starts a whole number of cycles back, so its phase relative to the
+    # first forecast period is 0.
+    future_seasonal = cycles.mean(axis=0)[np.arange(n_periods) % seasonal_period]
+    return trend_forecast + future_seasonal
+
+
+@weather_provider(
+    "mstl_arima",
+    "MSTL + ARIMA",
+    "Seasonal-trend decomposition (LOESS) with an automatically ordered ARIMA on the "
+    "deseasonalised series and the seasonal component continued forward. Needs at least "
+    "two full seasonal cycles.",
+)
+class MstlArimaWeatherProvider(FutureWeatherProviderBase):
+    def get_future_weather(self, historical_data, period_range, future_data=None, params=None):
+        # Imported lazily: temporal_dataclass imports api_types, which imports this
+        # registry for the BacktestParams default.
+        from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
+
+        params = params or {}
+        order = params.get("order")
+        order = tuple(order) if order is not None else None
+        seasonal_period = params.get("seasonal_period") or _seasonal_period(historical_data.period_range)
+        n_periods = len(period_range)
+
+        historical_data = historical_data.remove_field("disease_cases")
+        prediction_dict = {}
+        for location, data in historical_data.items():
+            fields = {}
+            for field in dataclasses.fields(data):
+                if field.name == "time_period":
+                    continue
+                y = getattr(data, field.name)
+                if y.dtype.kind not in ("f", "i"):
+                    # No seasonal signal to decompose; carry the last value forward.
+                    fields[field.name] = y[-1:][np.zeros(n_periods, dtype=int)]
+                    continue
+                fields[field.name] = _forecast_series(np.asarray(y, dtype=float), n_periods, seasonal_period, order)
+            prediction_dict[location] = data.__class__(period_range, **fields)
+        return DataSet(prediction_dict)

--- a/chap_core/assessment/weather_providers/mstl_arima.py
+++ b/chap_core/assessment/weather_providers/mstl_arima.py
@@ -91,12 +91,16 @@ def _is_well_conditioned(fitted) -> bool:
     return True
 
 
-def _select_order(y: np.ndarray) -> tuple[int, int, int]:
-    """Pick (p, d, q) by AICc over a bounded grid, as auto.arima does."""
+def _select_model(y: np.ndarray):
+    """Fit (p, d, q) by AICc over a bounded grid, as auto.arima does.
+
+    Returns the winning fitted model rather than its order, so the caller
+    forecasts from it directly instead of refitting the same series.
+    """
     from statsmodels.tsa.arima.model import ARIMA
 
     d = _n_differences(y)
-    best_order = None
+    best = None
     best_score = np.inf
     for p in range(MAX_P + 1):
         for q in range(MAX_Q + 1):
@@ -108,8 +112,8 @@ def _select_order(y: np.ndarray) -> tuple[int, int, int]:
                 continue
             score = fitted.aicc
             if np.isfinite(score) and score < best_score:
-                best_score, best_order = score, (p, d, q)
-    return best_order or FALLBACK_ARIMA_ORDER
+                best_score, best = score, fitted
+    return best if best is not None else ARIMA(y, order=FALLBACK_ARIMA_ORDER).fit()
 
 
 def _forecast_series(
@@ -142,8 +146,8 @@ def _forecast_series(
         if seasonal.ndim > 1:
             seasonal = seasonal.sum(axis=1)
         deseasonalised = y - seasonal
-        chosen = order if order is not None else _select_order(deseasonalised)
-        trend_forecast = np.asarray(ARIMA(deseasonalised, order=chosen).fit().forecast(n_periods), dtype=float)
+        model = ARIMA(deseasonalised, order=order).fit() if order is not None else _select_model(deseasonalised)
+        trend_forecast = np.asarray(model.forecast(n_periods), dtype=float)
 
     # Continue the seasonal component by averaging every complete cycle rather
     # than replaying the most recent one. MSTL's seasonal component varies over
@@ -178,18 +182,13 @@ class MstlArimaWeatherProvider(FutureWeatherProviderBase):
         seasonal_period = params.get("seasonal_period") or _seasonal_period(historical_data.period_range)
         n_periods = len(period_range)
 
-        historical_data = historical_data.remove_field("disease_cases")
         prediction_dict = {}
         for location, data in historical_data.items():
             fields = {}
             for field in dataclasses.fields(data):
                 if field.name == "time_period":
                     continue
-                y = getattr(data, field.name)
-                if y.dtype.kind not in ("f", "i"):
-                    # No seasonal signal to decompose; carry the last value forward.
-                    fields[field.name] = y[-1:][np.zeros(n_periods, dtype=int)]
-                    continue
-                fields[field.name] = _forecast_series(np.asarray(y, dtype=float), n_periods, seasonal_period, order)
+                y = np.asarray(getattr(data, field.name), dtype=float)
+                fields[field.name] = _forecast_series(y, n_periods, seasonal_period, order)
             prediction_dict[location] = data.__class__(period_range, **fields)
         return DataSet(prediction_dict)

--- a/chap_core/assessment/weather_providers/observed.py
+++ b/chap_core/assessment/weather_providers/observed.py
@@ -1,0 +1,24 @@
+"""Observed weather provider: perfect foresight, for diagnostic runs only."""
+
+from __future__ import annotations
+
+from chap_core.assessment.weather_providers import weather_provider
+from chap_core.assessment.weather_providers.base import FutureWeatherProviderBase
+
+
+@weather_provider(
+    "observed",
+    "Observed weather",
+    "The weather actually observed in the forecast window. Look-ahead: results are "
+    "not comparable to what a model can achieve in production.",
+    leaks_future_data=True,
+)
+class ObservedWeatherProvider(FutureWeatherProviderBase):
+    def get_future_weather(self, historical_data, period_range, future_data=None, params=None):
+        if future_data is None:
+            raise ValueError(
+                "The 'observed' weather provider needs the forecast window's observations, "
+                "which are only available when backtesting against historical data. "
+                "Use a forecasting provider such as 'climatology' to predict ahead."
+            )
+        return future_data.remove_field("disease_cases")

--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -290,6 +290,7 @@ def _run_eval(
                 prediction_length=backtest_params.n_periods,
                 n_test_sets=backtest_params.n_splits,
                 stride=backtest_params.stride,
+                future_weather_provider=backtest_params.future_weather_provider,
             )
 
             for _ in backtest(

--- a/chap_core/climate_predictor.py
+++ b/chap_core/climate_predictor.py
@@ -12,11 +12,16 @@ from .datatypes import ClimateData, SimpleClimateData
 
 
 def get_climate_predictor(train_data: DataSet[ClimateData]):
-    if isinstance(train_data.period_range[0], Month):
+    first = train_data.period_range[0]
+    if isinstance(first, Month):
         estimator = MonthlyClimatePredictor()
-    else:
-        assert isinstance(train_data.period_range[0], Week)
+    elif isinstance(first, Week):
         estimator = WeeklyClimatePredictor()
+    else:
+        raise ValueError(
+            f"The climatology fit needs monthly or weekly data, got {type(first).__name__}. "
+            "Use the 'observed' future-weather provider for other resolutions."
+        )
     estimator.train(train_data)
     return estimator
 
@@ -24,9 +29,6 @@ def get_climate_predictor(train_data: DataSet[ClimateData]):
 class MonthlyClimatePredictor:
     def __init__(self):
         self._models: defaultdict[str, dict[str, Any]] = defaultdict(dict)
-        # Non-numeric columns (org unit parents, codes, ...) carry no seasonal
-        # signal to regress on, so the last observed value is carried forward.
-        self._constants: defaultdict[str, dict[str, Any]] = defaultdict(dict)
         self._cls: type | None = None
 
     def _feature_matrix(self, time_period: PeriodRange):
@@ -42,25 +44,24 @@ class MonthlyClimatePredictor:
             for field in dataclasses.fields(data):  # type: ignore[arg-type]
                 if field.name in ("time_period"):
                     continue
-                y = getattr(data, field.name)
-                if y.dtype.kind not in ("f", "i"):
-                    self._constants[location][field.name] = y[-1:]
-                    continue
-                assert not np.isnan(y).any(), (field.name, y)
+                y = np.asarray(getattr(data, field.name), dtype=float)
+                # Fit on the observed rows only; a gap in a covariate should not
+                # take the whole evaluation down.
+                observed = ~np.isnan(y)
+                if not observed.any():
+                    raise ValueError(
+                        f"Cannot fit a climatology for '{field.name}' in {location}: every value is missing."
+                    )
                 model = linear_model.LinearRegression()
-                model.fit(x, y[:, None])
+                model.fit(x[observed], y[observed, None])
                 self._models[location][field.name] = model
 
     def predict(self, time_period: PeriodRange):
         x = self._feature_matrix(time_period)
         prediction_dict = {}
         assert self._cls is not None, "Model not trained - call train() first"
-        for location in self._models.keys() | self._constants.keys():
-            fields = {field: model.predict(x).ravel() for field, model in self._models[location].items()}
-            # Repeat the final observation by index so the column keeps its original
-            # container type (bionumpy encodes string columns as ragged arrays).
-            repeat = np.zeros(len(time_period), dtype=int)
-            fields |= {field: value[repeat] for field, value in self._constants[location].items()}
+        for location, models in self._models.items():
+            fields = {field: model.predict(x).ravel() for field, model in models.items()}
             prediction_dict[location] = self._cls(time_period, **fields)
         return DataSet(prediction_dict)
 

--- a/chap_core/climate_predictor.py
+++ b/chap_core/climate_predictor.py
@@ -24,6 +24,9 @@ def get_climate_predictor(train_data: DataSet[ClimateData]):
 class MonthlyClimatePredictor:
     def __init__(self):
         self._models: defaultdict[str, dict[str, Any]] = defaultdict(dict)
+        # Non-numeric columns (org unit parents, codes, ...) carry no seasonal
+        # signal to regress on, so the last observed value is carried forward.
+        self._constants: defaultdict[str, dict[str, Any]] = defaultdict(dict)
         self._cls: type | None = None
 
     def _feature_matrix(self, time_period: PeriodRange):
@@ -40,8 +43,9 @@ class MonthlyClimatePredictor:
                 if field.name in ("time_period"):
                     continue
                 y = getattr(data, field.name)
-                # assert float type
-                assert y.dtype.kind in ("f", "i"), (field.name, y.dtype)
+                if y.dtype.kind not in ("f", "i"):
+                    self._constants[location][field.name] = y[-1:]
+                    continue
                 assert not np.isnan(y).any(), (field.name, y)
                 model = linear_model.LinearRegression()
                 model.fit(x, y[:, None])
@@ -51,11 +55,13 @@ class MonthlyClimatePredictor:
         x = self._feature_matrix(time_period)
         prediction_dict = {}
         assert self._cls is not None, "Model not trained - call train() first"
-        for location, models in self._models.items():
-            prediction_dict[location] = self._cls(
-                time_period,
-                **{field: model.predict(x).ravel() for field, model in models.items()},
-            )
+        for location in self._models.keys() | self._constants.keys():
+            fields = {field: model.predict(x).ravel() for field, model in self._models[location].items()}
+            # Repeat the final observation by index so the column keeps its original
+            # container type (bionumpy encodes string columns as ragged arrays).
+            repeat = np.zeros(len(time_period), dtype=int)
+            fields |= {field: value[repeat] for field, value in self._constants[location].items()}
+            prediction_dict[location] = self._cls(time_period, **fields)
         return DataSet(prediction_dict)
 
 

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -78,7 +78,11 @@ class PredictionParams(DBModel):
     @field_validator("future_weather_provider")
     @classmethod
     def _check_weather_provider(cls, value: str) -> str:
-        resolve_weather_provider(value)
+        if resolve_weather_provider(value).leaks_future_data:
+            raise ValueError(
+                f"The '{value}' future-weather provider reads the forecast window's own observations "
+                "and so cannot forecast ahead. Use a forecasting provider such as 'climatology'."
+            )
         return value
 
 

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -1,7 +1,8 @@
-from pydantic import BaseModel, ConfigDict, Field, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 from pydantic.alias_generators import to_camel
 
 from chap_core.api_types import BacktestParams, FeatureCollectionModel
+from chap_core.assessment.weather_providers import DEFAULT_WEATHER_PROVIDER_ID, resolve_weather_provider
 from chap_core.database.base_tables import DBModel
 from chap_core.database.dataset_tables import DataSetCreateInfo, ObservationBase
 from chap_core.database.model_templates_and_config_tables import (
@@ -66,6 +67,19 @@ class PredictionParams(DBModel):
 
     model_id: str = Field(description="Canonical name of the configured model to run.")
     n_periods: int = Field(default=3, gt=0, description="Number of future periods to forecast.")
+    future_weather_provider: str = Field(
+        default=DEFAULT_WEATHER_PROVIDER_ID,
+        description="Id of the registered future-weather provider supplying climate covariates for the "
+        "forecast window. Should match the provider the model was backtested with. Providers that read "
+        "the forecast window's own observations cannot be used here. "
+        "See GET /v1/analytics/weather-providers.",
+    )
+
+    @field_validator("future_weather_provider")
+    @classmethod
+    def _check_weather_provider(cls, value: str) -> str:
+        resolve_weather_provider(value)
+        return value
 
 
 class ValidationError(DBModel):

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -11,7 +11,7 @@ from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.forecast import forecast_ahead
 from chap_core.assessment.metrics import compute_all_aggregated_metrics_from_backtest
 from chap_core.assessment.prediction_evaluator import backtest as _backtest
-from chap_core.climate_predictor import QuickForecastFetcher
+from chap_core.assessment.weather_providers import DEFAULT_WEATHER_PROVIDER_ID
 from chap_core.data import DataSet as InMemoryDataSet
 from chap_core.database.database import SessionWrapper
 from chap_core.database.dataset_manager import DataSetManager
@@ -82,6 +82,7 @@ def run_backtest(
     stride: int = _DEFAULT_PARAMS.stride,
     n_retrain: int = _DEFAULT_PARAMS.n_retrain,
     session: SessionWrapper | None = None,
+    future_weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
 ):
     from chap_core.assessment.dataset_splitting import train_test_generator
 
@@ -126,7 +127,7 @@ def run_backtest(
         prediction_length=n_periods,
         n_test_sets=n_splits,
         stride=stride,
-        future_weather_provider=QuickForecastFetcher,  # type: ignore[arg-type]
+        future_weather_provider=future_weather_provider,
     )
 
     status_logger.info(f"Running {n_splits} evaluation splits with prediction length {n_periods}")
@@ -171,6 +172,7 @@ def run_prediction(
     session: SessionWrapper,
     prediction_setup_id: int | None = None,
     configured_model_id: int | None = None,
+    future_weather_provider: str = DEFAULT_WEATHER_PROVIDER_ID,
 ):
     # NOTE: model_id arg from the user is actually the model's unique name identifier
     status_logger.info(f"Starting prediction for model '{model_id}' on dataset ID {dataset_id}")
@@ -187,7 +189,7 @@ def run_prediction(
     )
     assert configured_model.id is not None, "configured_model.id is required"
     estimator = session.get_configured_model_with_code(configured_model.id, prediction_length=n_periods)
-    predictions = forecast_ahead(estimator, dataset, n_periods)
+    predictions = forecast_ahead(estimator, dataset, n_periods, weather_provider=future_weather_provider)
     db_id = session.add_predictions(
         predictions,
         dataset_id,
@@ -276,6 +278,7 @@ def predict_pipeline_from_composite_dataset(
         session,
         prediction_setup_id=prediction_setup_id,
         configured_model_id=configured_model_id,
+        future_weather_provider=prediction_params.future_weather_provider,
     )
     return result
 
@@ -306,5 +309,6 @@ def run_backtest_from_dataset(
         stride=backtest_params.stride,
         n_retrain=backtest_params.n_retrain,
         session=session,
+        future_weather_provider=backtest_params.future_weather_provider,
     )
     return result

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -113,6 +113,7 @@ def run_backtest(
     info.n_splits = n_splits
     info.stride = stride
     info.n_retrain = n_retrain
+    info.future_weather_provider = future_weather_provider
 
     status_logger.info(f"Validating dataset with {len(list(dataset.locations()))} locations")
     dataset = validate_and_filter_dataset_for_evaluation(

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -17,6 +17,7 @@ from chap_core.api_types import (
 )
 from chap_core.assessment.dataset_splitting import train_test_generator
 from chap_core.assessment.thresholds import get_threshold_strategy, list_threshold_strategies
+from chap_core.assessment.weather_providers import list_weather_providers
 from chap_core.database.base_tables import DBModel
 from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import DataSet as DataSetTable
@@ -396,6 +397,7 @@ async def create_backtest(
         n_splits=request.n_splits,
         stride=request.stride,
         n_retrain=request.n_retrain,
+        future_weather_provider=request.future_weather_provider,
         database_url=database_url,
         **{JOB_TYPE_KW: JobType.EVALUATION_LEGACY, JOB_NAME_KW: request.name},
     )
@@ -745,6 +747,41 @@ class ThresholdStrategyInfo(DBModel):
     id: str = Field(description="Canonical strategy identifier used in request bodies.")
     display_name: str = Field(description="Human-friendly strategy name shown in pickers.")
     description: str = Field(default="", description="Short paragraph explaining what the strategy computes.")
+
+
+class WeatherProviderInfo(DBModel):
+    """One registered future-weather provider, for populating a picker."""
+
+    id: str = Field(description="Registry id to pass as `future_weather_provider`.")
+    display_name: str = Field(description="Human-friendly provider name shown in pickers.")
+    description: str = Field(default="", description="Short paragraph explaining where the covariates come from.")
+    leaks_future_data: bool = Field(
+        description="True if the provider reads the forecast window's own observations. Such providers give "
+        "look-ahead results that are not comparable to production performance, and cannot be used to predict ahead."
+    )
+
+
+@router.get(
+    "/weather-providers",
+    response_model=list[WeatherProviderInfo],
+    tags=["Backtests"],
+    summary="Discover which future-weather providers are available",
+)
+def list_future_weather_providers():
+    """List the registered future-weather providers, with a name, description and look-ahead flag for each.
+
+    Use this to populate a picker before setting `future_weather_provider` on a backtest or
+    prediction request.
+    """
+    return [
+        WeatherProviderInfo(
+            id=p["id"],
+            display_name=p["name"],
+            description=p["description"],
+            leaks_future_data=p["leaks_future_data"],
+        )
+        for p in list_weather_providers()
+    ]
 
 
 @router.get(

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -29,7 +29,7 @@ import chap_core.rest_api.db_worker_functions as wf
 from chap_core.api_types import FeatureCollectionModel
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metrics import compute_all_detailed_metrics
-from chap_core.assessment.weather_providers import DEFAULT_WEATHER_PROVIDER_ID, resolve_weather_provider
+from chap_core.assessment.weather_providers import resolve_weather_provider
 from chap_core.data import DataSet as InMemoryDataSet
 from chap_core.database.database import SessionWrapper
 from chap_core.database.dataset_manager import DataSetManager
@@ -1071,7 +1071,7 @@ async def run_prediction_setup(
     dataset_info = DataSetCreateInfo(name=request.name, type=dataset_type).model_dump()
     # Inherit the provider the setup's backtest was evaluated with, so a promoted
     # backtest predicts against the same future-weather source it was scored on.
-    provider = getattr(setup.backtest, "future_weather_provider", None) or DEFAULT_WEATHER_PROVIDER_ID
+    provider = setup.backtest.future_weather_provider
     if resolve_weather_provider(provider).leaks_future_data:
         raise HTTPException(
             status_code=400,

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -29,6 +29,7 @@ import chap_core.rest_api.db_worker_functions as wf
 from chap_core.api_types import FeatureCollectionModel
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metrics import compute_all_detailed_metrics
+from chap_core.assessment.weather_providers import DEFAULT_WEATHER_PROVIDER_ID, resolve_weather_provider
 from chap_core.data import DataSet as InMemoryDataSet
 from chap_core.database.database import SessionWrapper
 from chap_core.database.dataset_manager import DataSetManager
@@ -1068,7 +1069,21 @@ async def run_prediction_setup(
     # up in prediction-filtered UI/queries. Use a local instead of mutating the request.
     dataset_type = "prediction"
     dataset_info = DataSetCreateInfo(name=request.name, type=dataset_type).model_dump()
-    prediction_params = PredictionParams(model_id=model_id, n_periods=request.n_periods)
+    # Inherit the provider the setup's backtest was evaluated with, so a promoted
+    # backtest predicts against the same future-weather source it was scored on.
+    provider = getattr(setup.backtest, "future_weather_provider", None) or DEFAULT_WEATHER_PROVIDER_ID
+    if resolve_weather_provider(provider).leaks_future_data:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Prediction setup {prediction_setup_id} was evaluated with the '{provider}' future-weather "
+                "provider, which reads the forecast window's own observations and so cannot forecast ahead. "
+                "Re-run the backtest with a forecasting provider before running predictions from it."
+            ),
+        )
+    prediction_params = PredictionParams(
+        model_id=model_id, n_periods=request.n_periods, future_weather_provider=provider
+    )
     job = worker.queue_db(
         wf.predict_pipeline_from_composite_dataset,
         feature_names,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "urllib3>=2.7.0",              # explicit floor; transitive via requests/docker
     "rq>=2.9.0",
     "scikit-learn>=1.9.0",
+    "statsmodels>=0.14.6",
     "topojson>=1.10",
     "unidecode>=1.4.0",
     "uvicorn>=0.48.0",
@@ -216,6 +217,10 @@ disable_error_code = [
 # Ignore missing stubs for third-party libraries without type hints
 [[tool.mypy.overrides]]
 module = "sklearn.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "statsmodels.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/scripts/evaluate_laos.py
+++ b/scripts/evaluate_laos.py
@@ -1,5 +1,4 @@
 from chap_core.assessment.prediction_evaluator import evaluate_model
-from chap_core.climate_predictor import QuickForecastFetcher
 from chap_core.datatypes import FullData
 from chap_core.models.utils import get_model_from_directory_or_github_url
 from chap_core.predictor.naive_estimator import NaiveEstimator
@@ -11,4 +10,4 @@ model = get_model_from_directory_or_github_url(model_url)
 dataset = DataSet.from_csv('/home/knut/Data/ch_data/weekly_laos_data.csv', FullData)
 if __name__ == '__main__':
     evaluate_model(model, dataset, prediction_length=12, n_test_sets=41, report_filename='laos_weekly_report_2.pdf',
-                   weather_provider=QuickForecastFetcher)
+                   weather_provider="climatology")

--- a/scripts/example_data_generation/evaluation_response.py
+++ b/scripts/example_data_generation/evaluation_response.py
@@ -1,5 +1,4 @@
 from chap_core.assessment.prediction_evaluator import backtest
-from chap_core.climate_predictor import QuickForecastFetcher
 from chap_core.datatypes import FullData
 from chap_core.predictor.model_registry import registry
 from chap_core.rest_api.worker_functions import dataset_to_datalist, samples_to_evaluation_response
@@ -10,7 +9,7 @@ estimator = registry.get_model("auto_regressive_weekly")
 
 
 predictions_list = backtest(
-    estimator, dataset, prediction_length=12, n_test_sets=20, stride=2, weather_provider=QuickForecastFetcher
+    estimator, dataset, prediction_length=12, n_test_sets=20, stride=2, weather_provider="climatology"
 )
 
 # predictions = forecast_ahead(estimator, dataset, 12)

--- a/scripts/laos_weekly_evaluation.py
+++ b/scripts/laos_weekly_evaluation.py
@@ -1,5 +1,4 @@
 from chap_core.assessment.prediction_evaluator import evaluate_model
-from chap_core.climate_predictor import QuickForecastFetcher
 from chap_core.datatypes import FullData
 from chap_core.predictor.model_registry import registry
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
@@ -15,4 +14,4 @@ if __name__ == '__main__':
                    prediction_length=12,
                    n_test_sets=41,
                    report_filename=f'{filename}_{model_name}_report.pdf',
-                   weather_provider=QuickForecastFetcher)
+                   weather_provider="climatology")

--- a/scripts/local_data_handling/uganda_predictions.py
+++ b/scripts/local_data_handling/uganda_predictions.py
@@ -1,7 +1,6 @@
 import pandas as pd
 
 from chap_core.assessment.prediction_evaluator import backtest
-from chap_core.climate_predictor import QuickForecastFetcher
 from chap_core.datatypes import FullData
 from chap_core.predictor.model_registry import registry
 from chap_core.rest_api.worker_functions import dataset_to_datalist, samples_to_evaluation_response
@@ -11,7 +10,7 @@ dataset = DataSet.from_csv("/home/knut/Data/ch_data/uganda_weekly_data_harmonize
 model_name = "auto_regressive_weekly"
 estimator = registry.get_model(model_name)
 predictions_list = backtest(
-    estimator, dataset, prediction_length=12, n_test_sets=20, stride=2, weather_provider=QuickForecastFetcher
+    estimator, dataset, prediction_length=12, n_test_sets=20, stride=2, weather_provider="climatology"
 )
 response = samples_to_evaluation_response(
     predictions_list, quantiles=[0.05, 0.25, 0.5, 0.75, 0.95], real_data=dataset_to_datalist(dataset, "dengue")

--- a/tests/assessment/test_damped_persistence_provider.py
+++ b/tests/assessment/test_damped_persistence_provider.py
@@ -1,0 +1,76 @@
+"""Tests for the damped persistence future-weather provider."""
+
+import numpy as np
+import pytest
+
+from chap_core.assessment.weather_providers import get_future_weather, resolve_weather_provider
+
+from ..data_fixtures import full_data, multi_year_climate_health_data  # noqa: F401
+
+
+def test_provider_is_registered_and_does_not_leak():
+    assert resolve_weather_provider("damped_persistence").leaks_future_data is False
+
+
+def test_forecast_covers_requested_locations_and_periods(full_data):  # noqa: F811
+    periods = full_data.period_range[-3:]
+
+    result = get_future_weather("damped_persistence", full_data, periods)
+
+    assert set(result.keys()) == set(full_data.keys())
+    for data in result.values():
+        assert list(map(str, data.time_period)) == list(map(str, periods))
+
+
+def test_zero_damping_reproduces_climatology(multi_year_climate_health_data):  # noqa: F811
+    """With no anomaly carried forward the forecast is exactly the climatology."""
+    history = multi_year_climate_health_data
+    periods = history.period_range[-3:]
+
+    climatology = get_future_weather("climatology", history, periods)
+    damped = get_future_weather("damped_persistence", history, periods, params={"damping": 0.0})
+
+    for location in history.keys():
+        assert np.allclose(
+            np.asarray(damped[location].rainfall, dtype=float),
+            np.asarray(climatology[location].rainfall, dtype=float),
+        )
+
+
+def test_anomaly_decays_toward_climatology_with_horizon(multi_year_climate_health_data):  # noqa: F811
+    """The whole point of damping: further out, the forecast reverts to climatology."""
+    history = multi_year_climate_health_data
+    periods = history.period_range[-6:]
+
+    climatology = get_future_weather("climatology", history, periods)
+    damped = get_future_weather("damped_persistence", history, periods, params={"damping": 0.5})
+
+    for location in history.keys():
+        gap = np.abs(
+            np.asarray(damped[location].rainfall, dtype=float) - np.asarray(climatology[location].rainfall, dtype=float)
+        )
+        assert np.all(np.diff(gap) <= 1e-12), gap
+
+
+def test_undamped_persistence_holds_the_anomaly(multi_year_climate_health_data):  # noqa: F811
+    """With damping 1 the anomaly is carried forward undiminished."""
+    history = multi_year_climate_health_data
+    periods = history.period_range[-4:]
+
+    climatology = get_future_weather("climatology", history, periods)
+    persisted = get_future_weather("damped_persistence", history, periods, params={"damping": 1.0})
+
+    for location in history.keys():
+        gap = np.asarray(persisted[location].rainfall, dtype=float) - np.asarray(
+            climatology[location].rainfall, dtype=float
+        )
+        assert np.allclose(gap, gap[0])
+
+
+@pytest.mark.parametrize("damping", [0.0, 0.3, 1.0])
+def test_forecast_is_finite_for_any_damping(full_data, damping):  # noqa: F811
+    result = get_future_weather(
+        "damped_persistence", full_data, full_data.period_range[-3:], params={"damping": damping}
+    )
+    for data in result.values():
+        assert np.isfinite(np.asarray(data.rainfall, dtype=float)).all()

--- a/tests/assessment/test_mstl_arima_provider.py
+++ b/tests/assessment/test_mstl_arima_provider.py
@@ -1,0 +1,80 @@
+"""Tests for the MSTL + ARIMA future-weather provider."""
+
+import numpy as np
+import pytest
+
+from chap_core.assessment.weather_providers import get_future_weather, resolve_weather_provider
+
+from ..data_fixtures import full_data, multi_year_climate_health_data  # noqa: F401
+
+
+def test_provider_is_registered_and_does_not_leak():
+    assert resolve_weather_provider("mstl_arima").leaks_future_data is False
+
+
+def test_forecast_covers_requested_locations_and_periods(multi_year_climate_health_data):  # noqa: F811
+    history = multi_year_climate_health_data.restrict_time_period(
+        slice(None, multi_year_climate_health_data.period_range[-3])
+    )
+    periods = multi_year_climate_health_data.period_range[-2:]
+
+    result = get_future_weather("mstl_arima", history, periods)
+
+    assert set(result.keys()) == set(history.keys())
+    for data in result.values():
+        assert list(map(str, data.time_period)) == list(map(str, periods))
+        assert np.isfinite(data.rainfall).all()
+
+
+def test_forecast_tracks_the_seasonal_signal(multi_year_climate_health_data):  # noqa: F811
+    """On a clean seasonal series the forecast should beat a flat last-value guess."""
+    horizon = 6
+    full = multi_year_climate_health_data
+    history = full.restrict_time_period(slice(None, full.period_range[-(horizon + 1)]))
+    periods = full.period_range[-horizon:]
+
+    result = get_future_weather("mstl_arima", history, periods)
+
+    for location in full.keys():
+        truth = np.asarray(full[location].rainfall, dtype=float)[-horizon:]
+        forecast = np.asarray(result[location].rainfall, dtype=float)
+        last_value = float(np.asarray(history[location].rainfall, dtype=float)[-1])
+        assert np.abs(forecast - truth).mean() < np.abs(last_value - truth).mean()
+
+
+def test_short_history_is_rejected_with_a_usable_message(full_data):  # noqa: F811
+    with pytest.raises(ValueError, match="at least 2 full seasonal cycles"):
+        get_future_weather("mstl_arima", full_data, full_data.period_range[-3:])
+
+
+def test_forecast_stays_within_a_plausible_range(multi_year_climate_health_data):  # noqa: F811
+    """Near-unit-root models forecast explosive oscillations; they must be rejected.
+
+    On real admin1 data an unguarded AICc search picked such models for a handful
+    of series, forecasting rainfall of +-5000 against a historical range of 1-18.
+    """
+    history = multi_year_climate_health_data
+    periods = history.period_range[-3:]
+
+    result = get_future_weather("mstl_arima", history, periods)
+
+    for location in history.keys():
+        observed = np.asarray(history[location].rainfall, dtype=float)
+        spread = observed.max() - observed.min()
+        forecast = np.asarray(result[location].rainfall, dtype=float)
+        assert np.abs(forecast - observed.mean()).max() < 3 * spread
+
+
+def test_explicit_order_skips_the_search(multi_year_climate_health_data):  # noqa: F811
+    """A caller-supplied order is used as given, which is much faster."""
+    history = multi_year_climate_health_data
+    periods = history.period_range[-3:]
+
+    auto = get_future_weather("mstl_arima", history, periods)
+    fixed = get_future_weather("mstl_arima", history, periods, params={"order": (0, 0, 0)})
+
+    for location in history.keys():
+        assert not np.allclose(
+            np.asarray(auto[location].rainfall, dtype=float),
+            np.asarray(fixed[location].rainfall, dtype=float),
+        )

--- a/tests/assessment/test_mstl_arima_provider.py
+++ b/tests/assessment/test_mstl_arima_provider.py
@@ -43,8 +43,31 @@ def test_forecast_tracks_the_seasonal_signal(multi_year_climate_health_data):  #
 
 
 def test_short_history_is_rejected_with_a_usable_message(full_data):  # noqa: F811
-    with pytest.raises(ValueError, match="at least 2 full seasonal cycles"):
+    with pytest.raises(ValueError, match="more than 2 full seasonal cycles"):
         get_future_weather("mstl_arima", full_data, full_data.period_range[-3:])
+
+
+def test_exactly_two_cycles_is_rejected_not_crashed(multi_year_climate_health_data):  # noqa: F811
+    """MSTL drops periods >= half the series, so 24 monthly points yield no seasonal
+    component and statsmodels raises UnboundLocalError from inside. The boundary must
+    be refused with an actionable message instead."""
+    history = multi_year_climate_health_data
+    exactly_two_cycles = history.restrict_time_period(slice(None, history.period_range[23]))
+    assert len(exactly_two_cycles.period_range) == 24
+
+    with pytest.raises(ValueError, match="more than 2 full seasonal cycles"):
+        get_future_weather("mstl_arima", exactly_two_cycles, history.period_range[24:27])
+
+
+def test_just_over_two_cycles_is_accepted(multi_year_climate_health_data):  # noqa: F811
+    history = multi_year_climate_health_data
+    just_over = history.restrict_time_period(slice(None, history.period_range[24]))
+    assert len(just_over.period_range) == 25
+
+    result = get_future_weather("mstl_arima", just_over, history.period_range[25:28])
+
+    for data in result.values():
+        assert np.isfinite(np.asarray(data.rainfall, dtype=float)).all()
 
 
 def test_forecast_stays_within_a_plausible_range(multi_year_climate_health_data):  # noqa: F811

--- a/tests/assessment/test_weather_providers.py
+++ b/tests/assessment/test_weather_providers.py
@@ -1,0 +1,123 @@
+import pytest
+
+from chap_core.assessment.weather_providers import (
+    DEFAULT_WEATHER_PROVIDER_ID,
+    get_future_weather,
+    list_weather_providers,
+    resolve_weather_provider,
+    weather_provider,
+)
+from chap_core.assessment.weather_providers.base import FutureWeatherProviderBase
+from chap_core.api_types import BacktestParams
+from chap_core.rest_api.data_models import PredictionParams
+
+from ..data_fixtures import full_data, full_data_with_parent  # noqa: F401
+
+
+def test_builtin_providers_are_registered():
+    ids = {p["id"] for p in list_weather_providers()}
+    assert {"climatology", "observed"} <= ids
+
+
+def test_listing_exposes_id_name_description_and_leak_flag():
+    by_id = {p["id"]: p for p in list_weather_providers()}
+    assert by_id["climatology"]["leaks_future_data"] is False
+    assert by_id["observed"]["leaks_future_data"] is True
+    for provider_id in ("climatology", "observed"):
+        assert by_id[provider_id]["name"]
+        assert by_id[provider_id]["description"]
+
+
+def test_default_provider_does_not_leak():
+    assert resolve_weather_provider(DEFAULT_WEATHER_PROVIDER_ID).leaks_future_data is False
+
+
+def test_resolve_unknown_provider_lists_alternatives():
+    with pytest.raises(ValueError, match="Unknown future weather provider"):
+        resolve_weather_provider("no_such_provider")
+
+
+def test_decorator_rejects_class_not_deriving_from_base():
+    with pytest.raises(TypeError, match="must inherit from FutureWeatherProviderBase"):
+
+        @weather_provider("bad_provider", "Bad")
+        class NotAProvider:
+            pass
+
+
+@weather_provider("test_recorder_no_leak", "Recorder (no leak)")
+class _RecordingProvider(FutureWeatherProviderBase):
+    """Records whatever future_data the caller passed it."""
+
+    last_future_data: object = "unset"
+
+    def get_future_weather(self, historical_data, period_range, future_data=None, params=None):
+        type(self).last_future_data = future_data
+        return historical_data.remove_field("disease_cases")
+
+
+@weather_provider("test_recorder_leaks", "Recorder (leaks)", leaks_future_data=True)
+class _LeakingRecordingProvider(_RecordingProvider):
+    pass
+
+
+def test_future_data_withheld_from_non_leaking_provider(full_data):  # noqa: F811
+    get_future_weather("test_recorder_no_leak", full_data, full_data.period_range, future_data=full_data)
+    assert _RecordingProvider.last_future_data is None
+
+
+def test_future_data_passed_to_leaking_provider(full_data):  # noqa: F811
+    get_future_weather("test_recorder_leaks", full_data, full_data.period_range, future_data=full_data)
+    assert _LeakingRecordingProvider.last_future_data is full_data
+
+
+def test_observed_provider_returns_the_future_window(full_data):  # noqa: F811
+    future = full_data.restrict_time_period(slice(full_data.period_range[-3], None))
+    result = get_future_weather("observed", full_data, future.period_range, future_data=future)
+    assert "disease_cases" not in result.field_names()
+    for location in future.keys():
+        assert list(result[location].rainfall) == list(future[location].rainfall)
+
+
+def test_observed_provider_refuses_to_predict_ahead(full_data):  # noqa: F811
+    with pytest.raises(ValueError, match="only available when backtesting"):
+        get_future_weather("observed", full_data, full_data.period_range[-3:])
+
+
+def test_climatology_provider_covers_requested_periods(full_data):  # noqa: F811
+    periods = full_data.period_range[-3:]
+    result = get_future_weather("climatology", full_data, periods)
+    assert set(result.keys()) == set(full_data.keys())
+    for data in result.values():
+        assert list(map(str, data.time_period)) == list(map(str, periods))
+
+
+def test_backtest_params_defaults_to_the_default_provider():
+    assert BacktestParams().future_weather_provider == DEFAULT_WEATHER_PROVIDER_ID
+
+
+def test_prediction_params_defaults_to_the_default_provider():
+    assert PredictionParams(model_id="m").future_weather_provider == DEFAULT_WEATHER_PROVIDER_ID
+
+
+@pytest.mark.parametrize(
+    "build_params",
+    [
+        lambda value: BacktestParams(future_weather_provider=value),
+        lambda value: PredictionParams(model_id="m", future_weather_provider=value),
+    ],
+    ids=["backtest_params", "prediction_params"],
+)
+def test_params_reject_unregistered_provider(build_params):
+    with pytest.raises(ValueError, match="Unknown future weather provider"):
+        build_params("no_such_provider")
+
+
+def test_climatology_carries_non_numeric_fields_forward(full_data_with_parent):  # noqa: F811
+    """Static string columns (org unit parents, codes) have no seasonal signal to fit."""
+    periods = full_data_with_parent.period_range[-3:]
+
+    result = get_future_weather("climatology", full_data_with_parent, periods)
+
+    for location in full_data_with_parent.keys():
+        assert [str(value) for value in result[location].parent] == ["norway"] * len(periods)

--- a/tests/assessment/test_weather_providers.py
+++ b/tests/assessment/test_weather_providers.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from chap_core.assessment.weather_providers import (
@@ -11,7 +12,7 @@ from chap_core.assessment.weather_providers.base import FutureWeatherProviderBas
 from chap_core.api_types import BacktestParams
 from chap_core.rest_api.data_models import PredictionParams
 
-from ..data_fixtures import full_data, full_data_with_parent  # noqa: F401
+from ..data_fixtures import full_data, full_data_with_gap, full_data_with_parent, train_data_pop  # noqa: F401
 
 
 def test_builtin_providers_are_registered():
@@ -113,6 +114,13 @@ def test_params_reject_unregistered_provider(build_params):
         build_params("no_such_provider")
 
 
+def test_prediction_params_reject_look_ahead_provider():
+    """A provider that reads the forecast window cannot predict ahead, so the
+    request must fail at validation rather than inside the worker."""
+    with pytest.raises(ValueError, match="cannot forecast ahead"):
+        PredictionParams(model_id="m", future_weather_provider="observed")
+
+
 def test_climatology_carries_non_numeric_fields_forward(full_data_with_parent):  # noqa: F811
     """Static string columns (org unit parents, codes) have no seasonal signal to fit."""
     periods = full_data_with_parent.period_range[-3:]
@@ -121,3 +129,25 @@ def test_climatology_carries_non_numeric_fields_forward(full_data_with_parent): 
 
     for location in full_data_with_parent.keys():
         assert [str(value) for value in result[location].parent] == ["norway"] * len(periods)
+
+
+@pytest.mark.parametrize("provider_id", ["climatology", "damped_persistence"])
+def test_forecasting_providers_carry_population_forward(train_data_pop, provider_id):  # noqa: F401, F811
+    """Population is not seasonal; regressing it on month-of-year would hand the
+    model a climatological population instead of the current one."""
+    periods = train_data_pop.period_range[-3:]
+
+    result = get_future_weather(provider_id, train_data_pop, periods)
+
+    for location, data in train_data_pop.items():
+        assert list(result[location].population) == [data.population[-1]] * len(periods)
+        assert "disease_cases" not in result.field_names()
+
+
+def test_missing_covariate_values_do_not_break_the_fit(full_data_with_gap):  # noqa: F811
+    periods = full_data_with_gap.period_range[-3:]
+
+    result = get_future_weather("climatology", full_data_with_gap, periods)
+
+    for data in result.values():
+        assert np.isfinite(np.asarray(data.rainfall, dtype=float)).all()

--- a/tests/data_fixtures.py
+++ b/tests/data_fixtures.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
@@ -99,5 +100,24 @@ def full_data_with_parent() -> DataSet[ClimateHealthDataWithParent]:
     d = {
         "oslo": ClimateHealthDataWithParent(time_period, [1] * T, [1] * T, [20] * T, ["norway"] * T),
         "bergen": ClimateHealthDataWithParent(time_period, [100] * T, [1] * T, [1] * T, ["norway"] * T),
+    }
+    return DataSet(d)
+
+
+@pytest.fixture()
+def multi_year_climate_health_data() -> DataSet[ClimateHealthData]:
+    """Four years of monthly data with a clear annual cycle plus a linear trend.
+
+    Long enough for decomposition-based providers, which need at least two full
+    seasonal cycles before a seasonal component is meaningful.
+    """
+    time_period = PeriodRange.from_time_periods(Month(2012, 1), Month(2015, 12))
+    T = len(time_period)
+    months = np.arange(T) % 12
+    seasonal = 10 * np.sin(2 * np.pi * months / 12)
+    trend = 0.1 * np.arange(T)
+    d = {
+        "oslo": ClimateHealthData(time_period, 20 + seasonal + trend, [1.0] * T, [20.0] * T),
+        "bergen": ClimateHealthData(time_period, 100 + 2 * seasonal + trend, [1.0] * T, [1.0] * T),
     }
     return DataSet(d)

--- a/tests/data_fixtures.py
+++ b/tests/data_fixtures.py
@@ -105,6 +105,17 @@ def full_data_with_parent() -> DataSet[ClimateHealthDataWithParent]:
 
 
 @pytest.fixture()
+def full_data_with_gap(full_data) -> DataSet[ClimateHealthData]:
+    """Like ``full_data`` but with one missing rainfall value per location."""
+    d = {}
+    for location, data in full_data.items():
+        rainfall = np.asarray(data.rainfall, dtype=float)
+        rainfall[3] = np.nan
+        d[location] = ClimateHealthData(data.time_period, rainfall, data.mean_temperature, data.disease_cases)
+    return DataSet(d)
+
+
+@pytest.fixture()
 def multi_year_climate_health_data() -> DataSet[ClimateHealthData]:
     """Four years of monthly data with a clear annual cycle plus a linear trend.
 

--- a/tests/data_fixtures.py
+++ b/tests/data_fixtures.py
@@ -3,6 +3,7 @@ import pytest
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 from chap_core.datatypes import (
     ClimateHealthData,
+    tsdataclass,
     ClimateData,
     HealthData,
     FullData,
@@ -79,5 +80,24 @@ def good_predictions():
     d = {
         "oslo": HealthData(time_period, [19] * T),
         "bergen": HealthData(time_period, [2] * T),
+    }
+    return DataSet(d)
+
+
+@tsdataclass
+class ClimateHealthDataWithParent(ClimateHealthData):
+    """Climate/health data carrying a static, non-numeric org unit attribute."""
+
+    parent: str
+
+
+@pytest.fixture()
+def full_data_with_parent() -> DataSet[ClimateHealthDataWithParent]:
+    """Like ``full_data`` but with a string column that carries no seasonal signal."""
+    time_period = PeriodRange.from_time_periods(Month(2012, 1), Month(2012, 12))
+    T = len(time_period)
+    d = {
+        "oslo": ClimateHealthDataWithParent(time_period, [1] * T, [1] * T, [20] * T, ["norway"] * T),
+        "bergen": ClimateHealthDataWithParent(time_period, [100] * T, [1] * T, [1] * T, ["norway"] * T),
     }
     return DataSet(d)

--- a/tests/evaluation/test_weather_provider_persistence.py
+++ b/tests/evaluation/test_weather_provider_persistence.py
@@ -20,12 +20,10 @@ def test_non_default_provider_round_trips(backtest, tmp_path):
     filepath = tmp_path / "eval.nc"
     evaluation.to_file(filepath=filepath, model_name="TestModel", model_version="1.0.0")
 
-    loaded = Evaluation.from_file(filepath)
+    observed_backtest = Evaluation.from_file(filepath).to_backtest()
+    observed_backtest.future_weather_provider = "observed"
     observed_filepath = tmp_path / "eval_observed.nc"
-    Evaluation(
-        loaded.to_backtest(),
-        future_weather_provider="observed",
-    ).to_file(filepath=observed_filepath, model_name="TestModel", model_version="1.0.0")
+    Evaluation(observed_backtest).to_file(filepath=observed_filepath, model_name="TestModel", model_version="1.0.0")
 
     assert Evaluation.from_file(observed_filepath).future_weather_provider == "observed"
 
@@ -62,17 +60,10 @@ def test_from_file_sets_the_provider_on_the_backtest(backtest, tmp_path):
     assert loaded.to_backtest().future_weather_provider == "observed"
 
 
-def test_constructor_override_lands_on_the_backtest_row(backtest):
-    """The row is the single source of truth; an override must be written to it,
-    not held beside it, or a to_backtest()/from_backtest() round trip reverts it."""
-    evaluation = Evaluation(backtest, future_weather_provider="observed")
-
-    assert evaluation.to_backtest().future_weather_provider == "observed"
-    assert Evaluation.from_backtest(evaluation.to_backtest()).future_weather_provider == "observed"
-
-
-def test_no_override_keeps_the_row_value(backtest):
+def test_the_row_is_the_single_source_of_truth(backtest):
+    """A to_backtest()/from_backtest() round trip must not revert the provider."""
     backtest.future_weather_provider = "observed"
+    evaluation = Evaluation(backtest)
 
-    assert Evaluation(backtest).future_weather_provider == "observed"
-    assert Evaluation(backtest).to_backtest().future_weather_provider == "observed"
+    assert evaluation.future_weather_provider == "observed"
+    assert Evaluation.from_backtest(evaluation.to_backtest()).future_weather_provider == "observed"

--- a/tests/evaluation/test_weather_provider_persistence.py
+++ b/tests/evaluation/test_weather_provider_persistence.py
@@ -33,3 +33,30 @@ def test_non_default_provider_round_trips(backtest, tmp_path):
 def test_legacy_file_is_attributed_to_observed_weather(old_backtest_file):
     """Files predating the provider field were run against the real future weather."""
     assert Evaluation.from_file(old_backtest_file).future_weather_provider == LEGACY_WEATHER_PROVIDER_ID
+
+
+def test_from_backtest_reads_the_provider_off_the_row(backtest):
+    """An `observed` backtest must not convert into a `climatology` evaluation."""
+    backtest.future_weather_provider = "observed"
+
+    assert Evaluation.from_backtest(backtest).future_weather_provider == "observed"
+
+
+def test_from_backtest_exports_the_row_provider(backtest, tmp_path):
+    backtest.future_weather_provider = "observed"
+    filepath = tmp_path / "eval.nc"
+
+    Evaluation.from_backtest(backtest).to_file(filepath=filepath, model_name="TestModel", model_version="1.0.0")
+
+    assert Evaluation.from_file(filepath).future_weather_provider == "observed"
+
+
+def test_from_file_sets_the_provider_on_the_backtest(backtest, tmp_path):
+    """to_backtest() on a loaded evaluation must carry the provider it was read with."""
+    backtest.future_weather_provider = "observed"
+    filepath = tmp_path / "eval.nc"
+    Evaluation.from_backtest(backtest).to_file(filepath=filepath, model_name="TestModel", model_version="1.0.0")
+
+    loaded = Evaluation.from_file(filepath)
+
+    assert loaded.to_backtest().future_weather_provider == "observed"

--- a/tests/evaluation/test_weather_provider_persistence.py
+++ b/tests/evaluation/test_weather_provider_persistence.py
@@ -1,0 +1,35 @@
+"""The future-weather provider is recorded in the .nc file and survives a round trip."""
+
+from chap_core.assessment.evaluation import Evaluation
+from chap_core.assessment.weather_providers import (
+    DEFAULT_WEATHER_PROVIDER_ID,
+    LEGACY_WEATHER_PROVIDER_ID,
+)
+
+
+def test_provider_round_trips_through_nc_file(backtest, tmp_path):
+    evaluation = Evaluation.from_backtest(backtest)
+    filepath = tmp_path / "eval.nc"
+    evaluation.to_file(filepath=filepath, model_name="TestModel", model_version="1.0.0")
+
+    assert Evaluation.from_file(filepath).future_weather_provider == DEFAULT_WEATHER_PROVIDER_ID
+
+
+def test_non_default_provider_round_trips(backtest, tmp_path):
+    evaluation = Evaluation.from_backtest(backtest)
+    filepath = tmp_path / "eval.nc"
+    evaluation.to_file(filepath=filepath, model_name="TestModel", model_version="1.0.0")
+
+    loaded = Evaluation.from_file(filepath)
+    observed_filepath = tmp_path / "eval_observed.nc"
+    Evaluation(
+        loaded.to_backtest(),
+        future_weather_provider="observed",
+    ).to_file(filepath=observed_filepath, model_name="TestModel", model_version="1.0.0")
+
+    assert Evaluation.from_file(observed_filepath).future_weather_provider == "observed"
+
+
+def test_legacy_file_is_attributed_to_observed_weather(old_backtest_file):
+    """Files predating the provider field were run against the real future weather."""
+    assert Evaluation.from_file(old_backtest_file).future_weather_provider == LEGACY_WEATHER_PROVIDER_ID

--- a/tests/evaluation/test_weather_provider_persistence.py
+++ b/tests/evaluation/test_weather_provider_persistence.py
@@ -60,3 +60,19 @@ def test_from_file_sets_the_provider_on_the_backtest(backtest, tmp_path):
     loaded = Evaluation.from_file(filepath)
 
     assert loaded.to_backtest().future_weather_provider == "observed"
+
+
+def test_constructor_override_lands_on_the_backtest_row(backtest):
+    """The row is the single source of truth; an override must be written to it,
+    not held beside it, or a to_backtest()/from_backtest() round trip reverts it."""
+    evaluation = Evaluation(backtest, future_weather_provider="observed")
+
+    assert evaluation.to_backtest().future_weather_provider == "observed"
+    assert Evaluation.from_backtest(evaluation.to_backtest()).future_weather_provider == "observed"
+
+
+def test_no_override_keeps_the_row_value(backtest):
+    backtest.future_weather_provider = "observed"
+
+    assert Evaluation(backtest).future_weather_provider == "observed"
+    assert Evaluation(backtest).to_backtest().future_weather_provider == "observed"

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -490,6 +490,26 @@ def test_run_backtest_persists_resolved_params(override_session, p_seeded_engine
     assert (read.n_periods, read.n_splits, read.stride, read.n_retrain) == (3, 2, 1, 2)
 
 
+def test_run_backtest_persists_the_future_weather_provider(override_session, p_seeded_engine):
+    """A non-default provider must reach the row, or a look-ahead run is filed as climatology."""
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_id = session.session.exec(select(DataSet.id)).first()
+        model = session.get_configured_model_by_id_or_name("naive_model")
+        backtest_id = run_backtest(
+            BacktestCreate(name="provider", dataset_id=dataset_id, model_id=model.id),
+            n_periods=3,
+            n_splits=2,
+            stride=1,
+            session=session,
+            future_weather_provider="observed",
+        )
+        assert session.session.get(Backtest, backtest_id).future_weather_provider == "observed"
+
+    response = client.get(f"/v1/crud/backtests/{backtest_id}")
+    assert response.status_code == 200, response.text
+    assert BacktestRead.model_validate(response.json()).future_weather_provider == "observed"
+
+
 def test_run_backtest_retrains_n_retrain_times(p_seeded_engine, monkeypatch):
     """n_retrain must reach the evaluator, not just the row."""
     from chap_core.predictor.naive_estimator import NaiveEstimator

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -917,6 +917,65 @@ def test_run_prediction_setup_rejects_legacy_fields(override_session, seeded_ses
     assert response.status_code == 422
 
 
+def test_run_prediction_setup_inherits_the_backtest_provider(
+    override_session, seeded_session, example_polygons, monkeypatch
+):
+    """A promoted backtest must predict with the provider it was evaluated on, or the
+    prediction silently uses a different future-weather source than the scores imply."""
+    backtest = seeded_session.exec(select(Backtest)).first()
+    assert backtest is not None
+    backtest.future_weather_provider = "damped_persistence"
+    seeded_session.add(backtest)
+    seeded_session.commit()
+    setup_id = _create_prediction_setup(backtest.id, "Inherit provider").json()["id"]
+
+    request = create_make_data_request(example_polygons, [], ["rainfall", "disease_cases", "population"])
+    payload = request.model_dump(mode="json")
+    payload.pop("data_to_be_fetched", None)
+    payload.pop("data_sources", None)
+    payload["nPeriods"] = 3
+
+    from chap_core.rest_api.v1.routers import crud as crud_router
+
+    captured: dict = {}
+
+    class _FakeJob:
+        id = "captured-job"
+
+    class _CapturingWorker:
+        def queue_db(self, func, *args, **kwargs):
+            captured.update(kwargs)
+            return _FakeJob()
+
+    monkeypatch.setattr(crud_router, "worker", _CapturingWorker())
+    response = client.post(f"/v1/crud/prediction-setups/{setup_id}/run", json=payload)
+
+    assert response.status_code == 200, response.json()
+    assert captured["prediction_params"].future_weather_provider == "damped_persistence"
+
+
+def test_run_prediction_setup_rejects_a_look_ahead_provider(override_session, seeded_session, example_polygons):
+    """`observed` reads the forecast window's own weather, so it cannot forecast ahead.
+    Fail at the endpoint rather than deep inside the worker."""
+    backtest = seeded_session.exec(select(Backtest)).first()
+    assert backtest is not None
+    backtest.future_weather_provider = "observed"
+    seeded_session.add(backtest)
+    seeded_session.commit()
+    setup_id = _create_prediction_setup(backtest.id, "Look-ahead setup").json()["id"]
+
+    request = create_make_data_request(example_polygons, [], ["rainfall", "disease_cases", "population"])
+    payload = request.model_dump(mode="json")
+    payload.pop("data_to_be_fetched", None)
+    payload.pop("data_sources", None)
+    payload["nPeriods"] = 3
+
+    response = client.post(f"/v1/crud/prediction-setups/{setup_id}/run", json=payload)
+
+    assert response.status_code == 400, response.json()
+    assert "cannot forecast ahead" in response.json()["detail"]
+
+
 @pytest.mark.parametrize("n_periods", [0, -1])
 def test_run_prediction_setup_non_positive_n_periods_returns_422(
     override_session, seeded_session, example_polygons, n_periods

--- a/tests/integration/rest_api/test_from_seeded_engine.py
+++ b/tests/integration/rest_api/test_from_seeded_engine.py
@@ -127,6 +127,16 @@ def test_threshold_strategies_discovery(override_session):
     assert seasonal["description"]
 
 
+def test_weather_provider_discovery(override_session):
+    providers = client.get_json("/v1/analytics/weather-providers")
+    by_id = {p["id"]: p for p in providers}
+    assert {"climatology", "observed"} <= set(by_id)
+    assert by_id["climatology"]["displayName"]
+    assert by_id["climatology"]["description"]
+    assert by_id["climatology"]["leaksFutureData"] is False
+    assert by_id["observed"]["leaksFutureData"] is True
+
+
 def test_compute_thresholds(override_session):
     body = {"dataset_id": 1, "period_ids": ["2023-01", "2023-02"], "strategy": "seasonal"}
     response = client.post("/v1/analytics/thresholds", json=body)

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -50,6 +50,7 @@ _COLUMNS_ADDED_BY_MIGRATIONS = [
     ("backtest", "n_splits"),
     ("backtest", "stride"),
     ("backtest", "n_retrain"),
+    ("backtest", "future_weather_provider"),
 ]
 
 # Tables added by alembic migrations (not in the baseline schema).
@@ -308,6 +309,8 @@ class TestAlembicMigrations:
             for column in ("n_periods", "n_splits", "stride", "n_retrain"):
                 conn.execute(sa.text(f"ALTER TABLE backtest ADD COLUMN {column} INTEGER"))
                 conn.execute(sa.text(f"UPDATE backtest SET {column} = 0"))
+            conn.execute(sa.text("ALTER TABLE backtest ADD COLUMN future_weather_provider VARCHAR"))
+            conn.execute(sa.text("UPDATE backtest SET future_weather_provider = ''"))
             conn.commit()
 
         command.upgrade(alembic_cfg, "head")
@@ -321,6 +324,10 @@ class TestAlembicMigrations:
                 sa.text("SELECT n_periods, n_splits, stride, n_retrain FROM backtest WHERE name = 'empty_backtest'")
             ).one()
             assert tuple(row) == (3, 7, 1, 1)
+            # Every legacy backtest was run by the REST path, which always used
+            # QuickForecastFetcher - what the climatology provider now does.
+            providers = conn.execute(sa.text("SELECT future_weather_provider FROM backtest")).scalars().all()
+            assert set(providers) == {"climatology"}
 
         with engine.connect() as conn:
             row = conn.execute(

--- a/tests/test_climate_predictor.py
+++ b/tests/test_climate_predictor.py
@@ -42,6 +42,17 @@ def test_climate_predictor(climate_data):
     prediction = predictor.predict(time_period)
 
 
+def test_predict_preserves_training_location_order(climate_data):
+    """External models write history and future to CSV in dict order; the two must agree."""
+    predictor = MonthlyClimatePredictor()
+    predictor.train(climate_data)
+    time_period = PeriodRange.from_time_periods(Month.parse("2021-01"), Month.parse("2021-03"))
+
+    prediction = predictor.predict(time_period)
+
+    assert list(prediction.keys()) == list(climate_data.keys())
+
+
 def test_weekly_climate_predictor(weekly_climate_data):
     predictor = WeeklyClimatePredictor()
     predictor.train(weekly_climate_data)

--- a/tests/test_dataset_splitting.py
+++ b/tests/test_dataset_splitting.py
@@ -1,3 +1,5 @@
+import pytest
+
 from chap_core.time_period import Month
 from chap_core.assessment.dataset_splitting import (
     split_test_train_on_period,
@@ -6,6 +8,11 @@ from chap_core.assessment.dataset_splitting import (
     train_test_generator,
 )
 from chap_core.time_period import PeriodRange
+from chap_core.assessment.weather_providers import (
+    DEFAULT_WEATHER_PROVIDER_ID,
+    get_future_weather,
+    resolve_weather_provider,
+)
 from .data_fixtures import full_data
 
 
@@ -39,3 +46,29 @@ def test_train_test_generator(full_data):
     assert len(test_pairs) == 2
     assert all(len(pair[1].period_range) == 3 for pair in test_pairs)
     assert all(test_pairs[-1][1].period_range == full_data.period_range[-3:])
+
+
+def test_train_test_generator_defaults_to_non_leaking_provider(full_data):
+    """The default must route through a provider that never sees the forecast window."""
+    assert resolve_weather_provider(DEFAULT_WEATHER_PROVIDER_ID).leaks_future_data is False
+
+    _, pairs = train_test_generator(full_data, prediction_length=3, n_test_sets=1)
+    historic, masked_future, _ = next(iter(pairs))
+    expected = get_future_weather(DEFAULT_WEATHER_PROVIDER_ID, historic, masked_future.period_range)
+    for location in full_data.keys():
+        assert list(masked_future[location].rainfall) == list(expected[location].rainfall)
+
+
+def test_train_test_generator_observed_provider_returns_true_weather(full_data):
+    _, pairs = train_test_generator(full_data, prediction_length=3, n_test_sets=1, future_weather_provider="observed")
+    _, masked_future, future_truth = next(iter(pairs))
+    for location in full_data.keys():
+        assert list(masked_future[location].rainfall) == list(future_truth[location].rainfall)
+
+
+def test_train_test_generator_rejects_unknown_provider(full_data):
+    with pytest.raises(ValueError, match="Unknown future weather provider"):
+        _, pairs = train_test_generator(
+            full_data, prediction_length=3, n_test_sets=1, future_weather_provider="no_such_provider"
+        )
+        next(iter(pairs))

--- a/uv.lock
+++ b/uv.lock
@@ -421,6 +421,7 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "sqlmodel" },
     { name = "starlette" },
+    { name = "statsmodels" },
     { name = "stumpy" },
     { name = "topojson" },
     { name = "unidecode" },
@@ -512,6 +513,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.9.0" },
     { name = "sqlmodel", specifier = ">=0.0.38" },
     { name = "starlette", specifier = ">=1.0.1" },
+    { name = "statsmodels", specifier = ">=0.14.6" },
     { name = "stumpy", specifier = ">=1.14.1" },
     { name = "topojson", specifier = ">=1.10" },
     { name = "unidecode", specifier = ">=1.4.0" },
@@ -1190,6 +1192,24 @@ wheels = [
 ]
 
 [[package]]
+name = "formulaic"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "interface-meta" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/87/e7b9b39d218793f159d7425e264c0ac196da07f1decc333001502fac02fb/formulaic-1.2.2.tar.gz", hash = "sha256:c99e8f11ff7d327eaecaf63855ca69b7fa0da100ad6c0041ef80912fbac667e6", size = 657522, upload-time = "2026-06-02T18:24:42.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/75/0576b03f7889ad25b5385b4f6c69e0543713425a6f193b056c9b0a2e65ce/formulaic-1.2.2-py3-none-any.whl", hash = "sha256:0f84ff49e3fc9dc0e68ab08a0a9427874021aa6c558e66b44dc634a35739b09b", size = 118939, upload-time = "2026-06-02T18:24:41.344Z" },
+]
+
+[[package]]
 name = "geographiclib"
 version = "2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1463,6 +1483,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "interface-meta"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/5b/202a48a1ccdef721a95357fbe263c54ef87c18c4972df1ab5c22fe0f33d5/interface_meta-2.0.1.tar.gz", hash = "sha256:902bd9a95a12f195f15753a1080075d4eca7a2cb934fac7ac03c9e362b50796a", size = 15281, upload-time = "2026-04-30T22:35:36.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/d3/20a61a248feb1249cd81f83ce731f0bdf5170ed96a08a298f7081cda9e90/interface_meta-2.0.1-py3-none-any.whl", hash = "sha256:f38016bef9a4429b6d0792d809be7b65e9781820c674bf7f463999086b6e6323", size = 15330, upload-time = "2026-04-30T22:35:35.201Z" },
 ]
 
 [[package]]
@@ -2514,11 +2543,24 @@ wheels = [
 ]
 
 [[package]]
+name = "patsy"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/e3/950e513affdfe1c1864397b4f40d6ed06ec1b54f608e462c27f151dd72df/patsy-1.0.3.tar.gz", hash = "sha256:79ebf4c93ff4d296e58a9d5be2b2ee31bd49d737cf11d70ffbd8a44b2de42e65", size = 399992, upload-time = "2026-08-29T21:35:32.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/70/cd3cf5cff538323076a879edef02cce6f13f7d75e03d12f211b0a0dbd178/patsy-1.0.3-py2.py3-none-any.whl", hash = "sha256:d3dbebe8fd5f46e29912d030b63c6268647b59bf788a99e2af28a30234cf357c", size = 233318, upload-time = "2026-08-29T21:35:30.913Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3766,6 +3808,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "statsmodels"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "formulaic" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/1f/a3cbf6ed7cf6286afec694bfef561f3e51483197716717fb8476f1f0c50e/statsmodels-0.15.0.tar.gz", hash = "sha256:5d257fe58d0772bc46a557880ca78e2a8e07fec7bfd9d11074aef8e33e1aecbc", size = 15736853, upload-time = "2026-08-27T10:45:21.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/17/fee8cfc100c37b1c553515dbad59607a55085a5b9beac2b008e4c03b6388/statsmodels-0.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:09fe34ac80e147cd76cb702ba672559ee3c5dd3ba15c25a232922b46e5ffe70e", size = 11696848, upload-time = "2026-08-27T10:36:13.782Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/60/a885751cd3aa796ef94b60f6d3de0c9ace4190feb3e55414ee728d2a0abc/statsmodels-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ffe08752f420f12a0b03e8f7d8f3a45417615309b1f37f10561f9a53f044737", size = 11556170, upload-time = "2026-08-27T10:36:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f4/482701d2dc7540897b13ead827cf8499b11c7325753b8cc4ff1a82c87a18/statsmodels-0.15.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a7ab98634d47048c6b7c168b3f8f71369e256d7314bc386168526f34c7699d7", size = 11752604, upload-time = "2026-08-27T10:47:50.809Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/88/5c8819f232448d52514b76a64cf285bc608cff9179f3eeacf58750612323/statsmodels-0.15.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bcaa1e4499697c4e023e5fa6fb04459a34e4f4a449c45ae441992e933bde24db", size = 12055386, upload-time = "2026-08-27T10:49:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/19/a8/298e9b5c993cad3b58913d61b7e7cb0e2fba12e39d3114cd8484f922a5d1/statsmodels-0.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:88dbe345ecf317862481b3c86305f42133082e5b366a3a8cf240a6caac404daf", size = 12088356, upload-time = "2026-08-27T10:48:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f5/386c6cfda27c47df81643dc9466b3e28dc2a82152e524131977275a88e0c/statsmodels-0.15.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:ac9bce461d0c8f529f8ed331a469eaa5dd7c3213c06b62623a2e5438a6383093", size = 9809418, upload-time = "2026-08-27T10:36:50.646Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b4/a8a4d89918599309bebfc09a2f793a910279f3900671bc959ac8c810edd1/statsmodels-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:081adf7e5f2da63f63cbd90491447de5d4c4c2921f19814f235bcf3e736edd3c", size = 11312877, upload-time = "2026-08-27T10:37:08.325Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/79/66b57afdcbf9a8b21b1a8e4414ddb006e819b2a81243cd74c12f3301eca3/statsmodels-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:3e5f870037ca154a4d177aeac68704a784b24cf2c45d86b046fc28e37a2a5584", size = 10812282, upload-time = "2026-08-27T10:37:26.708Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/daf737efb6002905bd006d296f9ad031ed3861b640075bde3b734706b49d/statsmodels-0.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:04e65ee05475aeceb9cb954cf96c0f9361b9cdfd497b8aae47afbab0c7c786dd", size = 11698848, upload-time = "2026-08-27T10:37:46.312Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b1/ca42c91e427db43917d4ab5cc6991e7e50b574bcfdf6c4c8eb9590af71d3/statsmodels-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1f1443cc1ff7683f3d7a9054e6dccd92040fbd4324616a0b6dbb8af1ce7889fb", size = 11571229, upload-time = "2026-08-27T10:38:04.723Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/04/d803e8d014d4643d9c0a5eec78343073fbfff1c1018f776dd416c07fc076/statsmodels-0.15.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a45026596c71afa18543ec2af40b895609c181fc3649433c1cded5ce23ec5cd4", size = 11801588, upload-time = "2026-08-27T15:00:31.603Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/40d7678858065e9ec8efd9f37f04227b22a66632ba194e4aa43fda023f6a/statsmodels-0.15.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:edd803f4606061af8c7a83e2326ea294cbfa802a908dfbda4a88347301fb6820", size = 12062254, upload-time = "2026-08-27T15:00:49.803Z" },
+    { url = "https://files.pythonhosted.org/packages/51/69/16c73c3c09f4b8d85f125d7d3ae0f7092d4736a83d24c0159e4fb21632ec/statsmodels-0.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:eb7fc1147cd8d17132190db7a8e63cd76a06145dec502816d8f3c20619923f2b", size = 12101259, upload-time = "2026-08-27T15:01:08.755Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4c/1138aad8e3c27ebf941d732788488cce7c28d76404a7b7fc1186faad2890/statsmodels-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:c3c1138b4d0e5b0c2387b17dafd2a0fd137c67bd869f70d4ee56feecc918cb0d", size = 11348219, upload-time = "2026-08-27T15:11:12.924Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/bd/53546d8c9ab013d9a0513706d2a09a03aff12034e6f898987e8ce0f38257/statsmodels-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:74c0b63448f03020cc27a8ee698fbcf2ba91e61a9f9eee7978c0c4ed33a9b17f", size = 10866645, upload-time = "2026-08-27T10:38:20.886Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a1/0d38328643d4704c8de7867518c3f52ec145ff62537b2ca1e14cdeecf51b/statsmodels-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6197b4cca69fd7bc23ab9430abf1c479764cfe74767467f51964a633dfade7a5", size = 11870287, upload-time = "2026-08-27T10:38:38.271Z" },
+    { url = "https://files.pythonhosted.org/packages/28/55/fac7e03895f24a0b4883ff9fc69f9421a5df1b60e7edd7e68d49f4327593/statsmodels-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5538a734dd28efd450bb38a5d5fc94d13ee709bc497e3e4c0a24b3803e3eac39", size = 11755467, upload-time = "2026-08-27T10:38:54.683Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/38/5321b9f6065d1c5861e87853720603d56ae81795a83d3040410ca2684305/statsmodels-0.15.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dde0657d18e322eedb2540a84c0582e97afd0f78c370b45eebb0d4ac228a7a83", size = 11636274, upload-time = "2026-08-27T15:03:41.86Z" },
+    { url = "https://files.pythonhosted.org/packages/28/56/c75e984c492509d9ab2ba5f2c0e4eab7177cd2cec424cef9dafb42f0cc70/statsmodels-0.15.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90e75e726be2c9fc1d1d4c43337503a35864bdf5b4693773a08c6ee92d04a153", size = 11865818, upload-time = "2026-08-27T15:04:01.503Z" },
+    { url = "https://files.pythonhosted.org/packages/61/72/9e03975701c808767c19f394f670941a962204a4f6a00eeaf56b560348e8/statsmodels-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65e64afc2655a486ea44a5ffe4e2b05ee3abbcb10ea61d1c02d3e9e519338d9b", size = 11907800, upload-time = "2026-08-27T15:05:49.786Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a7/c467019a8bf1ab6a07ca88004f0a1d4ea2dae89642aa804e49437b256243/statsmodels-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:edee066ac9b171d95c3de925225331a21de1deb5b6452f252bc853e44566e72b", size = 11559083, upload-time = "2026-08-27T15:06:05.872Z" },
+    { url = "https://files.pythonhosted.org/packages/54/10/dc78352367cd5bb298340b57c390c944b66236f6d026cc238bc8264c7633/statsmodels-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:40b2737456e75d96866943e33017a1dffc9166025ee33b7eb373fbe8c7a85e09", size = 11029613, upload-time = "2026-08-27T10:39:10.043Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements CLIM-1042. Supersedes #566, which contained only a design document; that document is not part of this branch, so #566 can be closed.

## What changes

Future-weather providers become plugins in the same sense as metrics, backtest plots and threshold strategies: a class with an `id`, `name` and `description`, registered via `@weather_provider` and resolved by id from a registry.

Providers declare `leaks_future_data`. The call site passes the forecast window's observations **only** to providers that declare it:

```python
provider_cls = resolve_weather_provider(provider_id)
provider_cls().get_future_weather(
    historical_data,
    period_range,
    future_data=future_data if provider_cls.leaks_future_data else None,
    params=params,
)
```

A provider that does not declare the flag is structurally unable to look ahead, rather than trusted not to. "Use the real weather" is now the `observed` provider instead of the *absence* of a provider, which is what made the leak reachable by omission.

Forecasting providers only see seasonal numeric covariates. `get_future_weather` strips the target, string columns (org unit parents, codes) and non-seasonal numerics such as `population` before calling the provider, and reattaches them carried forward from their last observation. Regressing population on month-of-year would otherwise hand the model a climatological population instead of the current one. Providers stay pure forecasters and none has to re-implement that rule.

## Providers

| id | leaks | notes |
|---|---|---|
| `climatology` | no | per-location regression on month/week-of-year, the previous `QuickForecastFetcher` behaviour. **Default.** |
| `damped_persistence` | no | climatology plus the current anomaly, damped by `phi**h`; `phi` defaults to the lag-1 autocorrelation of the anomaly series |
| `mstl_arima` | no | MSTL decomposition + AICc-selected ARIMA; needs more than 2 seasonal cycles |
| `observed` | **yes** | perfect foresight, diagnostic runs only; cannot be used to predict ahead |

`future_weather_provider` is added to `BacktestParams` and `PredictionParams`, validated against the registry and threaded through `chap eval`, the REST API and the worker functions, so evaluation and prediction use the same source. `PredictionParams` additionally rejects providers that declare `leaks_future_data`, so a request for `observed` fails with 422 at every prediction entry point. A prediction setup inherits the provider its backtest was evaluated with. `GET /v1/analytics/weather-providers` lists the providers with their look-ahead flag.

The backtest row is the single source of truth for the provider. `Evaluation` reads it from the row, the worker persists it before the backtest is constructed, and NetCDF export and database persistence cannot disagree.

## Breaking change

**The default is `climatology` everywhere.** `chap eval` previously received the observed weather, so re-running an existing evaluation will produce different numbers. Pass `--backtest-params.future-weather-provider observed` to restore the old behaviour. The REST paths already used climatology and are unaffected.

Routing `chap eval` through climatology also means every CLI evaluation now fits `MonthlyClimatePredictor`. Its NaN assertion has been replaced by fitting on the observed rows of each covariate, so a gap in rainfall no longer aborts the run; a covariate that is entirely missing raises a ValueError naming the column. Data at resolutions other than month or week raises a ValueError pointing at the `observed` provider instead of a bare assertion.

## `.nc` backward compatibility

The provider is written into the evaluation `.nc` file. Files without the attribute are read back as `observed` (`LEGACY_WEATHER_PROVIDER_ID`): that is what produced them, and without the hedge they would silently inherit today's default and misreport how they were run.

## How the providers actually perform

Rolling-origin backtest, 3 periods ahead, MAE vs `climatology` over four real datasets (Vietnam/Laos admin1 monthly, Malawi district monthly, Laos weekly):

| | rainfall | mean_temperature |
|---|---|---|
| `damped_persistence` | +0.0%, -0.1%, +2.9%, -0.4% | +4.7%, +6.2%, +5.7%, -2.4% |
| `mstl_arima` | -1.1%, -4.8%, -18.7%, -21.1% | +14.1%, +2.6%, +1.9%, +15.3% |

`damped_persistence` never loses more than 2.4% and costs less than climatology to fit; when anomalies carry no signal its damping factor goes to ~0 and it degrades into climatology. `mstl_arima` is a strong choice for temperature-driven models, especially weekly, where climatology's 52 week-of-year dummies overfit, but is the wrong model for rainfall, which is intermittent and right-skewed, and it is 100-300x slower.

## New dependency

`statsmodels`, for `mstl_arima`. Pure Python over numpy/scipy; avoids the numba toolchain that `statsforecast` pulls in.

## Not included

`imported` (user-supplied forecast datasets) and a real seasonal-forecast product both need a decision on how the forecast data is referenced. Nothing yet asserts that a prediction's provider matches the backtest's beyond the setup-run path, which inherits it.

## Testing

`make lint` clean (ruff, mypy, pyright). Full suite: 1437 passed, 122 skipped.
