### PR TITLE
feat: endpoint suggesting covariate names for model-independent datasets

### DIFF
--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -143,6 +143,19 @@ class ChapDataSource(DBModel):
     dataset: str = Field(description="Canonical name of the upstream dataset this source pulls from.")
 
 
+class CovariateNameSuggestion(DBModel):
+    """One suggested covariate name for a model-independent dataset, with where the suggestion comes from."""
+
+    name: str = Field(description="Covariate name as it should appear in the dataset.")
+    standard: bool = Field(
+        description="True when the name comes from CHAP's built-in list of standard covariate names."
+    )
+    required_by: list[str] = Field(
+        default_factory=list,
+        description="Names of live model templates that list this covariate in `required_covariates`.",
+    )
+
+
 class MakePredictionRequest(DatasetMakeRequest, PredictionParams):
     """Long-path request for kicking off a prediction: combines dataset construction + model parameters."""
 

--- a/chap_core/rest_api/data_models.py
+++ b/chap_core/rest_api/data_models.py
@@ -152,7 +152,7 @@ class CovariateNameSuggestion(DBModel):
     )
     required_by: list[str] = Field(
         default_factory=list,
-        description="Names of live model templates that list this covariate in `required_covariates`.",
+        description="Names of the live model templates and configured models that need this covariate.",
     )
 
 

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -658,11 +658,13 @@ STRUCTURAL_FIELDS = RESERVED_FIELDS - {"disease_cases"}
 async def get_covariate_names(session: Session = Depends(get_session)) -> list[CovariateNameSuggestion]:
     """List covariate names to offer when naming the columns of a dataset that is not tied to a model.
 
-    Models only run on a dataset whose covariate names match their ``required_covariates``
+    Models only run on a dataset whose covariate names match the names they ask for
     verbatim, so picking a suggested name is what makes a dataset reusable across models.
-    The list is the union of CHAP's standard names and, for every live model template, its
-    required covariates plus the name of its target column (usually ``disease_cases``, but
-    a template may call it something else). ``requiredBy`` tells which templates need each
+    The list is the union of three sources: CHAP's standard names; for every live model
+    template, its required covariates plus the name of its target column (usually
+    ``disease_cases``, but a template may call it something else); and for every live
+    configured model, the extra continuous covariates its configuration adds on top of the
+    template. ``requiredBy`` names the templates and configured models that need each
     name. Free-text names are still allowed when creating a dataset.
     """
     required_by: dict[str, set[str]] = {name: set() for name in STANDARD_COVARIATE_NAMES}
