### PR TITLE
fix: bound chapkit client requests, treat cancelled jobs as failures, keep error detail (CLIM-1074)

### DIFF
--- a/chap_core/models/chapkit_rest_api_wrapper.py
+++ b/chap_core/models/chapkit_rest_api_wrapper.py
@@ -17,6 +17,16 @@ from chap_core.time_period.date_util_wrapper import pandas_period_to_string
 
 logger = logging.getLogger(__name__)
 
+# Per-request bounds. Long-running work (train, predict) is asynchronous on the
+# chapkit side and polled through wait_for_job, so these only need to cover a
+# single request such as a data upload or an artifact download. Same shape as
+# the v2 proxy client.
+DEFAULT_REQUEST_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=300.0, pool=10.0)
+
+# Consecutive failed status polls tolerated before wait_for_job gives up, so a
+# service that is restarting or a single transport blip does not abort a job wait.
+MAX_CONSECUTIVE_POLL_ERRORS = 5
+
 
 class RunInfo(BaseModel):
     """Runtime information passed from CHAP to models."""
@@ -50,14 +60,37 @@ def _serialize_geo(geo_features: dict[str, Any] | None) -> dict[str, Any] | None
     return geo_features if isinstance(geo_features, dict) else geo_features.model_dump()
 
 
+def _describe_error_response(response: httpx.Response) -> str:
+    """Summarize an error body: RFC 9457 problem details, the 422 validation shape, or raw text."""
+    try:
+        body = response.json()
+    except ValueError:
+        return response.text[:500]
+    if isinstance(body, dict):
+        parts = [str(body[key]) for key in ("title", "detail", "errors") if body.get(key)]
+        if body.get("trace_id"):
+            parts.append(f"trace_id={body['trace_id']}")
+        if parts:
+            return "; ".join(parts)
+    return str(body)[:500]
+
+
 class CHAPKitRestAPIWrapper:
     """Synchronous client for interacting with the CHAPKit REST API."""
 
-    def __init__(self, base_url: str = "http://localhost:8001", timeout: int = 7200):
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8001",
+        timeout: float | httpx.Timeout = DEFAULT_REQUEST_TIMEOUT,
+        transport: httpx.BaseTransport | None = None,
+    ):
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
         self.client = httpx.Client(
-            base_url=self.base_url, timeout=self.timeout, headers={"Content-Type": "application/json"}
+            base_url=self.base_url,
+            timeout=self.timeout,
+            headers={"Content-Type": "application/json"},
+            transport=transport,
         )
 
     def __enter__(self):
@@ -67,13 +100,23 @@ class CHAPKitRestAPIWrapper:
         self.close()
 
     def _request(self, method: str, endpoint: str, **kwargs) -> httpx.Response:
-        """Make synchronous HTTP request with error handling."""
+        """Make a synchronous HTTP request.
+
+        A non-2xx response is re-raised as ``httpx.HTTPStatusError`` with the
+        service's error detail in the message and the response still attached.
+        Transport errors (timeouts, connection failures) propagate unchanged.
+        """
         try:
             response = self.client.request(method, endpoint, **kwargs)
             response.raise_for_status()
             return response
-        except httpx.HTTPError as e:
-            raise httpx.HTTPError(f"API request failed: {e}") from e
+        except httpx.HTTPStatusError as e:
+            raise httpx.HTTPStatusError(
+                f"API request failed: {method} {endpoint} returned {e.response.status_code}: "
+                f"{_describe_error_response(e.response)}",
+                request=e.request,
+                response=e.response,
+            ) from e
 
     def close(self):
         """Close the client connection."""
@@ -185,16 +228,36 @@ class CHAPKitRestAPIWrapper:
 
     # Helper methods
 
-    def wait_for_job(self, job_id: str, poll_interval: int = 2, timeout: int | None = None) -> chapkit.ChapkitJobRecord:
-        """Wait for a job to complete."""
+    def wait_for_job(
+        self, job_id: str, poll_interval: float = 2, timeout: float | None = None
+    ) -> chapkit.ChapkitJobRecord:
+        """Wait for a job to reach a terminal status (completed, failed or canceled).
+
+        Up to MAX_CONSECUTIVE_POLL_ERRORS consecutive failed status requests are
+        tolerated before the last error is raised.
+        """
         start_time = time.time()
