### PR TITLE
fix: make service registry heartbeat atomic so pings cannot resurrect or overwrite registrations (CLIM-1073)

### DIFF
--- a/chap_core/rest_api/services/orchestrator.py
+++ b/chap_core/rest_api/services/orchestrator.py
@@ -15,6 +15,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from redis import Redis
+from redis.client import Pipeline
 
 from chap_core.rest_api.services.schemas import (
     PingResponse,
@@ -39,6 +40,10 @@ class Orchestrator:
     Services register with the orchestrator and must send periodic pings
     to maintain their registration. Services that fail to ping within
     the TTL window are automatically expired by Redis.
+
+    Registration and ping are optimistic Redis transactions (WATCH/MULTI/EXEC)
+    so that a ping racing a deregistration or a re-registration cannot
+    resurrect the old entry or write back a stale URL.
     """
 
     def __init__(self, redis_client: Redis, ttl_seconds: int = DEFAULT_TTL_SECONDS):
@@ -82,29 +87,39 @@ class Orchestrator:
         """
         service_id = payload.info.id
         key = self._make_key(service_id)
-        now = self._now_iso()
-        expires_at = self._compute_expires_at()
 
-        existing = self.redis.get(key)
-        if existing is not None:
-            existing_data: dict[str, Any] = json.loads(existing)  # type: ignore[arg-type]
-            registered_at = existing_data.get("registered_at", now)
-            message = "Service registration updated"
-        else:
-            registered_at = now
-            message = "Service registered successfully"
+        message = ""
 
-        service_data: dict[str, Any] = {
-            "id": service_id,
-            "url": payload.url,
-            "info": payload.info.model_dump(mode="json"),
-            "registered_at": registered_at,
-            "last_updated": now,
-            "last_ping_at": now,
-            "expires_at": expires_at,
-        }
+        def _register(pipe: Pipeline) -> None:
+            nonlocal message
+            now = self._now_iso()
+            expires_at = self._compute_expires_at()
 
-        self.redis.setex(key, self.ttl_seconds, json.dumps(service_data))
+            existing = pipe.get(key)
+            if existing is not None:
+                existing_data: dict[str, Any] = json.loads(existing)  # type: ignore[arg-type]
+                registered_at = existing_data.get("registered_at", now)
+                message = "Service registration updated"
+            else:
+                registered_at = now
+                message = "Service registered successfully"
+
+            service_data: dict[str, Any] = {
+                "id": service_id,
+                "url": payload.url,
+                "info": payload.info.model_dump(mode="json"),
+                "registered_at": registered_at,
+                "last_updated": now,
+                "last_ping_at": now,
+                "expires_at": expires_at,
+            }
+
+            pipe.multi()
+            pipe.setex(key, self.ttl_seconds, json.dumps(service_data))
+
+        # WATCH/MULTI/EXEC: a concurrent write to the key between the read and the
+        # write makes EXEC fail and redis-py retries against the new state.
+        self.redis.transaction(_register, key)
 
         return RegistrationResponse(
             id=service_id,
@@ -131,20 +146,32 @@ class Orchestrator:
             ServiceNotFoundError: If the service is not registered.
         """
         key = self._make_key(service_id)
-        data = self.redis.get(key)
 
-        if data is None:
-            raise ServiceNotFoundError(f"Service {service_id} not found")
+        now = ""
+        expires_at = ""
 
-        service_data: dict[str, Any] = json.loads(data)  # type: ignore[arg-type]
-        now = self._now_iso()
-        expires_at = self._compute_expires_at()
+        def _ping(pipe: Pipeline) -> None:
+            nonlocal now, expires_at
+            data = pipe.get(key)
+            if data is None:
+                raise ServiceNotFoundError(f"Service {service_id} not found")
 
-        service_data["last_ping_at"] = now
-        service_data["last_updated"] = now
-        service_data["expires_at"] = expires_at
+            service_data: dict[str, Any] = json.loads(data)  # type: ignore[arg-type]
+            now = self._now_iso()
+            expires_at = self._compute_expires_at()
 
-        self.redis.setex(key, self.ttl_seconds, json.dumps(service_data))
+            service_data["last_ping_at"] = now
+            service_data["last_updated"] = now
+            service_data["expires_at"] = expires_at
+
+            pipe.multi()
+            pipe.setex(key, self.ttl_seconds, json.dumps(service_data))
+
+        # The read and the write run as one WATCH/MULTI/EXEC transaction, so a ping
+        # can neither recreate a registration deleted in between nor overwrite a
+        # re-registration that changed the URL: EXEC fails and the ping is retried
+        # against the current state, or raises ServiceNotFoundError.
+        self.redis.transaction(_ping, key)
 
         return PingResponse(
             id=service_id,

--- a/docs/webapi/service-registration.md
+++ b/docs/webapi/service-registration.md
@@ -119,6 +119,8 @@ response = httpx.put(
 
 The ping resets the TTL timer. If a service fails to ping within the TTL window (default 30 seconds), it is automatically removed from the registry.
 
+A ping only refreshes the expiry. It never changes the registered URL or service info, so a service that moves must call `$register` again. A ping for a service that has expired or been deregistered returns 404 and does not recreate the registration; the service must re-register.
+
 ## Integration with Servicekit
 
 [Servicekit](https://github.com/winterop-com/servicekit) handles registration automatically. Configure your service with the registration URL and key:

--- a/tests/integration/rest_api/test_orchestrator.py
+++ b/tests/integration/rest_api/test_orchestrator.py
@@ -3,6 +3,7 @@ import pytest
 
 from chap_core.rest_api.services.orchestrator import (
     DEFAULT_TTL_SECONDS,
+    KEY_PREFIX,
     Orchestrator,
     ServiceNotFoundError,
 )
@@ -17,9 +18,35 @@ from chap_core.rest_api.services.schemas import (
 )
 
 
+class RacingFakeRedis(fakeredis.FakeRedis):
+    """FakeRedis whose transactions can be interleaved with a concurrent write.
+
+    Set ``before_write`` to a callable; it runs once, after the transaction has
+    read the key and right before it enters MULTI, which is the window a
+    concurrent deregister or re-register lands in.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.before_write = None
+
+    def pipeline(self, transaction=True, shard_hint=None):
+        pipe = super().pipeline(transaction, shard_hint)
+        original_multi = pipe.multi
+
+        def multi():
+            hook, self.before_write = self.before_write, None
+            if hook is not None:
+                hook()
+            return original_multi()
+
+        pipe.multi = multi  # type: ignore[method-assign]
+        return pipe
+
+
 @pytest.fixture
 def fake_redis():
-    return fakeredis.FakeRedis()
+    return RacingFakeRedis()
 
 
 @pytest.fixture
@@ -112,6 +139,26 @@ class TestPing:
     def test_ping_nonexistent_service_raises_error(self, orchestrator):
         with pytest.raises(ServiceNotFoundError):
             orchestrator.ping("nonexistent-id")
+
+    def test_ping_after_concurrent_deregister_does_not_resurrect(self, orchestrator, fake_redis, sample_payload):
+        reg = orchestrator.register(sample_payload)
+        fake_redis.before_write = lambda: orchestrator.deregister(reg.id)
+
+        with pytest.raises(ServiceNotFoundError):
+            orchestrator.ping(reg.id)
+
+        assert fake_redis.exists(f"{KEY_PREFIX}{reg.id}") == 0
+
+    def test_ping_after_concurrent_reregister_keeps_new_url(self, orchestrator, fake_redis, sample_payload):
+        reg = orchestrator.register(sample_payload)
+        new_payload = sample_payload.model_copy(update={"url": "http://new-host:9090"})
+        fake_redis.before_write = lambda: orchestrator.register(new_payload)
+
+        ping_response = orchestrator.ping(reg.id)
+
+        assert ping_response.status == "alive"
+        assert orchestrator.get(reg.id).url == "http://new-host:9090"
+        assert orchestrator.get(reg.id).last_ping_at == ping_response.last_ping_at
 
 
 class TestGet:


### PR DESCRIPTION
## Problem

`Orchestrator.ping()` read the whole registration with `GET` and wrote it back with `SETEX`. Two races follow, both reproduced against a real Redis:

- A ping that overlaps a graceful deregister recreates the deleted key for a full TTL (30 s), so chap-core keeps routing to a chapkit service that has shut down. A chapkit container pings on a timer and deregisters on shutdown, so the two are concurrent by construction.
- A ping that overlaps a re-registration with a new URL writes the old URL back.

`register()` had the same read-then-write shape. This is the path every deployment uses (for example `compose.ewars.yml`).

## Change

`register()` and `ping()` run as `WATCH`/`MULTI`/`EXEC` transactions through redis-py's `transaction` helper. A concurrent write between the read and `EXEC` makes `EXEC` fail and the operation retries against the new state; a ping for a key that no longer exists raises `ServiceNotFoundError` without writing. The stored JSON shape, TTL, `expires_at`, and response models are unchanged, so the sync hooks and the worker's URL resolution are unaffected. Default behaviour for a healthy service is identical.

## Tests

Two deterministic race tests in `tests/integration/rest_api/test_orchestrator.py`, using a `FakeRedis` subclass that runs a concurrent operation once, right before the transaction enters `MULTI`. Both fail against the previous implementation (resurrected key; old URL restored).

## Docs

`docs/webapi/service-registration.md` keepalive section now states that a ping only refreshes the expiry, never changes the URL, and returns 404 without recreating an expired or deregistered service.

## Verification

- `uv run pytest tests/integration/rest_api/test_orchestrator.py tests/integration/rest_api/test_services_router.py tests/integration/rest_api/test_chapkit_self_registration.py -q`: 71 passed
- `make lint`: clean
- Live against Redis 7 with a pipeline delayed between read and `MULTI`: deregister during ping leaves `exists = 0` and the ping raises; re-register during ping keeps `http://new:2`. Both retries were observed as `EXEC` failures followed by a retry.

Jira: CLIM-1073