### PR TITLE
ci: skip full test suite for docs-only and inert PRs (CLIM-903)

### DIFF
--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master, dev ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build-docs.yml
+++ b/.github/workflows/ci-build-docs.yml
@@ -2,9 +2,9 @@ name: build_docs
 
 on:
   push:
-    branches: [ master, dev, docs/sphinx-to-mkdocs ]
+    branches: [ master, docs/sphinx-to-mkdocs ]
   pull_request:
-    branches: [ master, dev ]
+    branches: [ master ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-lint-code-style.yml
+++ b/.github/workflows/ci-lint-code-style.yml
@@ -2,9 +2,9 @@ name: Code Formatting & Linting
 
 on:
   push:
-    branches: ["master", "dev"]
+    branches: ["master"]
   pull_request:
-    branches: ["master", "dev"]
+    branches: ["master"]
 
 permissions:
   contents: read

--- a/.github/workflows/ci-lint-code-style.yml
+++ b/.github/workflows/ci-lint-code-style.yml
@@ -1,9 +1,17 @@
 name: Code Formatting & Linting
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ["master", "dev"]
+  pull_request:
+    branches: ["master", "dev"]
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -35,9 +35,10 @@ jobs:
         with:
           predicate-quantifier: every
           filters: |
+            # predicate-quantifier applies to every filter, so a filter that should
+            # match any of several paths must be written as one union pattern.
             docs:
-              - 'docs/**'
-              - 'mkdocs.yml'
+              - '{docs/**,mkdocs.yml}'
             code:
               - '**'
               - '!docs/**'

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -5,9 +5,9 @@ name: Test-all (docker, external models, etc)
 
 on:
   push:
-    branches: ["master", "dev"]
+    branches: ["master"]
   pull_request:
-    branches: ["master", "dev"]
+    branches: ["master"]
 
 permissions:
   contents: read
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   # Classifies the PR so the expensive job below can be skipped or reduced.
-  # On push events every output is true so master and dev always get the full run.
+  # On push events every output is true so master always gets the full run.
   # The job names below are required checks in the master ruleset, so gating
   # happens with a job-level `if` (reported as skipped, which satisfies the
   # ruleset) rather than a workflow-level paths filter (left pending, blocks merge).

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -13,8 +13,46 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Classifies the PR so the expensive job below can be skipped or reduced.
+  # On push events every output is true so master and dev always get the full run.
+  # The job names below are required checks in the master ruleset, so gating
+  # happens with a job-level `if` (reported as skipped, which satisfies the
+  # ruleset) rather than a workflow-level paths filter (left pending, blocks merge).
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      docs: ${{ github.event_name != 'pull_request' || steps.filter.outputs.docs == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          predicate-quantifier: every
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
+            code:
+              - '**'
+              - '!docs/**'
+              - '!mkdocs.yml'
+              - '!charts/**'
+              - '!README.md'
+              - '!CLAUDE.md'
+              - '!LICENSE'
+              - '!.github/CODEOWNERS'
+              - '!.github/dependabot.yml'
+              - '!.github/**/*.md'
+
   test-all:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true'
     env:
       REDIS_HOST: localhost
 
@@ -81,7 +119,11 @@ jobs:
         with:
           default: "3.13"
           command: ""
-      - name: Run
+      - name: Run full suite
+        if: needs.changes.outputs.code == 'true'
         run: |
           cp .env.example .env
           make test-all
+      - name: Run slow documentation tests
+        if: needs.changes.outputs.code != 'true'
+        run: make test-docs-slow

--- a/.github/workflows/ci-test-external-models.yml
+++ b/.github/workflows/ci-test-external-models.yml
@@ -21,13 +21,14 @@ jobs:
   # Classifies the PR so the expensive job below can be skipped or reduced.
   # On push events every output is true so master always gets the full run.
   # The job names below are required checks in the master ruleset, so gating
-  # happens with a job-level `if` (reported as skipped, which satisfies the
-  # ruleset) rather than a workflow-level paths filter (left pending, blocks merge).
+  # happens on the steps: a workflow-level paths filter, or a job-level `if` on
+  # a matrix job, leaves the required check pending and blocks the merge.
   changes:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
       docs: ${{ github.event_name != 'pull_request' || steps.filter.outputs.docs == 'true' }}
+      tests: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' || steps.filter.outputs.docs == 'true' }}
     steps:
       - uses: actions/checkout@v7
       - id: filter
@@ -53,7 +54,6 @@ jobs:
 
   test-all:
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true'
     env:
       REDIS_HOST: localhost
 
@@ -107,15 +107,19 @@ jobs:
       #     large-packages: false
       #     swap-storage: true
       - name: Install uv
+        if: needs.changes.outputs.tests == 'true'
         uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python ${{ matrix.python-version }}
+        if: needs.changes.outputs.tests == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y libbz2-dev liblzma-dev
           uv python install ${{ matrix.python-version }}
       - name: Install the project
+        if: needs.changes.outputs.tests == 'true'
         run: uv sync --dev
       - name: Install pyenv
+        if: needs.changes.outputs.tests == 'true'
         uses: gabrielfalcao/pyenv-action@v18
         with:
           default: "3.13"
@@ -126,5 +130,5 @@ jobs:
           cp .env.example .env
           make test-all
       - name: Run slow documentation tests
-        if: needs.changes.outputs.code != 'true'
+        if: needs.changes.outputs.tests == 'true' && needs.changes.outputs.code != 'true'
         run: make test-docs-slow

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -28,9 +28,10 @@ jobs:
         with:
           predicate-quantifier: every
           filters: |
+            # predicate-quantifier applies to every filter, so a filter that should
+            # match any of several paths must be written as one union pattern.
             docs:
-              - 'docs/**'
-              - 'mkdocs.yml'
+              - '{docs/**,mkdocs.yml}'
             code:
               - '**'
               - '!docs/**'

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
       docs: ${{ github.event_name != 'pull_request' || steps.filter.outputs.docs == 'true' }}
+      tests: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' || steps.filter.outputs.docs == 'true' }}
     steps:
       - uses: actions/checkout@v7
       - id: filter
@@ -44,9 +45,11 @@ jobs:
               - '!.github/dependabot.yml'
               - '!.github/**/*.md'
 
+  # Steps rather than the job are gated: the expanded matrix names are required
+  # checks in the master ruleset, and a job skipped by a job-level `if` never
+  # expands its matrix, so those checks would stay pending and block the merge.
   test:
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,14 +58,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Set up environment variables
+        if: needs.changes.outputs.tests == 'true'
         run: |
           echo "Service Account Private Key is set"
       - name: Install uv
+        if: needs.changes.outputs.tests == 'true'
         uses: astral-sh/setup-uv@v10.0.1
       - name: Set up Python ${{ matrix.python-version }}
+        if: needs.changes.outputs.tests == 'true'
         run: uv python install ${{ matrix.python-version }}
       - name: Install the project
+        if: needs.changes.outputs.tests == 'true'
         run: uv sync --dev
       - name: Run pytest
+        if: needs.changes.outputs.tests == 'true'
         run: |
           uv run pytest -n auto --dist loadfile

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -9,8 +9,43 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Keep this block identical to the one in ci-test-external-models.yml;
+  # tests/test_ci_workflows.py checks that they do not drift apart.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      docs: ${{ github.event_name != 'pull_request' || steps.filter.outputs.docs == 'true' }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          predicate-quantifier: every
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
+            code:
+              - '**'
+              - '!docs/**'
+              - '!mkdocs.yml'
+              - '!charts/**'
+              - '!README.md'
+              - '!CLAUDE.md'
+              - '!LICENSE'
+              - '!.github/CODEOWNERS'
+              - '!.github/dependabot.yml'
+              - '!.github/**/*.md'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-test-python-install.yml
+++ b/.github/workflows/ci-test-python-install.yml
@@ -2,9 +2,9 @@ name: Build and test
 
 on:
   push:
-    branches: ["master", "dev"]
+    branches: ["master"]
   pull_request:
-    branches: ["master", "dev"]
+    branches: ["master"]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ docker compose -f compose.yml -f compose.ewars.yml up -d
 ## Deploy on Kubernetes
 
 CHAP can be deployed on Kubernetes using our helm chart which can be found [here](./charts/chap).
+

--- a/README.md
+++ b/README.md
@@ -72,4 +72,3 @@ docker compose -f compose.yml -f compose.ewars.yml up -d
 ## Deploy on Kubernetes
 
 CHAP can be deployed on Kubernetes using our helm chart which can be found [here](./charts/chap).
-

--- a/docs/contributor/testing.md
+++ b/docs/contributor/testing.md
@@ -69,7 +69,7 @@ make test-all
 
 To see what is actually being run, you can see what is specified under `test-all` in the Makefile.
 
-On pull requests, CI classifies the changed files before running the test jobs. PRs that only touch `docs/` or `mkdocs.yml` run the fast documentation tests and `make test-docs-slow` instead of the full `test-all` suite. PRs that only touch `README.md`, `CLAUDE.md`, `LICENSE`, `charts/` or `.github` metadata skip the test jobs entirely. Any other file, including `.env.example` and the workflows themselves, triggers the full run. The filter lives in the `changes` job of the workflows under `.github/workflows/`; before adding a path to it, check that no test reads that file (`tests/test_ci_workflows.py` enforces this).
+On pull requests, CI classifies the changed files before running the test jobs. PRs that only touch `docs/` or `mkdocs.yml` run the fast documentation tests and `make test-docs-slow` instead of the full `test-all` suite. PRs that only touch `README.md`, `CLAUDE.md`, `LICENSE`, `charts/` or `.github` metadata skip every test step, so the test jobs finish in seconds. Any other file, including `.env.example` and the workflows themselves, triggers the full run. The filter lives in the `changes` job of the workflows under `.github/workflows/`; before adding a path to it, check that no test reads that file (`tests/test_ci_workflows.py` enforces this).
 
 
 ## Some more details about integration tests

--- a/docs/contributor/testing.md
+++ b/docs/contributor/testing.md
@@ -69,6 +69,8 @@ make test-all
 
 To see what is actually being run, you can see what is specified under `test-all` in the Makefile.
 
+On pull requests, CI classifies the changed files before running the test jobs. PRs that only touch `docs/` or `mkdocs.yml` run the fast documentation tests and `make test-docs-slow` instead of the full `test-all` suite. PRs that only touch `README.md`, `CLAUDE.md`, `LICENSE`, `charts/` or `.github` metadata skip the test jobs entirely. Any other file, including `.env.example` and the workflows themselves, triggers the full run. The filter lives in the `changes` job of the workflows under `.github/workflows/`; before adding a path to it, check that no test reads that file (`tests/test_ci_workflows.py` enforces this).
+
 
 ## Some more details about integration tests
 

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -123,3 +123,15 @@ def test_changes_job_uses_every_quantifier(workflow):
 )
 def test_pr_classification(workflow, changed_files, expected):
     assert _classify(workflow, changed_files) == expected
+
+
+@pytest.mark.parametrize("workflow", GATED_WORKFLOWS)
+def test_required_jobs_are_gated_on_steps_not_on_the_job(workflow):
+    """A job-level `if` on a matrix job never expands the matrix, so the expanded job names
+    required by the master ruleset would stay pending. Only steps may be conditional."""
+    jobs = yaml.safe_load((REPO_ROOT / workflow).read_text())["jobs"]
+    for name, job in jobs.items():
+        if name == "changes":
+            continue
+        assert "if" not in job, f"{workflow} job {name!r} must gate its steps, not the job"
+        assert any("if" in step for step in job["steps"]), f"{workflow} job {name!r} has no gated step"

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -65,3 +65,61 @@ def test_changes_job_is_identical_across_workflows():
     first, *rest = [_changes_job(workflow) for workflow in GATED_WORKFLOWS]
     for other in rest:
         assert other == first
+
+
+def _expand_braces(pattern):
+    """picomatch brace lists ({a,b}) as used in the filters; nested braces are not needed."""
+    if "{" not in pattern:
+        return [pattern]
+    head, rest = pattern.split("{", 1)
+    alternatives, tail = rest.split("}", 1)
+    return [head + alternative + tail for alternative in alternatives.split(",")]
+
+
+def _matches(path, pattern):
+    return any(pathlib.PurePosixPath(path).full_match(expanded) for expanded in _expand_braces(pattern))
+
+
+def _classify(workflow, changed_files):
+    """Mirror dorny/paths-filter with predicate-quantifier: every.
+
+    A file matches a filter when it matches every one of its patterns; a filter
+    output is true when at least one changed file matches it.
+    """
+    result = {}
+    for name, patterns in _filters(workflow).items():
+        result[name] = any(
+            all(
+                (not _matches(path, pattern[1:])) if pattern.startswith("!") else _matches(path, pattern)
+                for pattern in patterns
+            )
+            for path in changed_files
+        )
+    return result
+
+
+@pytest.mark.parametrize("workflow", GATED_WORKFLOWS)
+def test_changes_job_uses_every_quantifier(workflow):
+    steps = _changes_job(workflow)["steps"]
+    (filter_step,) = [step for step in steps if step.get("id") == "filter"]
+    assert filter_step["with"]["predicate-quantifier"] == "every"
+
+
+@pytest.mark.parametrize("workflow", GATED_WORKFLOWS)
+@pytest.mark.parametrize(
+    ("changed_files", "expected"),
+    [
+        (["README.md"], {"code": False, "docs": False}),
+        (["LICENSE", ".github/CODEOWNERS", ".github/pull_request_template.md"], {"code": False, "docs": False}),
+        (["charts/chap/values.yaml"], {"code": False, "docs": False}),
+        (["docs/chap-cli/evaluation-workflow.md"], {"code": False, "docs": True}),
+        (["mkdocs.yml"], {"code": False, "docs": True}),
+        (["docs/index.md", "README.md"], {"code": False, "docs": True}),
+        (["chap_core/api.py"], {"code": True, "docs": False}),
+        ([".env.example"], {"code": True, "docs": False}),
+        ([".github/workflows/ci-test-python-install.yml"], {"code": True, "docs": False}),
+        (["docs/index.md", "chap_core/api.py"], {"code": True, "docs": True}),
+    ],
+)
+def test_pr_classification(workflow, changed_files, expected):
+    assert _classify(workflow, changed_files) == expected

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,67 @@
+"""The CI path filter must only treat files as inert that no test or build step reads.
+
+The `changes` job in the PR workflows skips the test jobs when a PR touches only the
+paths negated in its `code` filter. If a test later starts reading one of those files,
+a PR changing it would land untested, so the list is checked against tests/ and the
+Makefile here. The block is also duplicated across workflows and must not drift.
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+GATED_WORKFLOWS = [
+    ".github/workflows/ci-test-external-models.yml",
+    ".github/workflows/ci-test-python-install.yml",
+]
+
+# Negated patterns that are gated by their own workflow or tests rather than being inert.
+COVERED_ELSEWHERE = {"docs/**", "mkdocs.yml", "charts/**"}
+
+
+def _changes_job(workflow):
+    content = yaml.safe_load((REPO_ROOT / workflow).read_text())
+    return content["jobs"]["changes"]
+
+
+def _filters(workflow):
+    steps = _changes_job(workflow)["steps"]
+    (filter_step,) = [step for step in steps if step.get("id") == "filter"]
+    return yaml.safe_load(filter_step["with"]["filters"])
+
+
+def _inert_paths(workflow):
+    negated = [pattern[1:] for pattern in _filters(workflow)["code"] if pattern.startswith("!")]
+    return [pattern for pattern in negated if pattern not in COVERED_ELSEWHERE]
+
+
+def _readers():
+    """Tracked test files plus the Makefile; local virtualenvs under fixtures are hidden dirs."""
+    files = [
+        path
+        for path in (REPO_ROOT / "tests").rglob("*.py")
+        if not any(part.startswith(".") for part in path.relative_to(REPO_ROOT).parts)
+    ]
+    files.append(REPO_ROOT / "Makefile")
+    return [path for path in files if path != pathlib.Path(__file__).resolve()]
+
+
+@pytest.mark.parametrize("workflow", GATED_WORKFLOWS)
+def test_inert_paths_are_not_read_by_tests_or_makefile(workflow):
+    for inert in _inert_paths(workflow):
+        needle = inert.split("*")[0]
+        assert needle, f"pattern {inert!r} is too broad to check by name"
+        readers = [str(path.relative_to(REPO_ROOT)) for path in _readers() if needle in path.read_text()]
+        assert not readers, (
+            f"{inert!r} is skipped by the CI path filter in {workflow} but is referenced by "
+            f"{readers}; either remove it from the filter or drop the reference"
+        )
+
+
+def test_changes_job_is_identical_across_workflows():
+    first, *rest = [_changes_job(workflow) for workflow in GATED_WORKFLOWS]
+    for other in rest:
+        assert other == first


### PR DESCRIPTION
## Summary

CLIM-903. A PR today runs the full 14-minute `test-all` job plus three `test` legs regardless of what changed. This adds a `changes` job to the two test workflows that classifies the PR and gates the test steps on it:

- docs-only (`docs/**`, `mkdocs.yml`): `test` legs run (they contain the fast documentation tests) and `test-all` runs `make test-docs-slow` instead of the full suite.
- inert (`README.md`, `CLAUDE.md`, `LICENSE`, `charts/**`, `.github/CODEOWNERS`, `.github/dependabot.yml`, `.github/**/*.md`): every step after checkout in `test` and `test-all` is skipped, so the jobs finish in seconds.
- anything else, including `.env.example` (read by `test-all` and `tests/test_compose_deployment.py`) and the workflows themselves: full run, as before.
- push events to master: full run, as before.

The classification is of the whole PR diff against master, not of the latest commit. A PR that touches code and README runs everything.

The gate is on the steps, not the jobs, and the job names and matrix ids are unchanged. The expanded matrix names are required checks in the master ruleset; a workflow-level `paths` filter, or a job-level `if` on a matrix job, leaves those checks pending and blocks the merge, because a skipped job never expands its matrix. The ruleset needs no edit.

Also included:

- `concurrency` with `cancel-in-progress` on the four PR workflows, so a new push cancels the previous run.
- The lint workflow now triggers on push only for master, like the others, instead of running twice per PR.
- The retired `dev` branch is dropped from the triggers of the four workflows touched here.
- `tests/test_ci_workflows.py` locks in: the `docs`/`code` classification of representative PR diffs under the action's `every` quantifier, that no path treated as inert is referenced by a test or the Makefile, that the `changes` job is identical across workflows, and that the required jobs carry no job-level `if`.
- A short paragraph in `docs/contributor/testing.md`.

## Verification

This PR edits workflows, so it takes the full-run path: all six required checks run and the `changes` job is visible. `actionlint` passes locally. Cancel-in-progress is confirmed: each push cancelled the previous head's runs.

The skip and docs-only paths cannot be shown on this PR: the filter classifies the whole PR diff, and this diff includes the workflows. Verify after merge by opening a README-only PR (expect the `test` legs and `test-all` to complete in seconds with all steps after checkout skipped, PR mergeable) and a docs-only PR (expect `test-all` to run only the "Run slow documentation tests" step).

The two `chore` commits on the branch were a first attempt at that verification and cancel each other out; squash merge drops them.

## Follow-ups (not in this PR)

- `ci-test-python-install.yml` hardcodes `runs-on: ubuntu-latest`, so the windows and macos legs are three identical Ubuntu runs. Fixing it changes required check names and needs a ruleset edit.
- `astral-sh/setup-uv` is used without `enable-cache`, costing about 55 s per leg.
- `make test-all` runs pytest sequentially; xdist is already a dev dependency.