+        consecutive_errors = 0
 
         while True:
-            job = self.get_job(job_id)
-            logger.info(f"Job {job_id} status: {job.status}")
-
-            if job.status in ["completed", "failed", "canceled"]:
-                return job
+            try:
+                job = self.get_job(job_id)
+            except httpx.HTTPError as e:
+                consecutive_errors += 1
+                if consecutive_errors >= MAX_CONSECUTIVE_POLL_ERRORS:
+                    raise
+                logger.warning(
+                    "Polling job %s failed (%d/%d), retrying: %s",
+                    job_id,
+                    consecutive_errors,
+                    MAX_CONSECUTIVE_POLL_ERRORS,
+                    e,
+                )
+            else:
+                consecutive_errors = 0
+                logger.info(f"Job {job_id} status: {job.status}")
+                if job.status in ["completed", "failed", "canceled"]:
+                    return job
 
             if timeout and (time.time() - start_time) > timeout:
                 raise TimeoutError(f"Job {job_id} did not complete within {timeout} seconds")
@@ -207,7 +270,7 @@ class CHAPKitRestAPIWrapper:
         data: pd.DataFrame,
         run_info: RunInfo,
         geo_features: dict[str, Any] | None = None,
-        timeout: int | None = 300,
+        timeout: float | None = 7200,
     ) -> tuple[chapkit.ChapkitJobRecord, str]:
         """Train a model and wait for completion.
 
@@ -225,7 +288,7 @@ class CHAPKitRestAPIWrapper:
         run_info: RunInfo,
         historic_data: pd.DataFrame | None = None,
         geo_features: dict[str, Any] | None = None,
-        timeout: int | None = 7200,
+        timeout: float | None = 7200,
     ) -> tuple[chapkit.ChapkitJobRecord, str]:
         """Make predictions and wait for completion.
 

--- a/chap_core/models/external_chapkit_model.py
+++ b/chap_core/models/external_chapkit_model.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from chap_core.datatypes import Samples
+from chap_core.exceptions import ModelFailedException
 from chap_core.external.model_configuration import ModelTemplateConfigV2
 from chap_core.model_spec import PeriodType
 from chap_core.models.chapkit_rest_api_wrapper import CHAPKitRestAPIWrapper, RunInfo
@@ -173,7 +174,9 @@ class ExternalChapkitModelTemplate:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        """Stop service if in directory mode."""
+        """Close the client, and stop the service if in directory mode."""
+        if self.client is not None:
+            self.client.close()
         if self._service_manager is not None and not self._is_url_mode:
             self._service_manager.__exit__(exc_type, exc_val, exc_tb)
             self.rest_api_url = None
@@ -273,6 +276,7 @@ class ExternalChapkitModelTemplate:
             self.rest_api_url,
             configuration_id=configuration_id,
             model_information=self.model_template_config,
+            client=self.client,
         )
 
     @property
@@ -311,13 +315,16 @@ class ExternalChapkitModel(ExternalModelBase):
         rest_api_url: str,
         configuration_id: str,
         model_information: ModelTemplateConfigV2 | None = None,
+        client: CHAPKitRestAPIWrapper | None = None,
     ):
         self.model_name = model_name
         self.rest_api_url = rest_api_url
         self.configuration_id = configuration_id
         self._location_mapping = None
         self._adapters = None
-        self.client = CHAPKitRestAPIWrapper(rest_api_url)
+        # Share the template's client when given so one connection pool serves
+        # both, instead of opening a second one that nothing closes.
+        self.client = client if client is not None else CHAPKitRestAPIWrapper(rest_api_url)
         self._train_id: str | None = None
         self._model_information = model_information
 
