### PR TITLE
refactor: extract backtest evaluation details into a BacktestSpecification

### DIFF
--- a/alembic/versions/f2a3b4c5d6e1_extract_backtest_specification.py
+++ b/alembic/versions/f2a3b4c5d6e1_extract_backtest_specification.py
@@ -1,0 +1,192 @@
+"""extract_backtest_specification
+
+Move the evaluation parameters (n_periods, n_splits, stride, n_retrain,
+future_weather_provider) off the backtest row and onto a deduplicated
+``backtestspecification`` row that backtests point at, so that two backtests sharing a
+specification are comparable by construction.
+
+Existing rows are grouped by (dataset_id, and every one of those parameters) into one
+specification each, and the specification's org_units is the union of the org_units of
+the backtests that map to it. The provider is part of the key because two backtests
+given different climate covariates for their forecast windows are not comparable, even
+when every other parameter matches.
+
+Two things about the migrated data are worth knowing, because neither can be
+recovered here:
+
+- The parameters of rows predating d0e1f2a3b4c5 were reconstructed from their
+  forecasts rather than recorded. A split whose predictor returned nothing left no
+  forecasts and is therefore invisible, so such a backtest was reconstructed with a
+  lower n_splits and a wider stride. Two backtests that genuinely ran the same setup
+  can carry different parameters and will land on different specifications. Legacy
+  grouping is fragmented, and fragmented specifically for the models that misbehaved.
+- backtest.org_units is accumulated from what the model produced, not from the
+  filtered input, so for a model that dropped org units the copied set under-reports.
+  The union across the backtests sharing a specification is the best estimate
+  available: an org unit any of them forecast must have been in the input.
+  Specifications created from now on resolve org_units from the filtered dataset.
+
+Revision ID: f2a3b4c5d6e1
+Revises: e1f2a3b4c5d6
+Create Date: 2026-09-09
+
+"""
+
+import json
+import logging
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f2a3b4c5d6e1"
+down_revision: str | Sequence[str] | None = "e1f2a3b4c5d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+# The parameters as of this revision, with the SQL type each column carries. A parameter
+# added to BacktestParams later joins the specification's uniqueness key automatically,
+# but still needs its own migration to move the column and rebuild the constraint; this
+# list stays frozen at what was here.
+PARAM_TYPES = {
+    "n_periods": sa.Integer(),
+    "n_splits": sa.Integer(),
+    "stride": sa.Integer(),
+    "n_retrain": sa.Integer(),
+    "future_weather_provider": sa.String(),
+}
+PARAM_COLUMNS = tuple(PARAM_TYPES)
+# BacktestParams defaults when this migration was written. Only reached on downgrade,
+# for specifications that no backtest points at, so they stay local to this file.
+DEFAULT_PARAMS = {"n_periods": 3, "n_splits": 7, "stride": 1, "n_retrain": 1, "future_weather_provider": "climatology"}
+FOREIGN_KEY_NAME = "fk_backtest_specification_id_backtestspecification"
+
+
+def _has_table(table: str) -> bool:
+    return table in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table: str, column: str) -> bool:
+    return any(col["name"] == column for col in sa.inspect(op.get_bind()).get_columns(table))
+
+
+def _foreign_key_name(table: str, referred_table: str) -> str | None:
+    """Name of the constraint linking `table` to `referred_table`, whichever way it was created.
+
+    create_all names the constraint by the Postgres default rather than by
+    FOREIGN_KEY_NAME, so matching on the referred table is what makes this work on both
+    a database that reached the new schema through create_all and one that did not.
+    """
+    for fk in sa.inspect(op.get_bind()).get_foreign_keys(table):
+        if fk["referred_table"] == referred_table:
+            return fk["name"]
+    return None
+
+
+def _org_units(value) -> list[str]:
+    """Read a JSON org_units column, which comes back parsed or as text depending on the driver."""
+    if value is None:
+        return []
+    return json.loads(value) if isinstance(value, str) else list(value)
+
+
+def _backfill_specifications() -> None:
+    """Create one specification per distinct (dataset, parameters) and point the backtests at it."""
+    connection = op.get_bind()
+    columns = ", ".join(PARAM_COLUMNS)
+    rows = connection.execute(
+        sa.text(f"SELECT id, dataset_id, org_units, {columns} FROM backtest ORDER BY id")
+    ).fetchall()
+    if not rows:
+        return
+
+    org_units_by_key: dict[tuple[int, ...], set[str]] = {}
+    for row in rows:
+        key = (row.dataset_id, *(getattr(row, column) for column in PARAM_COLUMNS))
+        org_units_by_key.setdefault(key, set()).update(_org_units(row.org_units))
+
+    logger.info(f"Extracting {len(org_units_by_key)} backtest specifications from {len(rows)} backtests")
+    for key, org_units in org_units_by_key.items():
+        params = dict(zip(PARAM_COLUMNS, key[1:], strict=True))
+        specification_id = connection.execute(
+            sa.text(
+                f"INSERT INTO backtestspecification (dataset_id, {columns}, org_units) "
+                f"VALUES (:dataset_id, :{', :'.join(PARAM_COLUMNS)}, :org_units) RETURNING id"
+            ),
+            {"dataset_id": key[0], **params, "org_units": json.dumps(sorted(org_units))},
+        ).scalar_one()
+        connection.execute(
+            sa.text(
+                "UPDATE backtest SET specification_id = :specification_id WHERE dataset_id = :dataset_id AND "
+                + " AND ".join(f"{column} = :{column}" for column in PARAM_COLUMNS)
+            ),
+            {"specification_id": specification_id, "dataset_id": key[0], **params},
+        )
+
+
+def upgrade() -> None:
+    """Create the specification table, move the parameters onto it, then drop them from backtest.
+
+    Runs after e1f2a3b4c5d6, which put future_weather_provider on the backtest row; this
+    revision moves it onto the specification with the rest of the parameters.
+
+    Startup runs a generic metadata migration and create_all before Alembic, so the
+    table and the specification_id column may already exist, the latter filled with 0
+    rather than NULL. Both shapes end up the same way.
+    """
+    if not _has_table("backtestspecification"):
+        op.create_table(
+            "backtestspecification",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("dataset_id", sa.Integer(), nullable=False),
+            *(sa.Column(column, type_, nullable=False) for column, type_ in PARAM_TYPES.items()),
+            sa.Column("org_units", sa.JSON(), nullable=True),
+            sa.ForeignKeyConstraint(["dataset_id"], ["dataset.id"]),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(*(("dataset_id",) + PARAM_COLUMNS), name="uq_backtestspecification_params"),
+        )
+    if not _has_column("backtest", "specification_id"):
+        op.add_column("backtest", sa.Column("specification_id", sa.Integer(), nullable=True))
+
+    # The parameter columns are still there exactly when the backtests have not been
+    # moved yet; create_all never drops columns, so it cannot have removed them. The
+    # drop is guarded per column so that a database missing some of them, however it got
+    # there, still ends up with none of them on backtest.
+    if _has_column("backtest", "n_periods"):
+        _backfill_specifications()
+    for column in PARAM_COLUMNS:
+        if _has_column("backtest", column):
+            op.drop_column("backtest", column)
+
+    op.alter_column("backtest", "specification_id", existing_type=sa.Integer(), nullable=False)
+    if _foreign_key_name("backtest", "backtestspecification") is None:
+        op.create_foreign_key(FOREIGN_KEY_NAME, "backtest", "backtestspecification", ["specification_id"], ["id"])
+
+
+def downgrade() -> None:
+    """Copy the parameters back onto backtest and drop the specification table.
+
+    Lossy: a specification that no backtest points at has nowhere to go and is
+    dropped with the table, and the org_units it resolved are lost.
+    """
+    for column, type_ in PARAM_TYPES.items():
+        op.add_column("backtest", sa.Column(column, type_, nullable=True))
+    op.execute(
+        "UPDATE backtest SET "
+        + ", ".join(f"{column} = s.{column}" for column in PARAM_COLUMNS)
+        + " FROM backtestspecification s WHERE backtest.specification_id = s.id"
+    )
+    for column, default in DEFAULT_PARAMS.items():
+        op.execute(
+            sa.text(f"UPDATE backtest SET {column} = :default WHERE {column} IS NULL").bindparams(default=default)
+        )
+    for column, type_ in PARAM_TYPES.items():
+        op.alter_column("backtest", column, existing_type=type_, nullable=False)
+    foreign_key = _foreign_key_name("backtest", "backtestspecification")
+    if foreign_key is not None:
+        op.drop_constraint(foreign_key, "backtest", type_="foreignkey")
+    op.drop_column("backtest", "specification_id")
+    op.drop_table("backtestspecification")

