### PR TITLE
fix: drain chapkit service output so local services do not block (CLIM-1072)

### DIFF
--- a/chap_core/models/chapkit_service_manager.py
+++ b/chap_core/models/chapkit_service_manager.py
@@ -125,6 +125,8 @@ class ChapkitServiceManager:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             preexec_fn=os.setsid if os.name != "nt" else None,
         )

--- a/chap_core/models/chapkit_service_manager.py
+++ b/chap_core/models/chapkit_service_manager.py
@@ -2,11 +2,13 @@
 Manages lifecycle of chapkit model services started from local directories.
 """
 
+import collections
 import logging
 import os
 import signal
 import socket
 import subprocess
+import threading
 import time
 from pathlib import Path
 
@@ -15,6 +17,9 @@ import httpx
 from chap_core.exceptions import ChapkitServiceStartupError
 
 logger = logging.getLogger(__name__)
+
+# Number of most recent service output lines kept for error messages.
+OUTPUT_TAIL_LINES = 200
 
 
 def find_available_port(start_port: int = 8000, max_attempts: int = 100) -> int:
@@ -37,6 +42,12 @@ def is_url(path_or_url: str | Path) -> bool:
 class ChapkitServiceManager:
     """
     Manages the lifecycle of a chapkit model service subprocess.
+
+    The service's stdout and stderr are merged into one pipe that is drained
+    continuously on a background thread. Without that, a service that logs more
+    than the pipe buffer holds (about 64 KiB) blocks on its next write and stops
+    answering requests. Each line is forwarded to this module's logger at DEBUG
+    level, and the most recent lines are kept for error messages.
 
     Usage:
         with ChapkitServiceManager("/path/to/model") as manager:
@@ -66,6 +77,8 @@ class ChapkitServiceManager:
         self.startup_timeout = startup_timeout
         self._process: subprocess.Popen | None = None
         self._url: str | None = None
+        self._output: collections.deque[str] = collections.deque(maxlen=OUTPUT_TAIL_LINES)
+        self._reader: threading.Thread | None = None
 
     @property
     def url(self) -> str:
@@ -73,6 +86,10 @@ class ChapkitServiceManager:
         if self._url is None:
             raise RuntimeError("Service not started. Use as context manager.")
         return self._url
+
+    def recent_output(self) -> str:
+        """Return the most recent lines the service wrote to stdout or stderr."""
+        return "\n".join(self._output)
 
     def _validate_directory(self) -> None:
         """Validate that the model directory exists and is valid."""
@@ -101,13 +118,39 @@ class ChapkitServiceManager:
 
         logger.info(f"Starting chapkit service at {self._url} from {self.model_directory}")
 
+        self._output.clear()
         self._process = subprocess.Popen(
             command,
             cwd=self.model_directory,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
             preexec_fn=os.setsid if os.name != "nt" else None,
         )
+        self._reader = threading.Thread(
+            target=self._pump_output,
+            args=(self._process.stdout,),
+            name=f"chapkit-service-output-{self.port}",
+            daemon=True,
+        )
+        self._reader.start()
+
+    def _pump_output(self, stream) -> None:
+        """Drain the service's merged output until EOF, keeping a bounded tail."""
+        try:
+            for line in stream:
+                line = line.rstrip("\n")
+                self._output.append(line)
+                logger.debug("[chapkit service] %s", line)
+        finally:
+            stream.close()
+
+    def _join_reader(self, timeout: float) -> None:
+        """Wait briefly for the output thread to finish after the process exited."""
+        if self._reader is not None:
+            self._reader.join(timeout)
+            self._reader = None
 
     def _wait_for_healthy(self) -> None:
         """Wait for the service to become healthy."""
@@ -117,9 +160,10 @@ class ChapkitServiceManager:
         while time.time() - start_time < self.startup_timeout:
             assert self._process is not None
             if self._process.poll() is not None:
-                stdout, stderr = self._process.communicate()
+                self._join_reader(timeout=2)
                 raise ChapkitServiceStartupError(
-                    f"Service process died during startup.\nstdout: {stdout.decode()}\nstderr: {stderr.decode()}"
+                    f"Service process died during startup with exit code {self._process.returncode}.\n"
+                    f"Recent output:\n{self.recent_output()}"
                 )
 
             try:
@@ -135,9 +179,11 @@ class ChapkitServiceManager:
             logger.debug(f"Waiting for service at {health_url}...")
             time.sleep(1)
 
+        url = self._url
         self._stop_service()
         raise ChapkitServiceStartupError(
-            f"Service at {self._url} did not become healthy within {self.startup_timeout} seconds"
+            f"Service at {url} did not become healthy within {self.startup_timeout} seconds.\n"
+            f"Recent output:\n{self.recent_output()}"
         )
 
     def _stop_service(self) -> None:
@@ -165,6 +211,7 @@ class ChapkitServiceManager:
         except ProcessLookupError:
             pass
         finally:
+            self._join_reader(timeout=5)
             self._process = None
             self._url = None
 

--- a/tests/external/conftest.py
+++ b/tests/external/conftest.py
@@ -57,7 +57,7 @@ if mode == "die":
     sys.stdout.flush()
     sys.exit(3)
 
-status = "healthy" if mode == "flood" else "starting"
+status = "healthy" if mode in ("flood", "invalid_bytes") else "starting"
 
 
 class Handler(http.server.BaseHTTPRequestHandler):
@@ -84,8 +84,17 @@ def flood():
     sys.stderr.flush()
 
 
+def invalid_bytes():
+    sys.stdout.buffer.write(b"\\xff\\n")
+    sys.stdout.buffer.flush()
+    sys.stdout.write("AFTER_INVALID_BYTES\\n")
+    sys.stdout.flush()
+
+
 if mode == "flood":
     threading.Thread(target=flood, daemon=True).start()
+if mode == "invalid_bytes":
+    threading.Thread(target=invalid_bytes, daemon=True).start()
 
 http.server.ThreadingHTTPServer(("127.0.0.1", port), Handler).serve_forever()
 """
@@ -96,6 +105,7 @@ def fake_chapkit_service(tmp_path):
     """Return a factory that patches Popen in the service manager to launch the fake service.
 
     ``mode`` is one of ``"flood"`` (healthy, then floods stdout and stderr),