@@ -334,9 +341,10 @@ class ExternalChapkitModel(ExternalModelBase):
             run_info = RunInfo(prediction_length=1)
         job, artifact_id = self.client.train_and_wait(self.configuration_id, new_df, run_info, geo)
 
-        if job.status == "failed":
-            raise RuntimeError(
-                f"Training failed: {job.error or 'Unknown error'}. Stacktrace: {job.error_traceback or ''}"
+        if job.status != "completed":
+            raise ModelFailedException(
+                f"Training job {job.id} ended with status '{job.status}': {job.error or 'Unknown error'}. "
+                f"Stacktrace: {job.error_traceback or ''}"
             )
 
         assert artifact_id is not None, f"No artifact_id returned: {job}"
@@ -359,8 +367,11 @@ class ExternalChapkitModel(ExternalModelBase):
             geo_features=geo,
         )
 
-        if job.status == "failed":
-            raise RuntimeError(f"Prediction failed: {job.error or 'Unknown error'}")
+        if job.status != "completed":
+            raise ModelFailedException(
+                f"Prediction job {job.id} ended with status '{job.status}': {job.error or 'Unknown error'}. "
+                f"Stacktrace: {job.error_traceback or ''}"
+            )
 
         assert artifact_id is not None, f"No prediction artifact: {job.error or ''}"
 

--- a/chap_core/rest_api/v1/routers/crud.py
+++ b/chap_core/rest_api/v1/routers/crud.py
@@ -124,7 +124,10 @@ def _sync_live_chapkit_services(session: Session, orchestrator=None) -> set[str]
                 # sync can then create the template with its full user options.
                 try:
                     client = CHAPKitRestAPIWrapper(service.url, timeout=5)