--- a/alembic/versions/f2a3b4c5d6e1_extract_backtest_specification.py
+++ b/alembic/versions/f2a3b4c5d6e1_extract_backtest_specification.py
@@ -144,7 +144,7 @@ def upgrade() -> None:
             sa.Column("dataset_id", sa.Integer(), nullable=False),
             *(sa.Column(column, type_, nullable=False) for column, type_ in PARAM_TYPES.items()),
             sa.Column("org_units", sa.JSON(), nullable=True),
-            sa.ForeignKeyConstraint(["dataset_id"], ["dataset.id"]),
+            sa.ForeignKeyConstraint(["dataset_id"], ["dataset.id"], ondelete="CASCADE"),
             sa.PrimaryKeyConstraint("id"),
             sa.UniqueConstraint(*(("dataset_id",) + PARAM_COLUMNS), name="uq_backtestspecification_params"),
         )

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -311,8 +311,9 @@ class Evaluation(EvaluationBase):
         specification: BacktestSpecification | None = None,
     ) -> "Evaluation":
         info.created = datetime.datetime.now()
-        # The parameters live on the specification now, so they must not be passed to
-        # Backtest, where they are read-only properties reading through the link.
+        # The parameters live on the specification now and are computed fields on
+        # Backtest, reading through the link. Excluding them here keeps that explicit;
+        # passing them would be silently ignored rather than rejected.
         backtest = Backtest(
             **info.model_dump(exclude=set(BacktestParams.model_fields))
             | {"model_db_id": configured_model.id, "model_template_version": configured_model.model_template.version}

--- a/chap_core/assessment/evaluation.py
+++ b/chap_core/assessment/evaluation.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -19,14 +19,7 @@ import pandera.pandas as pa
 import xarray as xr
 from packaging.version import Version
 
-from chap_core.assessment.weather_providers import (
-    DEFAULT_WEATHER_PROVIDER_ID,
-    LEGACY_WEATHER_PROVIDER_ID,
-)
-
-if TYPE_CHECKING:
-    from chap_core.api_types import BacktestParams
-
+from chap_core.api_types import BacktestParams
 from chap_core.assessment.flat_representations import (
     FlatForecasts,
     FlatObserved,
@@ -34,10 +27,14 @@ from chap_core.assessment.flat_representations import (
     convert_backtest_to_flat_forecasts,
     max_horizon_distance,
 )
+from chap_core.assessment.weather_providers import (
+    DEFAULT_WEATHER_PROVIDER_ID,
+    LEGACY_WEATHER_PROVIDER_ID,
+)
 from chap_core.data import DataSet as _DataSet
 from chap_core.database.dataset_tables import DataSet, Observation, ObservationBase
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
-from chap_core.database.tables import Backtest, BacktestForecast
+from chap_core.database.tables import Backtest, BacktestForecast, BacktestSpecification
 from chap_core.datatypes import SamplesWithTruth
 from chap_core.external.model_configuration import ModelTemplateConfigV2
 from chap_core.rest_api.data_models import BacktestCreate
@@ -284,8 +281,8 @@ class Evaluation(EvaluationBase):
     def future_weather_provider(self) -> str:
         """Id of the future-weather provider these results were produced with.
 
-        The backtest row is the single source of truth, so database persistence
-        and NetCDF exports cannot disagree.
+        The backtest's specification is the single source of truth, so database
+        persistence and NetCDF exports cannot disagree.
         """
         return self._backtest.future_weather_provider
 
@@ -311,11 +308,20 @@ class Evaluation(EvaluationBase):
         info: BacktestCreate,
         historical_observations: list[Observation] | None = None,
         historical_context_periods: int = 0,
+        specification: BacktestSpecification | None = None,
     ) -> "Evaluation":
         info.created = datetime.datetime.now()
+        # The parameters live on the specification now, so they must not be passed to
+        # Backtest, where they are read-only properties reading through the link.
         backtest = Backtest(
-            **info.model_dump()
+            **info.model_dump(exclude=set(BacktestParams.model_fields))
             | {"model_db_id": configured_model.id, "model_template_version": configured_model.model_template.version}
+        )
+        # Callers persisting the backtest pass the deduplicated row resolved against the
+        # database. The CLI paths build an in-memory evaluation only, so a detached
+        # specification carrying the same parameters is enough for them.
+        backtest.specification = specification or BacktestSpecification(
+            dataset_id=info.dataset_id, **info.model_dump(include=set(BacktestParams.model_fields))
         )
         org_units = set()
         split_points = set()
@@ -393,7 +399,7 @@ class Evaluation(EvaluationBase):
         configured_model: ConfiguredModelDB,
         estimator,
         dataset: _DataSet,
-        backtest_params: "BacktestParams",
+        backtest_params: BacktestParams,
         backtest_name: str = "evaluation",
         historical_context_years: int = 6,
     ) -> "Evaluation":
@@ -689,7 +695,13 @@ class Evaluation(EvaluationBase):
             split_periods=split_periods,
             forecasts=[],
             dataset_id=0,
-            future_weather_provider=str(ds.attrs["future_weather_provider"]),
+            # The stored file carries no parameters beyond the provider, so this is a
+            # detached placeholder that keeps the parameter properties readable.
+            specification=BacktestSpecification(
+                dataset_id=0,
+                org_units=org_units,
+                future_weather_provider=str(ds.attrs["future_weather_provider"]),
+            ),
         )
 
         forecasts_df = pd.DataFrame(cast("pd.DataFrame", flat_data.forecasts))

--- a/chap_core/database/database.py
+++ b/chap_core/database/database.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import Session, SQLModel, create_engine, select
 from sqlmodel.sql.expression import SelectOfScalar
 
+from chap_core.api_types import BacktestParams
 from chap_core.log_config import is_debug_mode
 from chap_core.predictor.naive_estimator import NaiveEstimator
 
@@ -28,7 +29,7 @@ from .model_templates_and_config_tables import (
     compute_configuration_digest,
     drifted_template_content_fields,
 )
-from .tables import Backtest, Prediction, PredictionSamplesEntry
+from .tables import Backtest, BacktestSpecification, Prediction, PredictionSamplesEntry
 
 logger = logging.getLogger(__name__)
 engine = None
@@ -504,6 +505,41 @@ class SessionWrapper:
     def add_backtest(self, backtest: Backtest) -> None:
         self.session.add(backtest)
         self.session.commit()
