### PR TITLE
feat: persist backtest parameters and consolidate the backtest endpoints

### DIFF
--- a/alembic/versions/d0e1f2a3b4c5_add_backtest_params.py
+++ b/alembic/versions/d0e1f2a3b4c5_add_backtest_params.py
@@ -1,0 +1,119 @@
+"""add_backtest_params
+
+Store the evaluation parameters a backtest ran with (n_periods, n_splits, stride,
+n_retrain) on the backtest row. Legacy rows are reconstructed from their forecasts:
+one split per distinct last_seen_period, n_periods from the periods forecast per
+split, stride from the smallest gap between splits. n_retrain is 1 for every legacy
+row because the REST path never forwarded it.
+
+Revision ID: d0e1f2a3b4c5
+Revises: c9d0e1f2a3b4
+Create Date: 2026-09-08
+
+"""
+
+import logging
+from collections import defaultdict
+from collections.abc import Sequence
+from datetime import datetime
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d0e1f2a3b4c5"
+down_revision: str | Sequence[str] | None = "c9d0e1f2a3b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+PARAM_COLUMNS = ("n_periods", "n_splits", "stride", "n_retrain")
+# BacktestParams defaults when this migration was written. Only used for rows whose
+# forecasts do not allow the value to be derived, so they stay local to this file.
+DEFAULT_PARAMS = {"n_periods": 3, "n_splits": 7, "stride": 1, "n_retrain": 1}
+DEFAULT_WEEKLY_STRIDE = 4
+
+
+def _period_index(period_id: str) -> int | None:
+    """Ordinal of a period id in units of its own kind: months for YYYYMM, weeks for YYYYWnn / YYYYSunWnn."""
+    if "W" in period_id:
+        year, week = period_id.split("W")
+        return datetime.strptime(f"{year[:4]}-W{int(week):02d}-1", "%G-W%V-%u").toordinal() // 7
+    if len(period_id) == 6 and period_id.isdigit():
+        return int(period_id[:4]) * 12 + int(period_id[4:]) - 1
+    return None
+
+
+def derive_stride(split_ids: list[str]) -> int:
+    """Smallest gap between consecutive splits. A split that produced no forecasts leaves a wider gap."""
+    indices = [_period_index(split_id) for split_id in sorted(set(split_ids))]
+    if len(indices) < 2 or None in indices:
+        return DEFAULT_WEEKLY_STRIDE if split_ids and "W" in split_ids[0] else DEFAULT_PARAMS["stride"]
+    return min(b - a for a, b in zip(indices[:-1], indices[1:], strict=True))  # type: ignore[operator]
+
+
+def _derive_params(splits: list[tuple[str, int]]) -> dict[str, int]:
+    """Parameters for one backtest from its (last_seen_period, periods forecast) per split."""
+    if not splits:
+        return dict(DEFAULT_PARAMS)
+    split_ids = [split_id for split_id, _ in splits]
+    return {
+        "n_periods": max(n_periods for _, n_periods in splits),
+        "n_splits": len(split_ids),
+        "stride": derive_stride(split_ids),
+        "n_retrain": 1,
+    }
+
+
+def _backfill_backtest_params() -> None:
+    connection = op.get_bind()
+    missing = " OR ".join(f"{column} IS NULL OR {column} = 0" for column in PARAM_COLUMNS)
+    ids = [row.id for row in connection.execute(sa.text(f"SELECT id FROM backtest WHERE {missing}")).fetchall()]
+    if not ids:
+        return
+    splits: dict[int, list[tuple[str, int]]] = defaultdict(list)
+    for row in connection.execute(
+        sa.text(
+            "SELECT backtest_id, last_seen_period, COUNT(DISTINCT period) AS n_periods "
+            "FROM backtestforecast GROUP BY backtest_id, last_seen_period"
+        )
+    ).fetchall():
+        splits[row.backtest_id].append((row.last_seen_period, row.n_periods))
+    without_forecasts = [backtest_id for backtest_id in ids if backtest_id not in splits]
+    if without_forecasts:
+        logger.warning(f"Backtests {without_forecasts} have no forecasts; storing default parameters")
+    for backtest_id in ids:
+        params = _derive_params(splits.get(backtest_id, []))
+        connection.execute(
+            sa.text(
+                "UPDATE backtest SET n_periods = :n_periods, n_splits = :n_splits, "
+                "stride = :stride, n_retrain = :n_retrain WHERE id = :id"
+            ),
+            {**params, "id": backtest_id},
+        )
+
+
+def _has_column(table: str, column: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(col["name"] == column for col in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    """Add the parameter columns, reconstruct them for existing rows, then make them NOT NULL.
+
+    Startup runs a generic metadata migration before Alembic, so each column may
+    already exist with 0 in every row. Both shapes are backfilled the same way.
+    """
+    for column in PARAM_COLUMNS:
+        if not _has_column("backtest", column):
+            op.add_column("backtest", sa.Column(column, sa.Integer(), nullable=True))
+    _backfill_backtest_params()
+    for column in PARAM_COLUMNS:
+        op.alter_column("backtest", column, existing_type=sa.Integer(), nullable=False)
+
+
+def downgrade() -> None:
+    """Drop the parameter columns."""
+    for column in reversed(PARAM_COLUMNS):
+        op.drop_column("backtest", column)

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -425,6 +425,10 @@ class Evaluation(EvaluationBase):
             name=backtest_name,
             dataset_id=0,
             model_id=configured_model.id,
+            n_periods=backtest_params.n_periods,
+            n_splits=backtest_params.n_splits,
+            stride=backtest_params.stride,
+            n_retrain=backtest_params.n_retrain,
         )
 
         # Calculate number of periods based on dataset period type

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -385,7 +385,7 @@ class SessionWrapper:
     def get_configured_model_by_id_or_name(self, configured_model_id_or_name: int | str) -> ConfiguredModelDB:
         """Resolve a configured model from either its integer primary key or its name.
 
-        Exists so the public API can accept either shape on `POST /v1/crud/backtests/`
+        Exists so the public API can accept either shape on `POST /v1/analytics/create-backtest`
         without forcing callers to know that the DB column stores the name string.
         Integer ids raise ValueError if not found to stay consistent with the
         name-based lookup above.

--- a/chap_core/database/tables.py
+++ b/chap_core/database/tables.py
@@ -9,13 +9,18 @@ import numpy as np
 from sqlalchemy import JSON, Column
 from sqlmodel import Field, Relationship
 
+from chap_core.api_types import BacktestParams
 from chap_core.database.base_tables import DBModel, PeriodID
 from chap_core.database.dataset_tables import DataSet, DataSetInfo, DataSource, PydanticListType
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB, ModelConfiguration, ModelTemplateDB
 
 
-class BacktestBase(DBModel):
-    """Shared fields for every backtest shape (DB row, create request, read view)."""
+class BacktestBase(BacktestParams):
+    """Shared fields for every backtest shape (DB row, create request, read view).
+
+    The inherited `BacktestParams` fields hold the values the backtest actually ran
+    with, written by `run_backtest` after every override has been applied.
+    """
 
     dataset_id: int = Field(
         foreign_key="dataset.id", description="Foreign key to the `DataSet` the backtest evaluates against."

--- a/chap_core/rest_api/celery_tasks.py
+++ b/chap_core/rest_api/celery_tasks.py
@@ -34,7 +34,7 @@ class JobType(StrEnum):
     freely; only the string values are load-bearing.
     """
 
-    EVALUATION_LEGACY = "create_backtest"  # /v1/crud/backtests and /v1/analytics/create-backtest
+    EVALUATION_LEGACY = "create_backtest"  # /v1/analytics/create-backtest
     EVALUATION = "create_backtest_from_data"  # /v1/analytics/create-backtest-with-data/
     PREDICTION = "create_prediction"  # /v1/analytics/make-prediction
     DATASET = "create_dataset"  # /v1/analytics/make-dataset

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -91,11 +91,9 @@ class BacktestCreate(BacktestBase):
     """Request body for creating a backtest row directly (DB-level — typically the long path goes via `MakeBacktestRequest`)."""
 
     # Accept either the configured-model integer primary key or its string
-    # name. The underlying DB column (`BacktestBase.model_id`) is a string,
-    # but the `POST /v1/crud/backtests/` handler resolves an `int` to the
-    # corresponding name before persisting so the column stays consistent.
-    # See `chap_core.rest_api.v1.routers.crud.create_backtest` for the
-    # resolution path.
+    # name. The underlying DB column (`BacktestBase.model_id`) is a string;
+    # `run_backtest` resolves an `int` to the corresponding name before
+    # persisting so the column stays consistent.
     model_id: int | str = Field(  # type: ignore[assignment]
         description="Configured model to backtest: either the integer primary key or the canonical string name.",
     )
@@ -139,7 +137,9 @@ class MakeBacktestRequest(BacktestParams):
     """Request to backtest an already-imported dataset against a configured model."""
 
     name: str = Field(description="Human-friendly name for the resulting backtest row.")
-    model_id: str = Field(description="Canonical name of the configured model to backtest.")
+    model_id: int | str = Field(
+        description="Configured model to backtest: either the integer primary key or the canonical string name.",
+    )
     dataset_id: int = Field(description="Foreign key to the dataset the backtest evaluates against.")
 
 

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -19,14 +19,14 @@ from chap_core.database.dataset_tables import DataSetCreateInfo
 from chap_core.datatypes import HealthPopulationData, create_tsdataclass
 from chap_core.log_config import get_status_logger
 from chap_core.rest_api.data_models import BacktestCreate, FetchRequest, PredictionParams
-
-# from chap_core.rest_api.v1.routers.crud import BacktestCreate
 from chap_core.rest_api.worker_functions import WorkerConfig, harmonize_health_dataset
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 from chap_core.time_period import Month
 
 logger = logging.getLogger(__name__)
 status_logger = get_status_logger()
+# Single source of the backtest defaults; run_backtest must not define competing ones.
+_DEFAULT_PARAMS = BacktestParams()
 
 
 def convert_dicts_to_models(func):
@@ -78,8 +78,9 @@ def validate_and_filter_dataset_for_evaluation(
 def run_backtest(
     info: BacktestCreate,
     n_periods: int | None = None,
-    n_splits: int = 10,
-    stride: int = 1,
+    n_splits: int = _DEFAULT_PARAMS.n_splits,
+    stride: int = _DEFAULT_PARAMS.stride,
+    n_retrain: int = _DEFAULT_PARAMS.n_retrain,
     session: SessionWrapper | None = None,
 ):
     # NOTE: model_id arg from the user is actually the model's unique name identifier
@@ -103,6 +104,13 @@ def run_backtest(
     if n_periods is None:
         n_periods = _get_n_periods(dataset)
 
+    # Persist the resolved values, not the requested ones, so the row records
+    # what actually ran. This is the only place these fields are written.
+    info.n_periods = n_periods
+    info.n_splits = n_splits
+    info.stride = stride
+    info.n_retrain = n_retrain
+
     status_logger.info(f"Validating dataset with {len(list(dataset.locations()))} locations")
     dataset = validate_and_filter_dataset_for_evaluation(
         dataset,
@@ -122,6 +130,7 @@ def run_backtest(
         n_test_sets=n_splits,
         stride=stride,
         weather_provider=QuickForecastFetcher,
+        n_retrain=n_retrain,
     )
     last_train_period = dataset.period_range[-1]
     evaluation = Evaluation.from_samples_with_truth(predictions_list, last_train_period, configured_model, info=info)
@@ -288,6 +297,7 @@ def run_backtest_from_dataset(
         n_periods=backtest_params.n_periods,
         n_splits=backtest_params.n_splits,
         stride=backtest_params.stride,
+        n_retrain=backtest_params.n_retrain,
         session=session,
     )
     return result

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -392,9 +392,10 @@ async def create_backtest(
     job = worker.queue_db(
         wf.run_backtest,
         BacktestCreate(name=request.name, dataset_id=request.dataset_id, model_id=request.model_id),
-        request.n_periods,
-        request.n_splits,
-        request.stride,
+        n_periods=request.n_periods,
+        n_splits=request.n_splits,
+        stride=request.stride,
+        n_retrain=request.n_retrain,
         database_url=database_url,
         **{JOB_TYPE_KW: JobType.EVALUATION_LEGACY, JOB_NAME_KW: request.name},
     )

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -62,7 +62,6 @@ from chap_core.services import prediction_setup_service
 from chap_core.spatio_temporal_data.converters import observations_to_dataset
 
 from ...data_models import (
-    BacktestCreate,
     BacktestRead,
     BacktestUpdate,
     ConfiguredModelInfoRead,
@@ -375,43 +374,6 @@ async def get_metrics_csv(
         media_type="text/csv",
         headers={"Content-Disposition": f"attachment; filename=backtest_{backtest_id}_metrics.csv"},
     )
-
-
-@router.post(
-    "/backtests",
-    response_model=JobResponse,
-    tags=["Backtests"],
-    summary="Run a backtest against a stored dataset (legacy)",
-)
-async def create_backtest(
-    backtest: BacktestCreate,
-    database_url: str = Depends(get_database_url),
-    session: Session = Depends(get_session),
-):
-    """Legacy entrypoint for queueing a backtest against an already-imported dataset; prefer ``POST /v1/analytics/create-backtest`` for new integrations.
-
-    Accepts the model reference either as the configured-model name or its integer id —
-    the worker resolves both. Backtest runs in the background; the response gives a job
-    id, poll ``/v1/jobs/{id}`` (or ``/v1/jobs/{id}/evaluation_result``) for the
-    finished result. 404 if the dataset does not exist.
-    """
-    # `BacktestCreate.model_id` accepts either the configured-model name
-    # (what the DB column actually stores) or the integer primary key (what
-    # most API clients reach for because that's what GET /v1/crud/configured-models
-    # returns). The worker's run_backtest() normalises int -> name through
-    # `SessionWrapper.get_configured_model_by_id_or_name` before touching
-    # anything else, so the endpoint itself stays dumb and there's exactly
-    # one resolution point.
-    if session.get(DataSet, backtest.dataset_id) is None:
-        raise HTTPException(status_code=404, detail=f"Dataset {backtest.dataset_id} not found")
-    job = worker.queue_db(
-        wf.run_backtest,
-        backtest,
-        database_url=database_url,
-        **{JOB_TYPE_KW: JobType.EVALUATION_LEGACY, JOB_NAME_KW: backtest.name},
-    )
-
-    return JobResponse(id=job.id)
 
 
 @router.delete(

--- a/chap_core/simulation/naive_simulator.py
+++ b/chap_core/simulation/naive_simulator.py
@@ -88,7 +88,13 @@ class BacktestSimulator:
         periods = dataset_dims.time_periods[-(self._params.prediction_length + self._params.n_splits - 1) :]
         split_periods = periods[: self._params.n_splits]
         backtest = Backtest(
-            dataset=dataset, model_id="Naive Forecast", org_units=dataset_dims.locations, split_periods=split_periods
+            dataset=dataset,
+            model_id="Naive Forecast",
+            org_units=dataset_dims.locations,
+            split_periods=split_periods,
+            n_periods=self._params.prediction_length,
+            n_splits=self._params.n_splits,
+            stride=1,
         )
         forecasts = []
         for i in range(self._params.n_splits):

--- a/docs/contributor/cli_vs_rest_api.md
+++ b/docs/contributor/cli_vs_rest_api.md
@@ -50,7 +50,7 @@ capability today.
 
 | Capability | CLI | REST API | Shared module |
 |---|---|---|---|
-| Evaluate / backtest | `eval` | `POST /v1/analytics/create-backtest*`, `POST /v1/crud/backtests` | `chap_core.assessment.evaluation`, `rest_api/db_worker_functions.py` |
+| Evaluate / backtest | `eval` | `POST /v1/analytics/create-backtest*` | `chap_core.assessment.evaluation`, `rest_api/db_worker_functions.py` |
 | Forecast / predict | `forecast`, `multi-forecast` | `POST /v1/analytics/make-prediction`, `.../prediction-setups/{id}/run` | `chap_core.assessment.forecast` |
 | Dataset validate | `validate` | validated on `POST /v1/analytics/make-dataset` | `chap_core.services.dataset_validation` |
 | Dataset ingest / persist | — | `POST /v1/crud/datasets*`, `make-dataset` | `chap_core.database` (`DataSetManager`) |

--- a/docs/contributor/rest_api_and_database.md
+++ b/docs/contributor/rest_api_and_database.md
@@ -68,7 +68,7 @@ Standard CRUD endpoints for the core domain objects:
 - **Configured models** -- list, create, soft-delete configured models.
 - **Debug** -- create and get debug entries.
 
-Creating a backtest (`POST /v1/crud/backtests`) queues a Celery job and returns a
+Creating a backtest (`POST /v1/analytics/create-backtest`) queues a Celery job and returns a
 `JobResponse` with the task ID. The actual work happens in `db_worker_functions.py`,
 executed by the Celery worker.
 

--- a/tests/docker_db_flow.py
+++ b/tests/docker_db_flow.py
@@ -164,7 +164,7 @@ class IntegrationTest:
     def evaluate_model(self, model, dataset_id):
         logger.info(f"Making evaluation for {model}")
         job_id = self._post(
-            self._chap_url + "/v1/crud/backtests/",
+            self._chap_url + "/v1/analytics/create-backtest",
             json={"modelId": model, "datasetId": dataset_id, "name": f"integration_test: {model}"},
         )["id"]
         db_id = self.wait_for_db_id(job_id)

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -12,6 +12,7 @@ from sqlmodel import Session, select
 from chap_core.api_types import DataList, EvaluationEntry, PredictionEntry
 from chap_core.database.database import SessionWrapper
 from chap_core.database.dataset_manager import DataSetManager
+from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
 from chap_core.database.dataset_tables import DataSet, DataSetCreateInfo, DataSetWithObservations, ObservationBase
 from chap_core.database.model_spec_tables import ModelSpecRead
 from chap_core.database.tables import (
@@ -22,6 +23,7 @@ from chap_core.database.tables import (
     PredictionRead,
 )
 from chap_core.rest_api.data_models import (
+    BacktestCreate,
     BacktestFull,
     ConfiguredModelInfoRead,
     DatasetCreate,
@@ -32,6 +34,7 @@ from chap_core.rest_api.data_models import (
     ModelTemplateRead,
 )
 from chap_core.rest_api.app import app
+from chap_core.rest_api.db_worker_functions import run_backtest
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -99,7 +102,9 @@ def test_backtest_flow(celery_session_worker, clean_engine, dependency_overrides
         dataset_id = DataSetManager(session.session).save_dataset(
             DataSetCreateInfo(name="full_data", type="evaluation"), weekly_full_data, "polygons"
         )
-    response = client.post("/v1/crud/backtests", json={"datasetId": dataset_id, "modelId": "naive_model"})
+    response = client.post(
+        "/v1/analytics/create-backtest", json={"datasetId": dataset_id, "modelId": "naive_model", "name": "x"}
+    )
     assert response.status_code == 200, response.json()
     job_id = response.json()["id"]
     db_id = await_result_id(job_id)
@@ -301,7 +306,10 @@ def test_backtest_flow_from_request(
     celery_session_worker, clean_engine, dependency_overrides, anonymous_make_dataset_request
 ):
     db_id = _make_dataset(anonymous_make_dataset_request)
-    response = client.post("/v1/crud/backtests", json={"datasetId": db_id, "name": "testing", "modelId": "naive_model"})
+    response = client.post(
+        "/v1/analytics/create-backtest",
+        json={"datasetId": db_id, "name": "testing", "modelId": "naive_model", "nSplits": 2, "nRetrain": 2},
+    )
     assert response.status_code == 200, response.json()
     job_id = response.json()["id"]
     db_id = await_result_id(job_id, timeout=120)
@@ -318,6 +326,8 @@ def test_backtest_flow_from_request(
     data = response.json()
     assert data["name"] == "testing"
     assert data["created"] is not None
+    # The row records the resolved evaluation parameters.
+    assert (data["nPeriods"], data["nSplits"], data["stride"], data["nRetrain"]) == (3, 2, 1, 2)
 
 
 def test_compatible_backtests(clean_engine, dependency_overrides):
@@ -395,6 +405,7 @@ def test_get_backtest_bare_route_unknown_id_returns_404(clean_engine, dependency
         ("nSplits", -2),
         ("stride", 0),
         ("stride", -1),
+        ("nRetrain", 0),
     ],
 )
 def test_create_backtest_rejects_non_positive_params(field, value, clean_engine, dependency_overrides):
@@ -414,12 +425,8 @@ def test_create_backtest_rejects_non_positive_params(field, value, clean_engine,
 
 
 def test_create_backtest_unknown_dataset_returns_404(clean_engine, dependency_overrides):
-    """Both /v1/crud/backtests and /v1/analytics/create-backtest should reject
-    bogus dataset ids synchronously rather than queueing a job that fails later."""
-    crud_payload = {"name": "bogus", "datasetId": 999999, "modelId": "naive_model"}
-    response = client.post("/v1/crud/backtests", json=crud_payload)
-    assert response.status_code == 404, response.text
-
+    """/v1/analytics/create-backtest should reject bogus dataset ids synchronously
+    rather than queueing a job that fails later."""
     analytics_payload = {
         "name": "bogus",
         "datasetId": 999999,
@@ -430,6 +437,87 @@ def test_create_backtest_unknown_dataset_returns_404(clean_engine, dependency_ov
     }
     response = client.post("/v1/analytics/create-backtest", json=analytics_payload)
     assert response.status_code == 404, response.text
+
+
+def test_create_backtest_forwards_params_and_accepts_int_model_id(override_session, seeded_session, monkeypatch):
+    """The endpoint must hand every BacktestParams field, including n_retrain, to the worker
+    and accept the configured model's integer id as well as its name."""
+    from chap_core.rest_api.v1.routers import analytics
+
+    captured: dict = {}
+
+    class _FakeJob:
+        id = "captured-job"
+
+    class _CapturingWorker:
+        def queue_db(self, func, info, **kwargs):
+            captured["info"] = info
+            captured.update(kwargs)
+            return _FakeJob()
+
+    monkeypatch.setattr(analytics, "worker", _CapturingWorker())
+    model = seeded_session.exec(select(ConfiguredModelDB).where(ConfiguredModelDB.name == "naive_model")).first()
+    dataset_id = seeded_session.exec(select(DataSet.id)).first()
+
+    payload = {"name": "x", "datasetId": dataset_id, "modelId": model.id, "nSplits": 4, "nRetrain": 2}
+    response = client.post("/v1/analytics/create-backtest", json=payload)
+    assert response.status_code == 200, response.text
+    assert captured["info"].model_id == model.id
+    assert (captured["n_periods"], captured["n_splits"], captured["stride"], captured["n_retrain"]) == (3, 4, 1, 2)
+
+
+def test_run_backtest_persists_resolved_params(override_session, p_seeded_engine):
+    """The stored row records the parameters that actually ran: n_periods=None is
+    resolved from the (monthly) dataset, and an integer model id is resolved to its name."""
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_id = session.session.exec(select(DataSet.id)).first()
+        model = session.get_configured_model_by_id_or_name("naive_model")
+        backtest_id = run_backtest(
+            BacktestCreate(name="params", dataset_id=dataset_id, model_id=model.id),
+            n_periods=None,
+            n_splits=2,
+            stride=1,
+            n_retrain=2,
+            session=session,
+        )
+        row = session.session.get(Backtest, backtest_id)
+        assert (row.n_periods, row.n_splits, row.stride, row.n_retrain) == (3, 2, 1, 2)
+        assert row.model_id == "naive_model"
+
+    response = client.get(f"/v1/crud/backtests/{backtest_id}")
+    assert response.status_code == 200, response.text
+    read = BacktestRead.model_validate(response.json())
+    assert (read.n_periods, read.n_splits, read.stride, read.n_retrain) == (3, 2, 1, 2)
+
+
+def test_run_backtest_retrains_n_retrain_times(p_seeded_engine, monkeypatch):
+    """n_retrain must reach the evaluator, not just the row."""
+    from chap_core.predictor.naive_estimator import NaiveEstimator
+
+    class _CountingEstimator:
+        def __init__(self):
+            self.inner = NaiveEstimator()
+            self.train_calls = 0
+
+        def train(self, data):
+            self.train_calls += 1
+            return self.inner.train(data)
+
+    estimator = _CountingEstimator()
+    monkeypatch.setattr(SessionWrapper, "get_configured_model_with_code", lambda self, *args, **kwargs: estimator)
+
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_id = session.session.exec(select(DataSet.id)).first()
+        backtest_id = run_backtest(
+            BacktestCreate(name="retrain", dataset_id=dataset_id, model_id="naive_model"),
+            n_periods=3,
+            n_splits=4,
+            stride=1,
+            n_retrain=2,
+            session=session,
+        )
+        assert estimator.train_calls == 2
+        assert session.session.get(Backtest, backtest_id).n_retrain == 2
 
 
 def test_backtest_overlap_error_message_includes_id(clean_engine, dependency_overrides):

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -46,6 +46,10 @@ _COLUMNS_ADDED_BY_MIGRATIONS = [
     ("configuredmodeldb", "is_live"),
     ("prediction", "prediction_setup_id"),
     ("backtest", "max_horizon_distance"),
+    ("backtest", "n_periods"),
+    ("backtest", "n_splits"),
+    ("backtest", "stride"),
+    ("backtest", "n_retrain"),
 ]
 
 # Tables added by alembic migrations (not in the baseline schema).
@@ -145,6 +149,57 @@ def _create_baseline_schema(engine):
         for table, baseline_name, current_name in _COLUMNS_RENAMED_BY_MIGRATIONS:
             conn.execute(sa.text(f"ALTER TABLE {table} RENAME COLUMN {current_name} TO {baseline_name}"))
         conn.commit()
+
+
+def _insert_legacy_backtest(conn):
+    """Two backtests as a pre-parameter release stored them: one with forecasts on two
+    splits two months apart, three periods each, and one without forecasts."""
+    conn.execute(
+        sa.text(
+            "INSERT INTO configuredmodeldb (name, model_template_id, archived, uses_chapkit) "
+            "SELECT 'legacy_configured', id, false, false FROM modeltemplatedb WHERE name = 'legacy_model'"
+        )
+    )
+    conn.execute(sa.text("INSERT INTO dataset (name) VALUES ('legacy_dataset')"))
+    for name in ("legacy_backtest", "empty_backtest"):
+        conn.execute(
+            sa.text(
+                "INSERT INTO backtest (name, dataset_id, model_id, model_db_id) "
+                f"SELECT '{name}', d.id, 'legacy_configured', c.id FROM dataset d, configuredmodeldb c "
+                "WHERE d.name = 'legacy_dataset' AND c.name = 'legacy_configured'"
+            )
+        )
+    for last_seen, periods in (("202201", ("202202", "202203", "202204")), ("202203", ("202204", "202205", "202206"))):
+        for period in periods:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO backtestforecast (backtest_id, period, org_unit, values, last_train_period, last_seen_period) "
+                    f"SELECT id, '{period}', 'ou', '[1.0]', '202201', '{last_seen}' FROM backtest WHERE name = 'legacy_backtest'"
+                )
+            )
+
+
+def _migration_module(revision: str):
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    return ScriptDirectory.from_config(Config(str(ALEMBIC_INI))).get_revision(revision).module
+
+
+@pytest.mark.parametrize(
+    "split_ids,expected",
+    [
+        (["202301", "202212"], 1),  # month across a year boundary
+        (["202401", "202403", "202405"], 2),
+        (["2020W53", "2021W01"], 1),  # 53-week ISO year
+        (["2022W01", "2022W05", "2022W13"], 4),  # a skipped split leaves a wider gap
+        (["2022W01"], 4),  # single weekly split falls back to the weekly default
+        (["202201"], 1),
+    ],
+)
+def test_backtest_params_migration_derives_stride(split_ids, expected):
+    module = _migration_module("d0e1f2a3b4c5")
+    assert module.derive_stride(split_ids) == expected
 
 
 @pytest.mark.slow
@@ -249,9 +304,23 @@ class TestAlembicMigrations:
                 "UPDATE configuredmodeldb SET is_live = true",
             ]:
                 conn.execute(sa.text(statement))
+            _insert_legacy_backtest(conn)
+            for column in ("n_periods", "n_splits", "stride", "n_retrain"):
+                conn.execute(sa.text(f"ALTER TABLE backtest ADD COLUMN {column} INTEGER"))
+                conn.execute(sa.text(f"UPDATE backtest SET {column} = 0"))
             conn.commit()
 
         command.upgrade(alembic_cfg, "head")
+
+        with engine.connect() as conn:
+            row = conn.execute(
+                sa.text("SELECT n_periods, n_splits, stride, n_retrain FROM backtest WHERE name = 'legacy_backtest'")
+            ).one()
+            assert tuple(row) == (3, 2, 2, 1)
+            row = conn.execute(
+                sa.text("SELECT n_periods, n_splits, stride, n_retrain FROM backtest WHERE name = 'empty_backtest'")
+            ).one()
+            assert tuple(row) == (3, 7, 1, 1)
 
         with engine.connect() as conn:
             row = conn.execute(


### PR DESCRIPTION
## Summary

Backtest rows now store the four evaluation parameters (`n_periods`, `n_splits`, `stride`, `n_retrain`) as the values that actually ran, exposed on `BacktestRead`. `n_retrain` was silently dropped on both REST paths and always ran as 1; it is now threaded through `run_backtest`. `POST /v1/crud/backtests` is removed in favour of `POST /v1/analytics/create-backtest`, which now also accepts the configured model's integer id, so there is one endpoint and one set of defaults for backtesting a stored dataset.

Jira: CLIM-1052 (under CLIM-980, benchmarking).

## Changes

- `BacktestBase` inherits `BacktestParams`, so `Backtest` gets four NOT NULL columns and `BacktestRead` / `BacktestCreate` carry the same fields. `BacktestParams` stays the single definition and source of defaults.
- `run_backtest` accepts `n_retrain`, passes it to the evaluator, drops its competing `n_splits=10` default, and writes the resolved values onto the row after the `ewars_plus` and derive-from-dataset overrides. `run_backtest_from_dataset` forwards `n_retrain`; its weekly `stride=4` override already runs before the call, so the stored stride is the resolved one.
- CLI evaluations (`Evaluation.create`) and the naive simulator record their parameters as well.
- Alembic revision `d0e1f2a3b4c5`: adds the columns and reconstructs legacy rows from their forecasts (`n_splits` from distinct split points, `n_periods` from periods per split, `stride` from the smallest gap between splits, `n_retrain=1` since the REST path never forwarded it). Handles the generic startup migration having already created the columns with `0`. Rows without forecasts get the `BacktestParams` defaults with a warning.
- `MakeBacktestRequest.model_id` is `int | str`; `crud/backtests` removed; docs and the integration flow test updated.

## Notes for review

- Checked `dhis2-chap/chap-frontend` at `44aa78b` (2026-09-08): `POST /v1/crud/backtests` appears only as the generated client method `createBacktestV1CrudBacktestsPost` with no callers; the modeling app uses `create-backtest-with-data/` only, and the e2e fixtures only GET `/v1/crud/backtests/{id}/info`, which stays. Regenerating the client will drop the dead method. Job-type strings are unchanged.
- API and worker are separate images. `run_backtest` gains a keyword argument and `BacktestCreate` gains fields in the pickled task payload, so workers should roll before API pods.
- `create-backtest` still does not apply the weekly `stride=4` bump that `create-backtest-with-data` does; pre-existing and left as is.

## Test plan

- New: endpoint forwards all four params and accepts an integer `modelId`; `run_backtest` persists resolved values (`n_periods=None` resolves to 3 on monthly data, integer model id resolves to name); `n_retrain=2` retrains twice; `nRetrain=0` is rejected; migration derives stride across month and 53-week ISO year boundaries; docker-backed migration test backfills a legacy backtest to `(3, 2, 2, 1)` and one without forecasts to the defaults.
- `make lint` passes. `make test` passes except `tests/test_celery.py` and `tests/integration/rest_api/test_jobs_routes.py`, which fail at collection on this machine's redis server (pre-existing, identical on master).