-                    schema = client.get_config_schema()
+                    try:
+                        schema = client.get_config_schema()
+                    finally:
+                        client.close()
                     user_options = _parse_user_options_from_config_schema(schema)
                 except Exception:
                     logger.warning(
@@ -225,38 +228,41 @@ def _sync_chapkit_configured_models(
 
     client = wrapper_cls(service_url, timeout=5)
     try:
-        configs = client.list_configs()
-    except Exception:
-        logger.debug("Could not fetch configs from %s, will retry next sync", service_url)
-        return
+        try:
+            configs = client.list_configs()
+        except Exception:
+            logger.debug("Could not fetch configs from %s, will retry next sync", service_url)
+            return
 
-    default_additional = _resolve_chapkit_default_additional_covariates(client)
+        default_additional = _resolve_chapkit_default_additional_covariates(client)
 
-    if not configs:
-        session_wrapper.add_configured_model(
-            template_id,
-            ModelConfiguration(user_option_values={}, additional_continuous_covariates=default_additional),
-            "default",
-            uses_chapkit=True,
-        )
-        return
+        if not configs:
+            session_wrapper.add_configured_model(
+                template_id,
+                ModelConfiguration(user_option_values={}, additional_continuous_covariates=default_additional),
+                "default",
+                uses_chapkit=True,
+            )
+            return
 
-    for cfg in configs:
-        # Chapkit manages its own config data; chap-core stores the
-        # configured model as a reference only, with empty user options.
-        # Carry over `additional_continuous_covariates` from the config's
-        # own data when present; otherwise fall back to the service-level
-        # default probed above.
-        cfg_data = getattr(cfg, "data", None) or {}
-        if hasattr(cfg_data, "model_dump"):
-            cfg_data = cfg_data.model_dump()
-        cfg_additional = list(cfg_data.get("additional_continuous_covariates", []) or []) or default_additional
-        session_wrapper.add_configured_model(
-            template_id,
-            ModelConfiguration(user_option_values={}, additional_continuous_covariates=cfg_additional),
-            cfg.name,
-            uses_chapkit=True,
-        )
+        for cfg in configs:
+            # Chapkit manages its own config data; chap-core stores the
+            # configured model as a reference only, with empty user options.
+            # Carry over `additional_continuous_covariates` from the config's
+            # own data when present; otherwise fall back to the service-level
+            # default probed above.
+            cfg_data = getattr(cfg, "data", None) or {}
+            if hasattr(cfg_data, "model_dump"):
+                cfg_data = cfg_data.model_dump()
+            cfg_additional = list(cfg_data.get("additional_continuous_covariates", []) or []) or default_additional
+            session_wrapper.add_configured_model(
+                template_id,
+                ModelConfiguration(user_option_values={}, additional_continuous_covariates=cfg_additional),
+                cfg.name,
+                uses_chapkit=True,
+            )
+    finally:
+        client.close()
 
 
 router = APIRouter(prefix="/crud")

--- a/docs/chap-cli/eval-reference.md
+++ b/docs/chap-cli/eval-reference.md
@@ -185,6 +185,8 @@ When providing a directory path with `--run-config.is-chapkit-model`, Chap autom
 3. Runs the evaluation
 4. Stops the service when complete
 
+The service's own output is forwarded to Chap's debug log (`--run-config.debug`), and the last lines are included in the error message if the service fails to start.
+
 ## Input Data Format
 
 ### CSV File Requirements

--- a/tests/external/test_chapkit_integration.py
+++ b/tests/external/test_chapkit_integration.py
@@ -3,6 +3,10 @@
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import json
+import socket
+import threading
+
 import chapkit
 import httpx
 import pytest
@@ -14,7 +18,13 @@ from ulid import ULID
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
 from chapkit.api import HealthStatus
 
-from chap_core.models.chapkit_rest_api_wrapper import CHAPKitRestAPIWrapper, RunInfo
+from chap_core.exceptions import ModelFailedException
+from chap_core.models.chapkit_rest_api_wrapper import (
+    DEFAULT_REQUEST_TIMEOUT,
+    MAX_CONSECUTIVE_POLL_ERRORS,
+    CHAPKitRestAPIWrapper,
+    RunInfo,
+)
 from chap_core.models.external_chapkit_model import (
     ExternalChapkitModel,
     ExternalChapkitModelTemplate,
@@ -515,3 +525,177 @@ class TestIsChapkitUrl:
     def test_unreachable_service(self):
         with patch("chap_core.models.utils.httpx.get", side_effect=httpx.ConnectError("Connection refused")):
             assert _is_chapkit_url("http://localhost:9999") is False
+
+
+def _mock_wrapper(handler, **kwargs) -> CHAPKitRestAPIWrapper:
+    """A wrapper whose HTTP layer is an httpx.MockTransport driven by ``handler``."""
+    return CHAPKitRestAPIWrapper("http://chapkit.test", transport=httpx.MockTransport(handler), **kwargs)
+
+
+def _config_out_json(config_id=VALID_ULID_1):
+    return {
+        "id": config_id,
+        "name": "test",
+        "data": {"prediction_periods": 3},
+        "created_at": "2024-01-01T00:00:00",
+        "updated_at": "2024-01-01T00:00:00",
+    }
+
+
+class TestRequestErrorHandling:
+    def test_request_preserves_status_and_problem_detail(self):
+        def handler(request):
+            return httpx.Response(
+                409,
+                json={
+                    "type": "urn:servicekit:error:conflict",
+                    "title": "Conflict",
+                    "status": 409,
+                    "detail": "config x exists",
+                },
+                headers={"content-type": "application/problem+json"},
+            )
+
+        wrapper = _mock_wrapper(handler)
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            wrapper.get_config_schema()
+
+        assert exc_info.value.response.status_code == 409
+        assert "config x exists" in str(exc_info.value)
+        assert "Conflict" in str(exc_info.value)
+
+    def test_default_timeout_is_bounded(self):
+        assert CHAPKitRestAPIWrapper("http://chapkit.test").client.timeout == DEFAULT_REQUEST_TIMEOUT
+
+    def test_read_timeout_is_enforced_against_silent_server(self):
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        accepted = []
+
+        def accept_and_hold():
+            conn, _ = server.accept()
+            accepted.append(conn)
+
+        threading.Thread(target=accept_and_hold, daemon=True).start()
+        try:
+            wrapper = CHAPKitRestAPIWrapper(f"http://127.0.0.1:{port}", timeout=httpx.Timeout(0.5))
+            with pytest.raises(httpx.ReadTimeout):
+                wrapper.health()
+        finally:
+            for conn in accepted:
+                conn.close()
+            server.close()
+
+
+class TestWaitForJob:
+    def test_wait_for_job_tolerates_transient_poll_errors(self):
+        calls = []
+
+        def handler(request):
+            calls.append(request.url.path)
+            if len(calls) <= 2:
+                return httpx.Response(502, json={"title": "Bad Gateway", "status": 502})
+            return httpx.Response(200, json={"id": VALID_ULID_1, "status": "completed"})
+
+        job = _mock_wrapper(handler).wait_for_job(VALID_ULID_1, poll_interval=0)
+
+        assert job.status == "completed"
+        assert len(calls) == 3
+
+    def test_wait_for_job_gives_up_after_consecutive_errors(self):
+        calls = []
+
+        def handler(request):
+            calls.append(request.url.path)
+            return httpx.Response(502, json={"title": "Bad Gateway", "status": 502})
+
+        with pytest.raises(httpx.HTTPStatusError):
+            _mock_wrapper(handler).wait_for_job(VALID_ULID_1, poll_interval=0)
+
+        assert len(calls) == MAX_CONSECUTIVE_POLL_ERRORS
+
+
+class TestCancelledJobs:
+    @staticmethod
+    def _handler(train_status, predict_status, artifact_calls):
+        predict_job = str(ULID())
+
+        def handler(request):
+            path = request.url.path
+            if path == "/api/v1/ml/$train":
+                return httpx.Response(200, json={"job_id": VALID_ULID_1, "artifact_id": VALID_ULID_2, "message": "ok"})
+            if path == "/api/v1/ml/$predict":
+                return httpx.Response(200, json={"job_id": predict_job, "artifact_id": VALID_ULID_2, "message": "ok"})
+            if path == f"/api/v1/jobs/{VALID_ULID_1}":
+                return httpx.Response(200, json={"id": VALID_ULID_1, "status": train_status})
+            if path == f"/api/v1/jobs/{predict_job}":
+                return httpx.Response(
+                    200, json={"id": predict_job, "status": predict_status, "error": "stopped by operator"}
+                )
+            if path.startswith("/api/v1/artifacts/"):
+                artifact_calls.append(path)
+                return httpx.Response(404, json={"title": "Not Found", "status": 404})
+            raise AssertionError(f"unexpected request {request.method} {path}")
+
+        return handler
+
+    def test_train_raises_on_cancelled_job(self, train_data):
+        model = ExternalChapkitModel(
+            "m",
+            "http://chapkit.test",
+            configuration_id=VALID_ULID_1,
+            client=_mock_wrapper(self._handler("canceled", "completed", [])),
+        )
+
+        with pytest.raises(ModelFailedException, match="canceled"):
+            model.train(train_data)
+
+    def test_predict_raises_on_cancelled_job_without_fetching_artifact(self, train_data):
+        artifact_calls: list[str] = []
+        model = ExternalChapkitModel(
+            "m",
+            "http://chapkit.test",
+            configuration_id=VALID_ULID_1,
+            client=_mock_wrapper(self._handler("completed", "canceled", artifact_calls)),
+        )
+        model.train(train_data)
+
+        with pytest.raises(ModelFailedException, match="canceled"):
+            model.predict(train_data, train_data)
+
+        assert artifact_calls == []
+
+
+class TestTemplateClientLifecycle:
+    @staticmethod
+    def _handler(request):
+        path = request.url.path
+        if path == "/api/v1/info":
+            return httpx.Response(200, json=MOCK_INFO_DICT)
+        if path == "/api/v1/configs/$schema":
+            return httpx.Response(200, json=MOCK_CONFIG_SCHEMA)
+        if path == "/api/v1/configs" and request.method == "POST":
+            return httpx.Response(200, json=_config_out_json(json.loads(request.content).get("name") and VALID_ULID_1))
+        if path == "/api/v1/configs":
+            return httpx.Response(200, json=[_config_out_json()])
+        raise AssertionError(f"unexpected request {request.method} {path}")
+
+    def test_get_model_reuses_template_client(self):
+        template = ExternalChapkitModelTemplate("http://chapkit.test")
+        template.client = _mock_wrapper(self._handler)
+
+        model = template.get_model({})
+
+        assert model.client is template.client
+
+    def test_template_exit_closes_client_in_url_mode(self):
+        template = ExternalChapkitModelTemplate("http://chapkit.test")
+        template.client = _mock_wrapper(self._handler)
+
+        with template:
+            assert not template.client.client.is_closed
+
+        assert template.client is not None
+        assert template.client.client.is_closed


### PR DESCRIPTION
## Problems

All on the URL-mode path that deployments use (a running chapkit service such as `compose.ewars.yml`), in `chap_core/models/chapkit_rest_api_wrapper.py` and `chap_core/models/external_chapkit_model.py`:

1. `CHAPKitRestAPIWrapper` opened `httpx.Client(timeout=7200)`, applied to connect, read, write and pool. A hung service pinned a Celery worker for two hours per request.
2. `train()` and `predict()` only checked for status `failed`. A job that ended `canceled` was treated as success, because the artifact id comes from the submission response, so `_train_id` pointed at an artifact that was never produced and the failure surfaced later as a 404. chapkit's own CLI treats `canceled` as failure.
3. `_request` re-raised `httpx.HTTPStatusError` as a bare `httpx.HTTPError`, dropping the status code, the response, and the RFC 9457 problem body chapkit 2 returns.
4. `wait_for_job` aborted the whole wait on the first transient error while polling.
5. The template and the model each opened a connection pool and nothing ever closed either; the model-template sync in `crud.py` opened more per request.
6. `train_and_wait` defaulted to a 300 s job wait while `predict_and_wait` allowed 7200 s, so any training longer than five minutes raised `TimeoutError`.

## Change

- Default per-request timeout is `connect=10, read=300, write=300, pool=10`, the same shape as the v2 proxy client. Train and predict are asynchronous jobs polled by `wait_for_job`, so this does not cap training time. The training job wait is aligned to 7200 s. A `transport` argument allows `httpx.MockTransport` in tests.
- Any non-`completed` job status raises `ModelFailedException` (what every other runner raises) with the job's error and traceback. `db_worker_functions` catches `Exception`, and nothing caught the previous `RuntimeError`, so callers are unaffected.
- `_request` re-raises `HTTPStatusError` with the parsed problem detail (`title`, `detail`, `errors`, `trace_id`) in the message and the response attached. Transport errors propagate unchanged.
- `wait_for_job` tolerates up to five consecutive failed status polls before raising the last error.
- The model reuses the template's client; the template closes it on `__exit__` in URL mode (the CLI paths already use `with template:`); the sync code in `crud.py` closes the clients it opens.

Default behaviour for a healthy service is unchanged.

## Tests

Seven new tests in `tests/external/test_chapkit_integration.py` using `httpx.MockTransport`: problem-detail preservation, bounded default timeout, read timeout enforced against a server that accepts and never answers, transient poll errors tolerated, give-up after the error budget, cancelled train and cancelled predict (no artifact fetch), shared client, and close on template exit. They cannot import against the previous module.

## Docs

No page documented the client timeouts, the training wait, or job-status handling, so nothing was outdated. `docs/chap-cli/eval-reference.md` gains one line describing the directory-mode output forwarding added in #574.

## Verification

- `uv run pytest tests/external/test_chapkit_integration.py tests/external/test_external_chapkit_model.py tests/test_chapkit_service_info_compat.py -q`: 69 passed, 2 skipped
- `make lint`: clean
- `make test`: 1475 passed, 103 skipped
- `uv run pytest tests/integration/test_chapkit_e2e.py --run-slow`: 4 passed against a real chapkit 2.0.0 service (train, poll, predict, artifact fetch through the patched client)

Jira: CLIM-1074