+
+    def get_or_create_backtest_specification(
+        self, dataset_id: int, params: BacktestParams, org_units: list[str]
+    ) -> BacktestSpecification:
+        """Resolve the single specification row for these parameters, creating it if it is new.
+
+        Specifications are deduplicated so that backtests sharing one are comparable.
+        Concurrent backtest jobs can reach this at the same time, so losing the race on
+        the unique constraint is expected and re-reads the winner's row rather than
+        failing the backtest.
+        """
+        params_by_name = params.model_dump()
+
+        def existing() -> BacktestSpecification | None:
+            query = select(BacktestSpecification).where(BacktestSpecification.dataset_id == dataset_id)
+            for name, value in params_by_name.items():
+                query = query.where(getattr(BacktestSpecification, name) == value)
+            return self.session.exec(query).first()
+
+        found = existing()
+        if found is not None:
+            return found
+
+        specification = BacktestSpecification(dataset_id=dataset_id, org_units=org_units, **params_by_name)
+        self.session.add(specification)
+        try:
+            self.session.commit()
+        except sqlalchemy.exc.IntegrityError:
+            self.session.rollback()
+            found = existing()
+            if found is None:
+                raise
+            return found
+        self.session.refresh(specification)
+        return specification
 
     def add_predictions(
         self,

--- a/chap_core/database/tables.py
+++ b/chap_core/database/tables.py
@@ -26,8 +26,13 @@ class BacktestSpecification(BacktestParams, table=True):
     """
 
     id: int | None = Field(primary_key=True, default=None, description="Primary key.")  # type: ignore[assignment]
+    # A specification outlives the backtests pointing at it, and a run that fails after
+    # resolving one leaves it with no backtest at all, so it cascades from the dataset:
+    # without that, those leftover rows would keep an otherwise-empty dataset undeletable.
     dataset_id: int = Field(
-        foreign_key="dataset.id", description="Foreign key to the `DataSet` the specification evaluates against."
+        foreign_key="dataset.id",
+        ondelete="CASCADE",
+        description="Foreign key to the `DataSet` the specification evaluates against.",
     )
     dataset: DataSet = Relationship()
     org_units: list[str] = Field(

--- a/chap_core/database/tables.py
+++ b/chap_core/database/tables.py
@@ -6,7 +6,8 @@ import datetime
 from typing import Optional
 
 import numpy as np
-from sqlalchemy import JSON, Column
+from pydantic import computed_field
+from sqlalchemy import JSON, Column, UniqueConstraint
 from sqlmodel import Field, Relationship
 
 from chap_core.api_types import BacktestParams
@@ -15,11 +16,42 @@ from chap_core.database.dataset_tables import DataSet, DataSetInfo, DataSource, 
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB, ModelConfiguration, ModelTemplateDB
 
 
-class BacktestBase(BacktestParams):
+class BacktestSpecification(BacktestParams, table=True):
+    """The evaluation setup a backtest ran under: a dataset plus the parameters that decide what is scored.
+
+    Rows are deduplicated on the dataset plus every `BacktestParams` field, and are
+    immutable, so two backtests pointing at the same row are comparable by construction.
+    Resolve one with `SessionWrapper.get_or_create_backtest_specification` rather than
+    constructing it directly, or identical setups end up on separate rows.
+    """
+
+    id: int | None = Field(primary_key=True, default=None, description="Primary key.")  # type: ignore[assignment]
+    dataset_id: int = Field(
+        foreign_key="dataset.id", description="Foreign key to the `DataSet` the specification evaluates against."
+    )
+    dataset: DataSet = Relationship()
+    org_units: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSON),
+        description=(
+            "Org units the evaluation actually runs over: the dataset's units minus those the evaluation filter "
+            "drops for having no target data left in the training window. Derived from the parameters above, so "
+            "it is a resolved snapshot rather than part of the uniqueness key."
+        ),
+    )
+    # Every field of BacktestParams is part of what makes two backtests comparable, so
+    # the key is derived rather than listed: a parameter added there joins the key
+    # instead of silently letting two different setups share a row. Adding one still
+    # needs a migration to widen the constraint in the database.
+    __table_args__ = (
+        UniqueConstraint("dataset_id", *BacktestParams.model_fields, name="uq_backtestspecification_params"),
+    )
+
+
+class BacktestBase(DBModel):
     """Shared fields for every backtest shape (DB row, create request, read view).
 
-    The inherited `BacktestParams` fields hold the values the backtest actually ran
-    with, written by `run_backtest` after every override has been applied.
+    The evaluation parameters live on the linked `BacktestSpecification`, not here.
     """
 
     dataset_id: int = Field(
@@ -68,6 +100,11 @@ class Backtest(_BacktestRead, table=True):
     """Persisted backtest row. Owns its forecasts, metrics, and (optionally) a `PredictionSetup`."""
 
     id: int | None = Field(primary_key=True, default=None, description="Primary key.")  # type: ignore[assignment]
+    specification_id: int = Field(
+        foreign_key="backtestspecification.id",
+        description="Foreign key to the `BacktestSpecification` this backtest ran under.",
+    )
+    specification: BacktestSpecification = Relationship()
     dataset: DataSet = Relationship()
     forecasts: list["BacktestForecast"] = Relationship(back_populates="backtest", cascade_delete=True)
     metrics: list["BacktestMetric"] = Relationship(back_populates="backtest", cascade_delete=True)
@@ -86,6 +123,31 @@ class Backtest(_BacktestRead, table=True):
         sa_relationship_kwargs={"uselist": False},
         cascade_delete=True,
     )
+
+    @computed_field(description=BacktestParams.model_fields["n_periods"].description)  # type: ignore[prop-decorator]
+    @property
+    def n_periods(self) -> int:
+        return self.specification.n_periods
+
+    @computed_field(description=BacktestParams.model_fields["n_splits"].description)  # type: ignore[prop-decorator]
+    @property
+    def n_splits(self) -> int:
+        return self.specification.n_splits
+
+    @computed_field(description=BacktestParams.model_fields["stride"].description)  # type: ignore[prop-decorator]
+    @property
+    def stride(self) -> int:
+        return self.specification.stride
+
+    @computed_field(description=BacktestParams.model_fields["n_retrain"].description)  # type: ignore[prop-decorator]
+    @property
+    def n_retrain(self) -> int:
+        return self.specification.n_retrain
+
+    @computed_field(description=BacktestParams.model_fields["future_weather_provider"].description)  # type: ignore[prop-decorator]
+    @property
+    def future_weather_provider(self) -> str:
+        return self.specification.future_weather_provider
 
     @property
     def prediction_setup_id(self) -> int | None:
@@ -196,8 +258,13 @@ class PredictionSetupRead(DBModel):
 OldBacktestRead = _BacktestRead
 
 
-class BacktestRead(_BacktestRead):
-    """API read shape for a `Backtest`. Same fields as the DB row plus the joined dataset / model / setup links."""
+class BacktestRead(BacktestParams, _BacktestRead):
+    """API read shape for a `Backtest`. Same fields as the DB row plus the joined dataset / model / setup links.
+
+    The `BacktestParams` fields are read off the linked `BacktestSpecification` through
+    `Backtest`'s properties of the same name, so the wire shape is unchanged by the
+    specification extraction. Callers must eager-load `Backtest.specification`.
+    """
 
     dataset: DataSetMeta = Field(description="Slim dataset summary the backtest evaluated against.")
     aggregate_metrics: dict[str, float] = Field(

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -105,8 +105,12 @@ class ImportSummaryResponse(DBModel):
     rejected: list[ValidationError] = Field(description="One row per rejected observation, with the reason.")
 
 
-class BacktestCreate(BacktestBase):
-    """Request body for creating a backtest row directly (DB-level — typically the long path goes via `MakeBacktestRequest`)."""
+class BacktestCreate(BacktestParams, BacktestBase):
+    """Request body for creating a backtest row directly (DB-level — typically the long path goes via `MakeBacktestRequest`).
+
+    Carries the evaluation parameters flat; `run_backtest` resolves them into the
+    deduplicated `BacktestSpecification` the persisted row points at.
+    """
 
     # Accept either the configured-model integer primary key or its string
     # name. The underlying DB column (`BacktestBase.model_id`) is a string;

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -107,8 +107,9 @@ def run_backtest(
     if n_periods is None:
         n_periods = _get_n_periods(dataset)
 
-    # Persist the resolved values, not the requested ones, so the row records
-    # what actually ran. This is the only place these fields are written.
+    # Carry the resolved values, not the requested ones, so everything downstream of
+    # here sees what actually ran. The persisted copy is the specification resolved
+    # below; these keep `info` consistent for job metadata and logging.
     info.n_periods = n_periods
     info.n_splits = n_splits
     info.stride = stride

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -123,6 +123,19 @@ def run_backtest(
         n_splits=n_splits,
         stride=stride,
     )
+    # Resolved once the dataset is filtered: which org units survive is part of what
+    # makes two backtests comparable, and the filter above reads the parameters.
+    specification = session.get_or_create_backtest_specification(
+        dataset_id=info.dataset_id,
+        params=BacktestParams(
+            n_periods=n_periods,
+            n_splits=n_splits,
+            stride=stride,
+            n_retrain=n_retrain,
+            future_weather_provider=future_weather_provider,
+        ),
+        org_units=list(dataset.locations()),
+    )
     train_set, test_generator = train_test_generator(
         dataset,
         prediction_length=n_periods,
@@ -142,7 +155,9 @@ def run_backtest(
         n_retrain=n_retrain,
     )
     last_train_period = dataset.period_range[-1]
-    evaluation = Evaluation.from_samples_with_truth(predictions_list, last_train_period, configured_model, info=info)
+    evaluation = Evaluation.from_samples_with_truth(
+        predictions_list, last_train_period, configured_model, info=info, specification=specification
+    )
     backtest = evaluation.to_backtest()
     backtest.model_db_id = configured_model.id
     session.add_backtest(backtest)

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -223,6 +223,7 @@ def get_compatible_backtests(
         select(Backtest)
         .where(Backtest.id.in_(ids))  # type: ignore[union-attr, attr-defined]
         .options(
+            selectinload(Backtest.specification),  # type: ignore[arg-type]
             selectinload(Backtest.dataset).defer(DataSetTable.geojson),  # type: ignore[arg-type]
             selectinload(Backtest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
         )

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -283,6 +283,7 @@ async def get_backtests(session: Session = Depends(get_session)):
     """
     backtests = session.exec(
         select(Backtest).options(
+            selectinload(Backtest.specification),  # type: ignore[arg-type]
             selectinload(Backtest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
             selectinload(Backtest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
             selectinload(Backtest.prediction_setup),  # type: ignore[arg-type]
@@ -334,6 +335,7 @@ def get_backtest_info(backtest_id: Annotated[int, Path(alias="backtestId")], ses
         select(Backtest)
         .where(Backtest.id == backtest_id)
         .options(
+            selectinload(Backtest.specification),  # type: ignore[arg-type]
             selectinload(Backtest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
             selectinload(Backtest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
             selectinload(Backtest.prediction_setup),  # type: ignore[arg-type]
@@ -431,6 +433,7 @@ async def update_backtest(
         select(Backtest)
         .where(Backtest.id == backtest_id)
         .options(
+            selectinload(Backtest.specification),  # type: ignore[arg-type]
             selectinload(Backtest.dataset).defer(DataSet.geojson),  # type: ignore[arg-type]
             selectinload(Backtest.configured_model).selectinload(ConfiguredModelDB.model_template),  # type: ignore[arg-type]
             selectinload(Backtest.prediction_setup),  # type: ignore[arg-type]

--- a/chap_core/simulation/naive_simulator.py
+++ b/chap_core/simulation/naive_simulator.py
@@ -13,7 +13,7 @@ from numpy.random import normal, poisson
 
 from chap_core.assessment.flat_representations import max_horizon_distance
 from chap_core.database.dataset_tables import DataSet, Observation
-from chap_core.database.tables import Backtest, BacktestForecast
+from chap_core.database.tables import Backtest, BacktestForecast, BacktestSpecification
 
 
 class SimulationParams(pydantic.BaseModel):
@@ -92,9 +92,13 @@ class BacktestSimulator:
             model_id="Naive Forecast",
             org_units=dataset_dims.locations,
             split_periods=split_periods,
-            n_periods=self._params.prediction_length,
-            n_splits=self._params.n_splits,
-            stride=1,
+            specification=BacktestSpecification(
+                dataset_id=dataset.id,
+                org_units=dataset_dims.locations,
+                n_periods=self._params.prediction_length,
+                n_splits=self._params.n_splits,
+                stride=1,
+            ),
         )
         forecasts = []
         for i in range(self._params.n_splits):

--- a/tests/evaluation/conftest.py
+++ b/tests/evaluation/conftest.py
@@ -8,7 +8,14 @@ import numpy as np
 from chap_core.assessment.flat_representations import FlatObserved, FlatForecasts
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.database.dataset_tables import DataSetWithObservations, Observation, DataSet
-from chap_core.database.tables import BacktestRead, OldBacktestRead, BacktestForecast, Backtest, BacktestMetric
+from chap_core.database.tables import (
+    BacktestRead,
+    OldBacktestRead,
+    BacktestForecast,
+    Backtest,
+    BacktestMetric,
+    BacktestSpecification,
+)
 from chap_core.simulation.naive_simulator import DatasetDimensions, AdditiveSimulator, BacktestSimulator
 
 
@@ -190,6 +197,7 @@ def backtest(dataset, forecasts):
         dataset=dataset,
         model_id="Test Model",
         model_db_id=1,
+        specification=BacktestSpecification(dataset_id=1),
         name="Test Backtest",
         created=None,
         aggregate_metrics={},
@@ -206,6 +214,7 @@ def backtest_weeks(dataset_weeks, forecasts_weeks):
         dataset=dataset_weeks,
         model_id="Test Model",
         model_db_id=1,
+        specification=BacktestSpecification(dataset_id=1),
         name="Test Backtest",
         created=None,
         aggregate_metrics={},
@@ -223,6 +232,7 @@ def backtest_weeks_large(dataset_weeks_large, forecasts_weeks_large):
         dataset=dataset_weeks_large,
         model_id="Test Model Large",
         model_db_id=1,
+        specification=BacktestSpecification(dataset_id=1),
         name="Large Test Backtest",
         created=None,
         aggregate_metrics={},
@@ -240,6 +250,7 @@ def backtest_empty(dataset):
         dataset=dataset,
         model_id="Test Model",
         model_db_id=1,
+        specification=BacktestSpecification(dataset_id=1),
         name="Empty Test Backtest",
         created=None,
         aggregate_metrics={},

--- a/tests/evaluation/test_causal_plot.py
+++ b/tests/evaluation/test_causal_plot.py
@@ -8,7 +8,7 @@ import pytest
 from chap_core.assessment.causal_plot import plot_counterfactual
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.database.dataset_tables import DataSet, Observation
-from chap_core.database.tables import Backtest, BacktestForecast
+from chap_core.database.tables import Backtest, BacktestForecast, BacktestSpecification
 
 _EXAMPLE_DATA = Path(__file__).parent.parent.parent / "example_data"
 
@@ -50,6 +50,7 @@ def _make_vietnam_evaluation(df: pd.DataFrame, periods: list[str], geojson: str,
         dataset=dataset,
         model_id="test",
         model_db_id=1,
+        specification=BacktestSpecification(dataset_id=1),
         name="vietnam_test",
         created=None,
         aggregate_metrics={},

--- a/tests/evaluation/test_weather_provider_persistence.py
+++ b/tests/evaluation/test_weather_provider_persistence.py
@@ -21,7 +21,7 @@ def test_non_default_provider_round_trips(backtest, tmp_path):
     evaluation.to_file(filepath=filepath, model_name="TestModel", model_version="1.0.0")
 
     observed_backtest = Evaluation.from_file(filepath).to_backtest()
-    observed_backtest.future_weather_provider = "observed"
+    observed_backtest.specification.future_weather_provider = "observed"
     observed_filepath = tmp_path / "eval_observed.nc"
     Evaluation(observed_backtest).to_file(filepath=observed_filepath, model_name="TestModel", model_version="1.0.0")
 
@@ -33,15 +33,15 @@ def test_legacy_file_is_attributed_to_observed_weather(old_backtest_file):
     assert Evaluation.from_file(old_backtest_file).future_weather_provider == LEGACY_WEATHER_PROVIDER_ID
 
 
-def test_from_backtest_reads_the_provider_off_the_row(backtest):
+def test_from_backtest_reads_the_provider_off_the_specification(backtest):
     """An `observed` backtest must not convert into a `climatology` evaluation."""
-    backtest.future_weather_provider = "observed"
+    backtest.specification.future_weather_provider = "observed"
 
     assert Evaluation.from_backtest(backtest).future_weather_provider == "observed"
 
 
-def test_from_backtest_exports_the_row_provider(backtest, tmp_path):
-    backtest.future_weather_provider = "observed"
+def test_from_backtest_exports_the_specification_provider(backtest, tmp_path):
+    backtest.specification.future_weather_provider = "observed"
     filepath = tmp_path / "eval.nc"
 
     Evaluation.from_backtest(backtest).to_file(filepath=filepath, model_name="TestModel", model_version="1.0.0")
@@ -51,7 +51,7 @@ def test_from_backtest_exports_the_row_provider(backtest, tmp_path):
 
 def test_from_file_sets_the_provider_on_the_backtest(backtest, tmp_path):
     """to_backtest() on a loaded evaluation must carry the provider it was read with."""
-    backtest.future_weather_provider = "observed"
+    backtest.specification.future_weather_provider = "observed"
     filepath = tmp_path / "eval.nc"
     Evaluation.from_backtest(backtest).to_file(filepath=filepath, model_name="TestModel", model_version="1.0.0")
 
@@ -60,9 +60,9 @@ def test_from_file_sets_the_provider_on_the_backtest(backtest, tmp_path):
     assert loaded.to_backtest().future_weather_provider == "observed"
 
 
-def test_the_row_is_the_single_source_of_truth(backtest):
+def test_the_specification_is_the_single_source_of_truth(backtest):
     """A to_backtest()/from_backtest() round trip must not revert the provider."""
-    backtest.future_weather_provider = "observed"
+    backtest.specification.future_weather_provider = "observed"
     evaluation = Evaluation(backtest)
 
     assert evaluation.future_weather_provider == "observed"

--- a/tests/integration/rest_api/conftest.py
+++ b/tests/integration/rest_api/conftest.py
@@ -8,7 +8,14 @@ from sqlmodel import select, Session
 
 from chap_core.api_types import FeatureCollectionModel, FeatureModel
 from chap_core.database.dataset_tables import DataSet, Observation, DataSource
-from chap_core.database.tables import Prediction, Backtest, BacktestForecast, BacktestMetric, PredictionSamplesEntry
+from chap_core.database.tables import (
+    Prediction,
+    Backtest,
+    BacktestForecast,
+    BacktestMetric,
+    BacktestSpecification,
+    PredictionSamplesEntry,
+)
 from chap_core.rest_api.app import app
 from chap_core.rest_api.v1.routers.analytics import BacktestParams
 from chap_core.rest_api.v1.routers.dependencies import get_session
@@ -242,11 +249,17 @@ def _generate_forecasts(
 
 
 @pytest.fixture
-def backtest(dataset, forecasts):
+def backtest_specification(dataset, org_units, backtest_params):
+    return BacktestSpecification(dataset=dataset, org_units=org_units, **backtest_params.model_dump())
+
+
+@pytest.fixture
+def backtest(dataset, forecasts, backtest_specification):
     return Backtest(
         name="test backtest",
         dataset_id=1,
         dataset=dataset,
+        specification=backtest_specification,
         forecasts=forecasts,
         model_id="naive_model",
         aggregate_metrics={"MAE": 1.5},
@@ -255,11 +268,15 @@ def backtest(dataset, forecasts):
 
 
 @pytest.fixture
-def backtest_with_nans(dataset_with_nans, forecasts_2):
+def backtest_with_nans(dataset_with_nans, forecasts_2, org_units, backtest_params):
     return Backtest(
         name="test_backtest_with_nans",
         dataset_id=1,
         dataset=dataset_with_nans,
+        # A distinct dataset, so a distinct specification even though the parameters match.
+        specification=BacktestSpecification(
+            dataset=dataset_with_nans, org_units=org_units, **backtest_params.model_dump()
+        ),
         forecasts=forecasts_2,
         model_id="naive_model",
         aggregate_metrics={"MAE": 1.5},

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -18,6 +18,7 @@ from chap_core.database.model_spec_tables import ModelSpecRead
 from chap_core.database.tables import (
     Backtest,
     BacktestRead,
+    BacktestSpecification,
     Prediction,
     PredictionInfo,
     PredictionRead,
@@ -337,7 +338,12 @@ def test_compatible_backtests(clean_engine, dependency_overrides):
         session.commit()
 
         ds_id = dataset.id
+        # One specification for all three: same dataset, same (default) parameters.
+        specification = BacktestSpecification(dataset_id=ds_id)
+        session.add(specification)
+        session.commit()
         backtest = Backtest(
+            specification=specification,
             dataset_id=ds_id,
             name="testing",
             model_id="naive_model",
@@ -346,6 +352,7 @@ def test_compatible_backtests(clean_engine, dependency_overrides):
             split_periods=["202201", "202202"],
         )
         matching = Backtest(
+            specification=specification,
             dataset_id=ds_id,
             name="testing2",
             model_id="chap_auto_ewars",
@@ -354,6 +361,7 @@ def test_compatible_backtests(clean_engine, dependency_overrides):
             split_periods=["202202", "202203"],
         )
         non_matching = Backtest(
+            specification=specification,
             dataset_id=ds_id,
             name="testing3",
             model_id="auto_regressive_monthly",
@@ -491,7 +499,7 @@ def test_run_backtest_persists_resolved_params(override_session, p_seeded_engine
 
 
 def test_run_backtest_persists_the_future_weather_provider(override_session, p_seeded_engine):
-    """A non-default provider must reach the row, or a look-ahead run is filed as climatology."""
+    """A non-default provider must reach the specification, or a look-ahead run is filed as climatology."""
     with SessionWrapper(p_seeded_engine) as session:
         dataset_id = session.session.exec(select(DataSet.id)).first()
         model = session.get_configured_model_by_id_or_name("naive_model")
@@ -508,6 +516,135 @@ def test_run_backtest_persists_the_future_weather_provider(override_session, p_s
     response = client.get(f"/v1/crud/backtests/{backtest_id}")
     assert response.status_code == 200, response.text
     assert BacktestRead.model_validate(response.json()).future_weather_provider == "observed"
+
+
+def _run(session, name, dataset_id, **params):
+    return run_backtest(
+        BacktestCreate(name=name, dataset_id=dataset_id, model_id="naive_model"), session=session, **params
+    )
+
+
+def test_backtests_with_the_same_parameters_share_one_specification(p_seeded_engine):
+    """Deduplication is what makes "these two results are comparable" structural."""
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_id = session.session.exec(select(DataSet.id)).first()
+        params = {"n_periods": 3, "n_splits": 2, "stride": 1, "n_retrain": 1}
+        first = session.session.get(Backtest, _run(session, "first", dataset_id, **params))
+        second = session.session.get(Backtest, _run(session, "second", dataset_id, **params))
+
+        assert first.specification_id == second.specification_id
+        assert (first.n_periods, first.n_splits, first.stride, first.n_retrain) == (3, 2, 1, 1)
+
+
+def test_every_backtest_parameter_is_part_of_the_uniqueness_key():
+    """A parameter that is not in the key would let two incomparable setups share a row.
+
+    Adding a field to BacktestParams therefore widens this constraint on its own, but
+    the database still needs a migration to widen it there too.
+    """
+    from chap_core.api_types import BacktestParams
+    from chap_core.database.tables import BacktestSpecification
+
+    constraint = next(
+        c
+        for c in BacktestSpecification.__table__.constraints
+        if getattr(c, "name", None) == "uq_backtestspecification_params"
+    )
+    assert {column.name for column in constraint.columns} == {"dataset_id", *BacktestParams.model_fields}
+
+
+def test_differing_parameters_produce_different_specifications(p_seeded_engine):
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_id = session.session.exec(select(DataSet.id)).first()
+        two_splits = session.session.get(Backtest, _run(session, "two", dataset_id, n_periods=3, n_splits=2))
+        three_splits = session.session.get(Backtest, _run(session, "three", dataset_id, n_periods=3, n_splits=3))
+
+        assert two_splits.specification_id != three_splits.specification_id
+        assert (two_splits.n_splits, three_splits.n_splits) == (2, 3)
+
+
+def test_differing_weather_providers_produce_different_specifications(p_seeded_engine):
+    """Results scored against different climate covariates are not comparable, so the
+    provider is part of the key just like the split parameters are."""
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_id = session.session.exec(select(DataSet.id)).first()
+        params = {"n_periods": 3, "n_splits": 2, "stride": 1, "n_retrain": 1}
+        climatology = session.session.get(
+            Backtest, _run(session, "climatology", dataset_id, future_weather_provider="climatology", **params)
+        )
+        observed = session.session.get(
+            Backtest, _run(session, "observed", dataset_id, future_weather_provider="observed", **params)
+        )
+
+        assert climatology.specification_id != observed.specification_id
+        assert observed.specification.future_weather_provider == "observed"
+
+
+def test_differing_datasets_produce_different_specifications(p_seeded_engine):
+    """The dataset is part of the key: identical parameters over different data are not comparable."""
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_ids = session.session.exec(select(DataSet.id).order_by(DataSet.id)).all()
+        params = {"n_periods": 3, "n_splits": 2, "stride": 1, "n_retrain": 1}
+        specification_ids = {
+            session.session.get(Backtest, _run(session, f"ds{dataset_id}", dataset_id, **params)).specification_id
+            for dataset_id in dataset_ids[:2]
+        }
+
+        assert len(specification_ids) == 2
+
+
+def test_specification_org_units_are_the_ones_left_after_filtering(p_seeded_engine):
+    """org_units belongs on the specification because the filter that produces it reads
+    the parameters: a longer evaluation window shortens the training window and can drop
+    an org unit whose only target values sit in the part that is now evaluated."""
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_id = session.session.exec(select(DataSet.id).where(DataSet.name == "dataset_with_nans")).first()
+        dataset = DataSetManager(session.session).to_dataset(dataset_id)
+        backtest = session.session.get(Backtest, _run(session, "filtered", dataset_id, n_periods=2, n_splits=2))
+
+        assert set(backtest.specification.org_units) < set(dataset.locations())
+        assert set(backtest.specification.org_units) == set(backtest.org_units)
+
+
+def test_backtest_read_still_exposes_the_parameters_flat(override_session, p_seeded_engine):
+    """The parameters moved behind a relationship; the wire shape must not have moved with them."""
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_id = session.session.exec(select(DataSet.id)).first()
+        backtest_id = _run(session, "read", dataset_id, n_periods=3, n_splits=2, stride=1, n_retrain=2)
+
+    response = client.get(f"/v1/crud/backtests/{backtest_id}")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert (body["nPeriods"], body["nSplits"], body["stride"], body["nRetrain"]) == (3, 2, 1, 2)
+    # Lock the generated contract down: a later refactor must not quietly add or drop a
+    # field the frontend reads.
+    assert set(BacktestRead.model_json_schema(mode="serialization")["properties"]) == {
+        "nPeriods",
+        "nSplits",
+        "stride",
+        "nRetrain",
+        "futureWeatherProvider",
+        "datasetId",
+        "modelId",
+        "name",
+        "created",
+        "modelTemplateVersion",
+        "id",
+        "orgUnits",
+        "splitPeriods",
+        "maxHorizonDistance",
+        "dataset",
+        "aggregateMetrics",
+        "configuredModel",
+        "predictionSetupId",
+    }
+    assert set(body) == set(BacktestRead.model_json_schema(mode="serialization")["properties"])
+
+    # /full serialises the table class itself, so its parameters resolve through a lazy
+    # load that has to happen while the request session is still open.
+    full = client.get(f"/v1/crud/backtests/{backtest_id}/full")
+    assert full.status_code == 200, full.text
+    assert (full.json()["nPeriods"], full.json()["nSplits"]) == (3, 2)
 
 
 def test_run_backtest_retrains_n_retrain_times(p_seeded_engine, monkeypatch):
@@ -956,6 +1093,21 @@ def test_run_prediction_setup_rejects_legacy_fields(override_session, seeded_ses
     assert response.status_code == 422
 
 
+def _point_at_provider(session, backtest, provider):
+    """Move a backtest onto a specification differing only in the weather provider.
+
+    Specifications are immutable and shared between backtests, so changing the provider
+    means pointing at a different one rather than editing the one already there.
+    """
+    specification = BacktestSpecification(
+        **backtest.specification.model_dump(exclude={"id"}) | {"future_weather_provider": provider}
+    )
+    session.add(specification)
+    backtest.specification = specification
+    session.add(backtest)
+    session.commit()
+
+
 def test_run_prediction_setup_inherits_the_backtest_provider(
     override_session, seeded_session, example_polygons, monkeypatch
 ):
@@ -963,9 +1115,7 @@ def test_run_prediction_setup_inherits_the_backtest_provider(
     prediction silently uses a different future-weather source than the scores imply."""
     backtest = seeded_session.exec(select(Backtest)).first()
     assert backtest is not None
-    backtest.future_weather_provider = "damped_persistence"
-    seeded_session.add(backtest)
-    seeded_session.commit()
+    _point_at_provider(seeded_session, backtest, "damped_persistence")
     setup_id = _create_prediction_setup(backtest.id, "Inherit provider").json()["id"]
 
     request = create_make_data_request(example_polygons, [], ["rainfall", "disease_cases", "population"])
@@ -998,9 +1148,7 @@ def test_run_prediction_setup_rejects_a_look_ahead_provider(override_session, se
     Fail at the endpoint rather than deep inside the worker."""
     backtest = seeded_session.exec(select(Backtest)).first()
     assert backtest is not None
-    backtest.future_weather_provider = "observed"
-    seeded_session.add(backtest)
-    seeded_session.commit()
+    _point_at_provider(seeded_session, backtest, "observed")
     setup_id = _create_prediction_setup(backtest.id, "Look-ahead setup").json()["id"]
 
     request = create_make_data_request(example_polygons, [], ["rainfall", "disease_cases", "population"])

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -9,6 +9,7 @@ Requires Docker to be available. Skips automatically if Docker is not running.
 New migrations are automatically tested since upgrade always targets "head".
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -27,6 +28,7 @@ from chap_core.database.tables import (  # noqa: F401
     Backtest,
     BacktestForecast,
     BacktestMetric,
+    BacktestSpecification,
     Prediction,
     PredictionSamplesEntry,
     PredictionSetup,
@@ -46,17 +48,14 @@ _COLUMNS_ADDED_BY_MIGRATIONS = [
     ("configuredmodeldb", "is_live"),
     ("prediction", "prediction_setup_id"),
     ("backtest", "max_horizon_distance"),
-    ("backtest", "n_periods"),
-    ("backtest", "n_splits"),
-    ("backtest", "stride"),
-    ("backtest", "n_retrain"),
-    ("backtest", "future_weather_provider"),
+    ("backtest", "specification_id"),
 ]
 
 # Tables added by alembic migrations (not in the baseline schema).
 # These are dropped after create_all so the migration can re-create them.
 _TABLES_ADDED_BY_MIGRATIONS = [
     "predictionsetup",
+    "backtestspecification",
 ]
 
 # Unique constraints from migrations, with the baseline constraint that each one replaced.
@@ -152,9 +151,16 @@ def _create_baseline_schema(engine):
         conn.commit()
 
 
+# Backtests as a pre-parameter release stored them, with the org units each scored.
+# legacy_backtest and twin_backtest forecast the same splits, so they derive the same
+# parameters and must end up sharing one specification; empty_backtest has no forecasts
+# and falls back to the defaults, so it gets its own.
+_LEGACY_BACKTESTS = {"legacy_backtest": ["ou1"], "twin_backtest": ["ou2"], "empty_backtest": ["ou3"]}
+_LEGACY_SPLITS = (("202201", ("202202", "202203", "202204")), ("202203", ("202204", "202205", "202206")))
+
+
 def _insert_legacy_backtest(conn):
-    """Two backtests as a pre-parameter release stored them: one with forecasts on two
-    splits two months apart, three periods each, and one without forecasts."""
+    """Seed the legacy backtests, two of them with forecasts on two splits two months apart."""
     conn.execute(
         sa.text(
             "INSERT INTO configuredmodeldb (name, model_template_id, archived, uses_chapkit) "
@@ -162,22 +168,24 @@ def _insert_legacy_backtest(conn):
         )
     )
     conn.execute(sa.text("INSERT INTO dataset (name) VALUES ('legacy_dataset')"))
-    for name in ("legacy_backtest", "empty_backtest"):
+    for name, org_units in _LEGACY_BACKTESTS.items():
         conn.execute(
             sa.text(
-                "INSERT INTO backtest (name, dataset_id, model_id, model_db_id) "
-                f"SELECT '{name}', d.id, 'legacy_configured', c.id FROM dataset d, configuredmodeldb c "
+                "INSERT INTO backtest (name, dataset_id, model_id, model_db_id, org_units) "
+                f"SELECT '{name}', d.id, 'legacy_configured', c.id, '{json.dumps(org_units)}' "
+                "FROM dataset d, configuredmodeldb c "
                 "WHERE d.name = 'legacy_dataset' AND c.name = 'legacy_configured'"
             )
         )
-    for last_seen, periods in (("202201", ("202202", "202203", "202204")), ("202203", ("202204", "202205", "202206"))):
-        for period in periods:
-            conn.execute(
-                sa.text(
-                    "INSERT INTO backtestforecast (backtest_id, period, org_unit, values, last_train_period, last_seen_period) "
-                    f"SELECT id, '{period}', 'ou', '[1.0]', '202201', '{last_seen}' FROM backtest WHERE name = 'legacy_backtest'"
+    for name in ("legacy_backtest", "twin_backtest"):
+        for last_seen, periods in _LEGACY_SPLITS:
+            for period in periods:
+                conn.execute(
+                    sa.text(
+                        "INSERT INTO backtestforecast (backtest_id, period, org_unit, values, last_train_period, last_seen_period) "
+                        f"SELECT id, '{period}', 'ou', '[1.0]', '202201', '{last_seen}' FROM backtest WHERE name = '{name}'"
+                    )
                 )
-            )
 
 
 def _migration_module(revision: str):
@@ -233,6 +241,11 @@ class TestAlembicMigrations:
             result = conn.execute(sa.text("SELECT version_num FROM alembic_version"))
             current = result.scalar_one()
             assert current == head_rev, f"Expected head {head_rev}, got {current}"
+
+        # Every evaluation parameter belongs to the specification now, so none of them
+        # may be left behind on backtest by an earlier revision that added them there.
+        columns = {col["name"] for col in sa.inspect(engine).get_columns("backtest")}
+        assert not columns & {"n_periods", "n_splits", "stride", "n_retrain", "future_weather_provider"}
 
     def test_downgrade_to_base_and_upgrade_again(self, engine):
         """
@@ -306,7 +319,7 @@ class TestAlembicMigrations:
             ]:
                 conn.execute(sa.text(statement))
             _insert_legacy_backtest(conn)
-            for column in ("n_periods", "n_splits", "stride", "n_retrain"):
+            for column in ("n_periods", "n_splits", "stride", "n_retrain", "specification_id"):
                 conn.execute(sa.text(f"ALTER TABLE backtest ADD COLUMN {column} INTEGER"))
                 conn.execute(sa.text(f"UPDATE backtest SET {column} = 0"))
             conn.execute(sa.text("ALTER TABLE backtest ADD COLUMN future_weather_provider VARCHAR"))
@@ -316,18 +329,43 @@ class TestAlembicMigrations:
         command.upgrade(alembic_cfg, "head")
 
         with engine.connect() as conn:
-            row = conn.execute(
-                sa.text("SELECT n_periods, n_splits, stride, n_retrain FROM backtest WHERE name = 'legacy_backtest'")
-            ).one()
-            assert tuple(row) == (3, 2, 2, 1)
-            row = conn.execute(
-                sa.text("SELECT n_periods, n_splits, stride, n_retrain FROM backtest WHERE name = 'empty_backtest'")
-            ).one()
-            assert tuple(row) == (3, 7, 1, 1)
+            # The parameters moved onto the specification, so they are only reachable
+            # through the link now.
+            params = {
+                row.name: (row.n_periods, row.n_splits, row.stride, row.n_retrain)
+                for row in conn.execute(
+                    sa.text(
+                        "SELECT b.name, s.n_periods, s.n_splits, s.stride, s.n_retrain FROM backtest b "
+                        "JOIN backtestspecification s ON b.specification_id = s.id"
+                    )
+                ).fetchall()
+            }
+            assert params == {
+                "legacy_backtest": (3, 2, 2, 1),
+                "twin_backtest": (3, 2, 2, 1),
+                "empty_backtest": (3, 7, 1, 1),
+            }
+            # Identical parameters deduplicate onto one specification, which is what
+            # makes the two backtests comparable; the third one differs and gets its own.
+            specifications = {
+                (row.n_periods, row.n_splits, row.stride, row.n_retrain): row.org_units
+                for row in conn.execute(
+                    sa.text("SELECT n_periods, n_splits, stride, n_retrain, org_units FROM backtestspecification")
+                ).fetchall()
+            }
+            # org_units is the union across the backtests that share the specification.
+            assert specifications == {(3, 2, 2, 1): ["ou1", "ou2"], (3, 7, 1, 1): ["ou3"]}
             # Every legacy backtest was run by the REST path, which always used
             # QuickForecastFetcher - what the climatology provider now does.
-            providers = conn.execute(sa.text("SELECT future_weather_provider FROM backtest")).scalars().all()
-            assert set(providers) == {"climatology"}
+            providers = conn.execute(sa.text("SELECT future_weather_provider FROM backtestspecification")).scalars()
+            assert set(providers.all()) == {"climatology"}
+
+        columns = {col["name"] for col in sa.inspect(engine).get_columns("backtest")}
+        assert not columns & {"n_periods", "n_splits", "stride", "n_retrain", "future_weather_provider"}
+        specification_id = next(
+            col for col in sa.inspect(engine).get_columns("backtest") if col["name"] == "specification_id"
+        )
+        assert specification_id["nullable"] is False
 
         with engine.connect() as conn:
             row = conn.execute(

--- a/tests/test_backtest_specification.py
+++ b/tests/test_backtest_specification.py
@@ -1,0 +1,56 @@
+"""ORM-level tests for BacktestSpecification lifetime against its dataset.
+
+Uses an in-memory SQLite engine with foreign-key enforcement enabled, the same
+way tests/test_prediction_setup.py does, because the behaviour under test is a
+database-level ON DELETE action rather than anything the ORM does in Python.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import event
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from chap_core.database.dataset_tables import DataSet
+from chap_core.database.tables import BacktestSpecification
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite://")
+
+    @event.listens_for(eng, "connect")
+    def _enable_fk(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    SQLModel.metadata.create_all(eng)
+    return eng
+
+
+def test_deleting_dataset_removes_specifications_that_outlived_their_backtests(engine):
+    """A dataset whose backtests are gone is still deletable.
+
+    Nothing deletes a specification on its own, and a backtest that fails after
+    resolving one leaves it behind with no backtest at all, so without the cascade
+    those leftover rows would keep the dataset pinned forever.
+    """
+    with Session(engine) as session:
+        dataset = DataSet(name="ds")
+        session.add(dataset)
+        session.commit()
+        assert dataset.id is not None
+        dataset_id = dataset.id
+
+        session.add(BacktestSpecification(dataset_id=dataset_id))
+        session.commit()
+
+        session.delete(dataset)
+        session.commit()
+
+        assert session.get(DataSet, dataset_id) is None
+        remaining = session.exec(
+            select(BacktestSpecification).where(BacktestSpecification.dataset_id == dataset_id)
+        ).all()
+        assert remaining == []

--- a/tests/test_prediction_setup.py
+++ b/tests/test_prediction_setup.py
@@ -16,7 +16,7 @@ from sqlmodel import Session, SQLModel, create_engine, select
 
 from chap_core.database.dataset_tables import DataSet
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB, ModelTemplateDB
-from chap_core.database.tables import Backtest, Prediction, PredictionSetup
+from chap_core.database.tables import Backtest, BacktestSpecification, Prediction, PredictionSetup
 
 
 @pytest.fixture
@@ -49,11 +49,15 @@ def _make_parents(session: Session) -> tuple[int, int, int]:
     assert model.id is not None
     assert dataset.id is not None
 
+    specification = BacktestSpecification(dataset_id=dataset.id)
+    session.add(specification)
+    session.commit()
     backtest = Backtest(
         dataset_id=dataset.id,
         model_id="cfg",
         name="bt",
         model_db_id=model.id,
+        specification=specification,
     )
     session.add(backtest)
     session.commit()

--- a/tests/test_prediction_setup_service.py
+++ b/tests/test_prediction_setup_service.py
@@ -14,7 +14,7 @@ from sqlmodel import Session, SQLModel, create_engine, select
 
 from chap_core.database.dataset_tables import DataSet
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB, ModelTemplateDB
-from chap_core.database.tables import Backtest, Prediction, PredictionSetup, QuantileTarget
+from chap_core.database.tables import Backtest, BacktestSpecification, Prediction, PredictionSetup, QuantileTarget
 from chap_core.services.prediction_setup_service import (
     BacktestNotFoundError,
     DuplicateSetupError,
@@ -56,7 +56,12 @@ def _make_parents(session: Session) -> tuple[int, int, int]:
     assert model.id is not None
     assert dataset.id is not None
 
-    backtest = Backtest(dataset_id=dataset.id, model_id="cfg", name="bt", model_db_id=model.id)
+    specification = BacktestSpecification(dataset_id=dataset.id)
+    session.add(specification)
+    session.commit()
+    backtest = Backtest(
+        dataset_id=dataset.id, model_id="cfg", name="bt", model_db_id=model.id, specification=specification
+    )
     session.add(backtest)
     session.commit()
     assert backtest.id is not None


### PR DESCRIPTION
Implements CLIM-1070, under the benchmarking epic CLIM-980.

## Why

The parameters that decide whether two backtests are comparable — `n_periods`, `n_splits`, `stride`, `n_retrain`, the dataset, and the resulting org unit set — lived as columns on each backtest row. They were owned by a single backtest and could not be referred to by anything else.

Benchmarking needs the opposite. Comparing models means running them against the same specification, and adding a model to an existing comparison later has to be a new backtest pointing at a specification that already exists, not a re-run of everything. While the details are duplicated per row, "these results are comparable" is something every caller has to verify by comparing columns.

## What changes

`BacktestSpecification` holds the dataset, the evaluation parameters and the resolved org unit set. Rows are deduplicated and immutable; `Backtest` gains a not-null `specification_id` and loses its own copies of the four parameter columns.

The uniqueness key is **derived from `BacktestParams` rather than listed**:

```python
__table_args__ = (
    UniqueConstraint("dataset_id", *BacktestParams.model_fields, name="uq_backtestspecification_params"),
)
```

A parameter added to `BacktestParams` joins the key automatically instead of silently letting two different setups share a row. A test pins that invariant. Widening the constraint in the database still needs a migration.

`org_units` is stored but is **not** part of the key, because it is derived from it. `validate_and_filter_dataset_for_evaluation` drops locations whose target is empty across the training window, and the length of that window is `n_periods + (n_splits - 1) * stride`. The same dataset under different parameters yields different org units, so they belong to the specification rather than to the dataset.

Resolve-or-create lives in `SessionWrapper.get_or_create_backtest_specification`. Concurrent backtest jobs can race, so a unique violation re-reads the winner's row rather than failing the backtest.

Not in scope: a benchmark table. A benchmark is a specification with more than one backtest under it, which is a query rather than a table.

## REST contract

`BacktestRead` is unchanged. It keeps the four parameters as flat fields, now read through the relationship, and its generated schema is byte-identical — a test pins the property set, and the read paths eager-load the specification so listings do not fall into an N+1.

One endpoint does change. `GET /v1/crud/backtests/{id}/full` declares `response_model=Backtest`, the table class itself, so its component gains `specificationId` and the four parameters become `readOnly` and `required` instead of optional-with-a-default. Nothing is removed or renamed, and for a response-only schema this is a tightening, but it is a diff rather than literally no change.

## Migration

`f2a3b4c5d6e1` groups existing backtests by `(dataset_id, parameters)` into one specification each, points the rows at them, then drops the columns. It handles the startup path where `create_all` has already made the table and the generic metadata migration has already added `specification_id` filled with `0`.

Two things about the backfilled data cannot be repaired, and both are recorded in the migration docstring so migrated rows are not mistaken for properly resolved ones:

- **Parameters on pre-existing rows were themselves reconstructed** from forecasts by #569. A split whose predictor returned nothing left no forecasts and is invisible, so such a backtest was reconstructed with a lower `n_splits` and a wider `stride`. Two backtests that really ran the same setup can carry different parameters and will land on different specifications. Legacy grouping is fragmented, and fragmented specifically for the models that misbehaved.
- **Copied `org_units` are output-derived**, accumulated from what each model produced rather than from the filtered input, so a model that dropped locations under-reports. The union across the backtests sharing a specification is the best available estimate: an org unit any of them forecast must have been in the input. Specifications created from now on resolve `org_units` correctly.

`downgrade()` copies the parameters back and is lossy: a specification no backtest points at is dropped with the table.

## Tests

`tests/test_alembic_migrations.py` seeds a third legacy backtest whose forecasts match `legacy_backtest`, so it derives identical parameters and must land on the same specification. It then asserts the three backtests resolve to exactly two specifications, that the parameters read through the link are what the old assertions expected, that `org_units` is the union across the contributing rows, that the four columns are gone and that `specification_id` is not null.

New behaviour tests cover identical parameters sharing one specification, differing parameters and differing datasets producing different ones, `org_units` matching the post-filter locations including a case where the filter drops one, and the read contract.

## The future-weather provider

#568 merged first, and this branch is rebased on top of it. `future_weather_provider` moves off `backtest` onto the specification with the rest of the parameters: two backtests given different climate covariates for their forecast windows are not comparable, so keeping the provider on the row would have left the one parameter that matters most for comparability outside the thing that certifies it.

The model side needed no edit — the key is derived from `BacktestParams.model_fields`, so the field joined it on its own, and a test asserts a `climatology` and an `observed` run land on different specifications. `Backtest.future_weather_provider` became a fifth read-through property, so `Evaluation.future_weather_provider` and the prediction-setup inheritance in `crud.py` keep working unchanged.

The migration takes `down_revision = "e1f2a3b4c5d6"` and carries a type per parameter column rather than assuming integers, since the provider is a VARCHAR. It moves all five columns, guarding each drop so a database missing some of them still ends up with none on `backtest`.

Tests that set the provider by assigning to the backtest now go through the specification. Two of them did so on a *persisted* backtest, where mutating a shared immutable specification would have changed the provider for every backtest pointing at it; those point the backtest at a new specification instead.

## Out of scope

The benchmark batch endpoint, covariate mapping, optional covariates, HPO run persistence and marketplace lookup stay in their own CLIM-980 issues. The `ewars_plus` `n_periods=3` override and the weekly `stride=4` bump are tracked separately, but note the override mutates a key field, so it has to be applied before the specification is resolved — as it is here.