@@ -672,6 +674,14 @@ async def get_covariate_names(session: Session = Depends(get_session)) -> list[C
             if name in STRUCTURAL_FIELDS:
                 continue
             required_by.setdefault(name, set()).add(template.name)
+    configured_models = session.exec(
+        select(ConfiguredModelDB).where(ConfiguredModelDB.is_live == True, ConfiguredModelDB.archived == False)
+    ).all()
+    for configured_model in configured_models:
+        for name in configured_model.additional_continuous_covariates:
+            if name in STRUCTURAL_FIELDS:
+                continue
+            required_by.setdefault(name, set()).add(configured_model.name)
     return [
         CovariateNameSuggestion(name=name, standard=name in STANDARD_COVARIATE_NAMES, required_by=sorted(models))
         for name, models in required_by.items()

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -641,10 +641,6 @@ STANDARD_COVARIATE_NAMES = [
     "rainfall",
     "mean_temperature",
     "population",
-    "surface_pressure",
-    "mean_sea_level_pressure",
-    "u_component_of_wind_10m",
-    "v_component_of_wind_10m",
 ]
 
 

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -22,9 +22,10 @@ from chap_core.database.base_tables import DBModel
 from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.dataset_tables import DataSet as DataSetTable
 from chap_core.database.dataset_tables import DataSetCreateInfo
-from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
+from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB, ModelTemplateDB
 from chap_core.database.tables import Backtest, BacktestForecast, Prediction
 from chap_core.datatypes import create_tsdataclass
+from chap_core.services.dataset_validation import RESERVED_FIELDS
 from chap_core.spatio_temporal_data.converters import observations_to_dataframe, observations_to_dataset
 from chap_core.spatio_temporal_data.temporal_dataclass import DataSet
 
@@ -34,6 +35,7 @@ from ...data_models import (
     BacktestDomain,
     BacktestRead,
     ChapDataSource,
+    CovariateNameSuggestion,
     DatasetMakeRequest,
     ImportSummaryResponse,
     JobResponse,
@@ -632,6 +634,45 @@ async def get_data_sources() -> list[ChapDataSource]:
     identifier.
     """
     return data_sources
+
+
+STANDARD_COVARIATE_NAMES = [
+    "rainfall",
+    "mean_temperature",
+    "population",
+    "surface_pressure",
+    "mean_sea_level_pressure",
+    "u_component_of_wind_10m",
+    "v_component_of_wind_10m",
+]
+
+
+@router.get(
+    "/covariate-names",
+    response_model=list[CovariateNameSuggestion],
+    tags=["Datasets"],
+    summary="Suggest covariate names for a model-independent dataset",
+)
+async def get_covariate_names(session: Session = Depends(get_session)) -> list[CovariateNameSuggestion]:
+    """List covariate names to offer when naming the columns of a dataset that is not tied to a model.
+
+    Models only run on a dataset whose covariate names match their ``required_covariates``
+    verbatim, so picking a suggested name is what makes a dataset reusable across models.
+    The list is the union of CHAP's standard names and the required covariates of every
+    live model template; ``requiredBy`` tells which templates need each name. Free-text
+    names are still allowed when creating a dataset.
+    """
+    required_by: dict[str, list[str]] = {name: [] for name in STANDARD_COVARIATE_NAMES}
+    templates = session.exec(select(ModelTemplateDB).where(ModelTemplateDB.is_live == True)).all()
+    for template in templates:
+        for covariate in template.required_covariates:
+            if covariate in RESERVED_FIELDS:
+                continue
+            required_by.setdefault(covariate, []).append(template.name)
+    return [
+        CovariateNameSuggestion(name=name, standard=name in STANDARD_COVARIATE_NAMES, required_by=sorted(models))
+        for name, models in required_by.items()
+    ]
 
 
 @router.post(

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -637,6 +637,7 @@ async def get_data_sources() -> list[ChapDataSource]:
 
 
 STANDARD_COVARIATE_NAMES = [
+    "disease_cases",
     "rainfall",
     "mean_temperature",
     "population",
@@ -645,6 +646,11 @@ STANDARD_COVARIATE_NAMES = [
     "u_component_of_wind_10m",
     "v_component_of_wind_10m",
 ]
+
+
+# Reserved columns that come from an observation's period / org-unit fields rather than
+# being a named data column the user fills in. Unlike those, `disease_cases` is suggestable.
+STRUCTURAL_FIELDS = RESERVED_FIELDS - {"disease_cases"}
 
 
 @router.get(
@@ -658,17 +664,18 @@ async def get_covariate_names(session: Session = Depends(get_session)) -> list[C
 
     Models only run on a dataset whose covariate names match their ``required_covariates``
     verbatim, so picking a suggested name is what makes a dataset reusable across models.
-    The list is the union of CHAP's standard names and the required covariates of every
-    live model template; ``requiredBy`` tells which templates need each name. Free-text
-    names are still allowed when creating a dataset.
+    The list is the union of CHAP's standard names and, for every live model template, its
+    required covariates plus the name of its target column (usually ``disease_cases``, but
+    a template may call it something else). ``requiredBy`` tells which templates need each
+    name. Free-text names are still allowed when creating a dataset.
     """
-    required_by: dict[str, list[str]] = {name: [] for name in STANDARD_COVARIATE_NAMES}
+    required_by: dict[str, set[str]] = {name: set() for name in STANDARD_COVARIATE_NAMES}
     templates = session.exec(select(ModelTemplateDB).where(ModelTemplateDB.is_live == True)).all()
     for template in templates:
-        for covariate in template.required_covariates:
-            if covariate in RESERVED_FIELDS:
+        for name in [*template.required_covariates, template.target]:
+            if name in STRUCTURAL_FIELDS:
                 continue
-            required_by.setdefault(covariate, []).append(template.name)
+            required_by.setdefault(name, set()).add(template.name)
     return [
         CovariateNameSuggestion(name=name, standard=name in STANDARD_COVARIATE_NAMES, required_by=sorted(models))
         for name, models in required_by.items()

--- a/docs/contributor/rest_api_and_database.md
+++ b/docs/contributor/rest_api_and_database.md
@@ -86,6 +86,7 @@ Higher-level endpoints used by the Modeling App:
 - `GET /compatible-backtests/{id}` -- find backtests compatible for comparison.
 - `GET /backtest-overlap/{id1}/{id2}` -- find overlapping org units and periods.
 - `GET /data-sources` -- return the list of available climate data sources.
+- `GET /covariate-names` -- suggest covariate names (standard names plus what live model templates require).
 
 ### jobs.py (`/v1/jobs/...`)
 

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -228,6 +228,18 @@ def test_get_data_sources():
     assert next(ds for ds in data if "rainfall" in ds["supportedFeatures"])["dataset"] == "era5"
 
 
+def test_get_covariate_names(dependency_overrides):
+    response = client.get("/v1/analytics/covariate-names")
+    data = response.json()
+    assert response.status_code == 200, data
+    by_name = {entry["name"]: entry for entry in data}
+    assert len(by_name) == len(data), "names should be unique"
+    assert by_name["rainfall"]["standard"] is True
+    assert "naive_model" in by_name["rainfall"]["requiredBy"]
+    assert "disease_cases" not in by_name
+    assert all(entry["standard"] or entry["requiredBy"] for entry in data)
+
+
 @pytest.fixture
 def make_prediction_request(make_dataset_request):
     return MakePredictionRequest(

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -236,7 +236,10 @@ def test_get_covariate_names(dependency_overrides):
     assert len(by_name) == len(data), "names should be unique"
     assert by_name["rainfall"]["standard"] is True
     assert "naive_model" in by_name["rainfall"]["requiredBy"]
-    assert "disease_cases" not in by_name
+    assert by_name["disease_cases"]["standard"] is True
+    assert "naive_model" in by_name["disease_cases"]["requiredBy"], "target column should be suggested too"
+    assert "time_period" not in by_name
+    assert "location" not in by_name
     assert all(entry["standard"] or entry["requiredBy"] for entry in data)
 
 

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -242,6 +242,17 @@ def test_get_covariate_names(dependency_overrides):
     assert "location" not in by_name
     assert all(entry["standard"] or entry["requiredBy"] for entry in data)
 
+    configured_models = client.get("/v1/crud/configured-models").json()
+    extras = {
+        (model["name"], covariate)
+        for model in configured_models
+        for covariate in model["additionalContinuousCovariates"]
+    }
+    assert extras, "seeded config should include a model with extra covariates"
+    for model_name, covariate in extras:
+        assert covariate in by_name, (covariate, sorted(by_name))
+        assert model_name in by_name[covariate]["requiredBy"], by_name[covariate]
+
 
 @pytest.fixture
 def make_prediction_request(make_dataset_request):


### PR DESCRIPTION
First piece of CLIM-1071. Datasets can be created without a model, but the columns still need names, and a model only runs on a dataset whose covariate names match what it asks for verbatim. This adds the endpoint that tells a client which names to offer.

`GET /v1/analytics/covariate-names` returns the union of three sources:

- a hardcoded list of standard names (`STANDARD_COVARIATE_NAMES` in the analytics router): `disease_cases`, `rainfall`, `mean_temperature`, `population`
- for every live model template, its `required_covariates` plus its `target` column name
- for every live, unarchived configured model, the `additional_continuous_covariates` its configuration layers on top of the template

Each entry carries `standard` (whether the name is in the built-in list) and `requiredBy` (which templates and configured models need it), so a UI can both suggest names and explain why one matters.

The target is included because the user names that column when creating a dataset just like any covariate, and a template may call it something other than `disease_cases`. The configured-model extras are included because a dataset has to carry those columns too for that model to run. Only the structural columns are filtered out: `time_period`, `location` and `location_name`, which come from an observation's period and org-unit fields rather than being named by the user. Free-text names remain allowed when creating a dataset.

Not included here, still open under CLIM-1071: validation of free-text names on dataset creation, the runnable-models check for an existing dataset, and aligning the ERA5 data-source catalogue entries that still have `[""]` placeholders. The related `dataSources` persistence bug is fixed separately in #578.

Tested with a new case in `tests/integration/rest_api/test_db_endpoints.py`, which derives the configured-model expectations from the seeded config rather than hardcoding names.