### PR TITLE
fix: persist data sources when creating a dataset via make-dataset

### DIFF
--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -15,7 +15,7 @@ from chap_core.assessment.weather_providers import DEFAULT_WEATHER_PROVIDER_ID
 from chap_core.data import DataSet as InMemoryDataSet
 from chap_core.database.database import SessionWrapper
 from chap_core.database.dataset_manager import DataSetManager
-from chap_core.database.dataset_tables import DataSetCreateInfo
+from chap_core.database.dataset_tables import DataSetCreateInfo, DataSource
 from chap_core.datatypes import HealthPopulationData, create_tsdataclass
 from chap_core.log_config import get_status_logger
 from chap_core.rest_api.data_models import BacktestCreate, FetchRequest, PredictionParams
@@ -225,6 +225,7 @@ def harmonize_and_add_dataset(
     ds_type: str,
     session: SessionWrapper,
     worker_config: WorkerConfig = WorkerConfig(),
+    data_sources: list[DataSource] | None = None,
 ) -> int:
     status_logger.info(f"Processing and adding dataset '{name}' of type '{ds_type}'")
     provided_dataclass = create_tsdataclass(provided_field_names)
@@ -235,7 +236,7 @@ def harmonize_and_add_dataset(
         )
     else:
         full_dataset = dataset_obj
-    info = DataSetCreateInfo(name=name, type=ds_type)
+    info = DataSetCreateInfo(name=name, type=ds_type, data_sources=data_sources or [])
     db_id: int = DataSetManager(session.session).save_dataset(
         info, full_dataset, polygons=dataset_obj.polygons.model_dump_json()
     )

--- a/chap_core/rest_api/v1/routers/analytics.py
+++ b/chap_core/rest_api/v1/routers/analytics.py
@@ -88,6 +88,7 @@ def make_dataset(
         provided_data.model_dump(),
         request.name,
         request.type,
+        data_sources=request.data_sources,
         database_url=database_url,
         worker_config=worker_settings,
         **{JOB_TYPE_KW: JobType.DATASET, JOB_NAME_KW: request.name},

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, select
 
 from chap_core.api_types import DataList, EvaluationEntry, PredictionEntry
 from chap_core.database.database import SessionWrapper
+from chap_core.datatypes import create_tsdataclass
 from chap_core.database.dataset_manager import DataSetManager
 from chap_core.database.model_templates_and_config_tables import ConfiguredModelDB
 from chap_core.database.dataset_tables import DataSet, DataSetCreateInfo, DataSetWithObservations, ObservationBase
@@ -34,7 +35,8 @@ from chap_core.rest_api.data_models import (
     ModelTemplateRead,
 )
 from chap_core.rest_api.app import app
-from chap_core.rest_api.db_worker_functions import run_backtest
+from chap_core.spatio_temporal_data.converters import observations_to_dataset
+from chap_core.rest_api.db_worker_functions import harmonize_and_add_dataset, run_backtest
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -218,6 +220,29 @@ def test_list_model_templates(celery_session_worker, dependency_overrides):
     assert "chap_ewars_monthly" in (m.name for m in models)
     ewars_model = next(m for m in models if m.name == "chap_ewars_monthly")
     assert "population" in [f for f in ewars_model.required_covariates], ewars_model.required_covariates
+
+
+def test_make_dataset_import_persists_data_sources(clean_engine, dataset_make_request):
+    """The covariate to data-element mapping sent to make-dataset must survive the import."""
+    request = dataset_make_request
+    assert request.data_sources, "fixture should provide a mapping to persist"
+    feature_names = list({obs.feature_name for obs in request.provided_data})
+    provided_data = observations_to_dataset(create_tsdataclass(feature_names), request.provided_data, fill_missing=True)
+    provided_data.set_polygons(request.geojson)
+
+    with SessionWrapper(clean_engine) as session:
+        dataset_id = harmonize_and_add_dataset(
+            feature_names,
+            request.data_to_be_fetched,
+            provided_data.model_dump(),
+            request.name,
+            request.type,
+            session=session,
+            data_sources=request.data_sources,
+        )
+        stored = session.session.get(DataSet, dataset_id)
+        assert stored is not None
+        assert stored.data_sources == request.data_sources
 
 
 def test_get_data_sources():


### PR DESCRIPTION
`POST /v1/analytics/make-dataset` accepts a `dataSources` mapping (covariate name to DHIS2 data element id) in its body and then throws it away. The endpoint passed only the feature names, fetch list, observations, name and type to the background worker, and the worker rebuilt `DataSetCreateInfo` from the name and type alone, so the mapping never reached `save_dataset`.

Verified against a running instance before the fix: submitting a mapping and reading the dataset back from `GET /v1/crud/datasets` returned an empty list.

`POST /v1/analytics/make-prediction` and `POST /v1/analytics/create-backtest-with-data` build the info object from the whole request and were never affected. That is why this went unnoticed: the mapping survives on the model-coupled paths the frontend uses today, and is lost precisely on the model-independent path that the new create-dataset page needs (CLIM-1075).

Prediction setups snapshot `covariateSources` from the dataset, so the loss propagated there too.

The fix threads `data_sources` from the endpoint through to the worker and onto the saved dataset.

Found while scoping CLIM-1071.

Tested with a new case in `tests/integration/rest_api/test_db_endpoints.py`, which reuses the existing `dataset_make_request` fixture. Confirmed it fails without the fix and passes with it.