+    ``"invalid_bytes"`` (healthy, writes a byte that is not valid UTF-8, then keeps logging),
     ``"die"`` (prints a line and exits 3), or ``"starting"`` (never becomes healthy).
     """
     script = tmp_path / "fake_chapkit_service.py"

--- a/tests/external/conftest.py
+++ b/tests/external/conftest.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+from unittest.mock import patch
+
 import pandas as pd
 import pytest
 
@@ -35,3 +39,74 @@ def test_data(split_data):
 @pytest.fixture
 def full_train_data(train_data):
     return train_data.add_fields(FullData, population=lambda data: [100000] * len(data))
+
+
+# A stand-in for `uv run fastapi dev`: a tiny HTTP server that answers /health and
+# writes more than a pipe buffer to stdout and stderr. Used to test
+# ChapkitServiceManager without a chapkit model installed.
+_FAKE_CHAPKIT_SERVICE = """
+import http.server
+import json
+import sys
+import threading
+
+mode, port = sys.argv[1], int(sys.argv[2])
+
+if mode == "die":
+    print("fake service refused to start")
+    sys.stdout.flush()
+    sys.exit(3)
+
+status = "healthy" if mode == "flood" else "starting"
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = json.dumps({"status": status}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+def flood():
+    chunk = "x" * 1024
+    for _ in range(256):
+        sys.stdout.write(chunk + "\\n")
+        sys.stderr.write(chunk + "\\n")
+    sys.stdout.write("STDOUT_FLOOD_DONE\\n")
+    sys.stdout.flush()
+    sys.stderr.write("STDERR_FLOOD_DONE\\n")
+    sys.stderr.flush()
+
+
+if mode == "flood":
+    threading.Thread(target=flood, daemon=True).start()
+
+http.server.ThreadingHTTPServer(("127.0.0.1", port), Handler).serve_forever()
+"""
+
+
+@pytest.fixture
+def fake_chapkit_service(tmp_path):
+    """Return a factory that patches Popen in the service manager to launch the fake service.
+
+    ``mode`` is one of ``"flood"`` (healthy, then floods stdout and stderr),
+    ``"die"`` (prints a line and exits 3), or ``"starting"`` (never becomes healthy).
+    """
+    script = tmp_path / "fake_chapkit_service.py"
+    script.write_text(_FAKE_CHAPKIT_SERVICE)
+    real_popen = subprocess.Popen
+
+    def factory(mode: str):
+        def launch(command, **kwargs):
+            port = command[command.index("--port") + 1]
+            return real_popen([sys.executable, str(script), mode, port], **kwargs)
+
+        return patch("chap_core.models.chapkit_service_manager.subprocess.Popen", side_effect=launch)
+
+    return factory

--- a/tests/external/test_external_chapkit_model.py
+++ b/tests/external/test_external_chapkit_model.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import patch
 
 import httpx
@@ -122,6 +123,34 @@ class TestChapkitServiceManager:
         manager = ChapkitServiceManager(str(tmp_path))
         with pytest.raises(RuntimeError, match="Service not started"):
             _ = manager.url
+
+    def test_service_stays_responsive_when_output_exceeds_pipe_buffer(self, tmp_path, fake_chapkit_service):
+        with fake_chapkit_service("flood"):
+            with ChapkitServiceManager(str(tmp_path), startup_timeout=15) as manager:
+                deadline = time.time() + 15
+                while "STDERR_FLOOD_DONE" not in manager.recent_output() and time.time() < deadline:
+                    time.sleep(0.1)
+                assert "STDOUT_FLOOD_DONE" in manager.recent_output()
+                assert "STDERR_FLOOD_DONE" in manager.recent_output()
+                assert httpx.get(manager.url + "/health", timeout=2).status_code == 200
+                stop_started = time.time()
+            assert time.time() - stop_started < 5
+
+    def test_death_during_startup_reports_output(self, tmp_path, fake_chapkit_service):
+        with fake_chapkit_service("die"):
+            with pytest.raises(ChapkitServiceStartupError, match="died during startup") as exc_info:
+                with ChapkitServiceManager(str(tmp_path), startup_timeout=15):
+                    pass
+        assert "fake service refused to start" in str(exc_info.value)
+
+    def test_startup_timeout_reports_url(self, tmp_path, fake_chapkit_service):
+        with fake_chapkit_service("starting"):
+            with pytest.raises(ChapkitServiceStartupError, match="did not become healthy") as exc_info:
+                with ChapkitServiceManager(str(tmp_path), startup_timeout=2):
+                    pass
+        message = str(exc_info.value)
+        assert "http://127.0.0.1:" in message
+        assert "None" not in message
 
 
 class TestGetModelTemplateConfig:

--- a/tests/external/test_external_chapkit_model.py
+++ b/tests/external/test_external_chapkit_model.py
@@ -136,6 +136,15 @@ class TestChapkitServiceManager:
                 stop_started = time.time()
             assert time.time() - stop_started < 5
 
+    def test_reader_survives_invalid_output_bytes(self, tmp_path, fake_chapkit_service):
+        with fake_chapkit_service("invalid_bytes"):
+            with ChapkitServiceManager(str(tmp_path), startup_timeout=15) as manager:
+                deadline = time.time() + 15
+                while "AFTER_INVALID_BYTES" not in manager.recent_output() and time.time() < deadline:
+                    time.sleep(0.1)
+                assert "AFTER_INVALID_BYTES" in manager.recent_output()
+                assert httpx.get(manager.url + "/health", timeout=2).status_code == 200
+
     def test_death_during_startup_reports_output(self, tmp_path, fake_chapkit_service):
         with fake_chapkit_service("die"):
             with pytest.raises(ChapkitServiceStartupError, match="died during startup") as exc_info:


### PR DESCRIPTION
## Problem

`ChapkitServiceManager` starts a local chapkit model with `uv run fastapi dev` and captures the child's stdout and stderr into pipes that nothing reads while the service runs. servicekit logs one structured line to stdout per request (about 1.2 KB under chapkit 2), so the 64 KiB pipe fills after roughly 55 requests. The child then blocks in `write()`, uvicorn's event loop wedges, `/health` stops answering, SIGTERM is ignored, and the manager burns the full startup timeout plus the 10 s grace period before SIGKILL.

Reproduced with the unmodified manager against the repository's own chapkit fixture model on chapkit 1.1.1 and 2.0.0. With no artificial output at all, the chapkit 2 service went unresponsive after 59 health requests (4.4 s). With the pipes drained the same service handled 21,776 requests in two minutes, so the defect is in chap-core, not chapkit.

Two adjacent defects share the cause and are fixed here too: the startup-timeout message read `Service at None` because `_stop_service()` cleared the URL before the message was formatted, and all buffered service output was discarded on that path.

Reachability: directory mode only, reached from the CLI with a local model path and `--run-config.is-chapkit-model`. The Docker worker always talks to chapkit services by URL and never constructs a `ChapkitServiceManager`, so deployments are not affected.

## Change

- Merge stderr into stdout and drain the pipe continuously on a daemon thread. Each line is forwarded to the module logger at DEBUG (visible under `chap eval --debug` and in the Celery per-task debug file) and the last 200 lines are kept in a bounded deque.
- Both startup error messages (process died, did not become healthy) now include that tail, and the timeout message includes the real URL.
- `_stop_service` joins the reader thread after the process exits, so the pipe is closed and no descriptors leak.
- New public `recent_output()` accessor.

## Tests

`tests/external/conftest.py` gains a `fake_chapkit_service` fixture: a stand-in HTTP server launched by patching `Popen` in the manager module, so no chapkit install is needed. It can flood both streams after becoming healthy, exit at startup with a message, or serve a never-healthy status. Three new tests in `TestChapkitServiceManager` cover each case. The flood and timeout tests fail against the previous manager (`AttributeError: recent_output` and `Service at None`).

## Verification

- `uv run pytest tests/external/test_external_chapkit_model.py -q`: 23 passed, 2 skipped
- `make lint`: ruff, mypy, pyright clean
- End to end against real chapkit 2.0.0 and 1.1.1 model directories with the corrected manager: healthy in about 1.3 s, no `ReadTimeout` across 21,776 (chapkit 2, own logging only) and about 5,400 (1 MiB flood, both versions) health requests, stop in 0.3 s

Jira: CLIM-1072