### PR TITLE
fix: keep the broker and database off the network model services share (CLIM-977)

### DIFF
--- a/compose.ghcr.yml
+++ b/compose.ghcr.yml
@@ -43,6 +43,9 @@ services:
         target: /data/logs
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    networks:
+      - default
+      - backend
     ports:
       - "8000:8000"
     healthcheck:
@@ -80,6 +83,9 @@ services:
       CHAP_LOGS_DIR: /data/logs
       CHAP_RUNS_DIR: /data/runs
       PYTENSOR_FLAGS: "base_compiledir=/data/pytensor"
+    networks:
+      - default
+      - backend
     command: "/app/.venv/bin/celery -A chap_core.rest_api.celery_tasks worker --loglevel=info"
     working_dir: /app
     # Declared here, not inherited: a pinned tag may predate the image's HEALTHCHECK.
@@ -120,6 +126,8 @@ services:
   redis:
     restart: unless-stopped
     image: valkey/valkey:8
+    networks:
+      - backend
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
@@ -142,6 +150,8 @@ services:
       start_period: 40s
     volumes:
       - chap-db:/var/lib/postgresql/data
+    networks:
+      - backend
     expose:
       - "5432"
 
@@ -152,3 +162,8 @@ volumes:
   uv: {}
   pytensor: {}
   runs: {}
+
+networks:
+  # redis and postgres live here, off the default network, so model services
+  # (which attach only to default) cannot reach the Celery broker or the database.
+  backend: {}

--- a/compose.yml
+++ b/compose.yml
@@ -28,6 +28,9 @@ services:
         target: /data/logs
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    networks:
+      - default
+      - backend
     ports:
       - "8000:8000"
     healthcheck:
@@ -67,6 +70,9 @@ services:
       CHAP_LOGS_DIR: /data/logs
       CHAP_RUNS_DIR: /data/runs
       PYTENSOR_FLAGS: "base_compiledir=/data/pytensor"
+    networks:
+      - default
+      - backend
     command: "/app/.venv/bin/celery -A chap_core.rest_api.celery_tasks worker --loglevel=info"
     working_dir: /app
     extra_hosts:
@@ -100,6 +106,8 @@ services:
   redis:
     restart: unless-stopped
     image: valkey/valkey:8
+    networks:
+      - backend
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
@@ -122,6 +130,8 @@ services:
       start_period: 40s
     volumes:
       - chap-db:/var/lib/postgresql/data
+    networks:
+      - backend
     expose:
       - "5432"
 
@@ -135,3 +145,8 @@ volumes:
   uv: {}
   pytensor: {}
   runs: {}
+
+networks:
+  # redis and postgres live here, off the default network, so model services
+  # (which attach only to default) cannot reach the Celery broker or the database.
+  backend: {}

--- a/docs/modeling-app/running-your-own-model.md
+++ b/docs/modeling-app/running-your-own-model.md
@@ -55,6 +55,7 @@ services:
 The important parts:
 
 - **`SERVICEKIT_ORCHESTRATOR_URL`** points at Chap's registration endpoint using the Compose service name `chap`, not `localhost`. The `$$` is not a typo — Compose expands `$` as a variable, so `$$register` is how you write a literal `$register`.
+- No `networks` key is needed. Model services land on the default Compose network, which reaches `chap` and `worker` but not the Celery broker or the database, so a model container cannot enqueue tasks or read data on its own.
 - **`depends_on: chap: condition: service_healthy`** makes your model wait until Chap answers its health check, so the first registration attempt succeeds.
 - **`ports`** is optional and only needed if you want to reach the model directly from the host for debugging. Chap itself reaches it over the internal network. Pick a host port that is not already taken — the bundled stack uses 8000 for `chap` and 5002 for `ewars`, and the sample services in `compose.override.yml.example` add 5001 (`chtorch`) and 3288 (`ewars_plus`).
 - If your Chap deployment sets `SERVICEKIT_REGISTRATION_KEY` in `.env`, uncomment that line, or registration will be rejected.

--- a/docs/webapi/docker-compose-doc.md
+++ b/docs/webapi/docker-compose-doc.md
@@ -21,7 +21,7 @@ This is a short example for how to setup Chap-core locally as a service using do
 
 ## Compose file reference
 
-The repository ships several compose files. `compose.yml` and `compose.ghcr.yml` are **base** files and are alternatives to each other — never stack them, because Compose appends list fields on overlay and you get duplicate `security_opt` / `cap_drop` entries that fail validation. Everything else is an overlay layered on top of a base with additional `-f` flags.
+The repository ships several compose files. `compose.yml` and `compose.ghcr.yml` are **base** files and are alternatives to each other — never stack them, because Compose appends list fields on overlay and you get duplicate `security_opt` / `cap_drop` entries that fail validation. Everything else is an overlay layered on top of a base with additional `-f` flags. Both base files keep `redis` and `postgres` on a separate `backend` network; `chap` and `worker` join it alongside the default network, so model services on the default network cannot reach the broker or the database.
 
 | File | Kind | Purpose |
 |------|------|---------|

--- a/tests/test_compose_deployment.py
+++ b/tests/test_compose_deployment.py
@@ -168,3 +168,38 @@ def test_env_example_leaves_redis_password_unset():
         f".env.example sets {active}, so copying it to .env makes the redis client send AUTH "
         f"to a valkey service that has no password configured"
     )
+
+
+BASE_COMPOSE_FILES = ["compose.yml", "compose.ghcr.yml"]
+
+# The broker and database live here. Model services attach only to the implicit default
+# network, which reaches chap and worker but not this one.
+BACKEND_NETWORK = "backend"
+
+
+@pytest.mark.parametrize("compose_file", BASE_COMPOSE_FILES)
+def test_base_compose_keeps_broker_and_database_off_default_network(compose_file):
+    content = yaml.safe_load((REPO_ROOT / compose_file).read_text())
+    assert BACKEND_NETWORK in (content.get("networks") or {}), (
+        f"{compose_file} does not declare the '{BACKEND_NETWORK}' network"
+    )
+    services = content["services"]
+    for name in ("redis", "postgres"):
+        assert services[name].get("networks") == [BACKEND_NETWORK], (
+            f"{compose_file}: '{name}' must sit on '{BACKEND_NETWORK}' only, or any model service on the "
+            f"default network can reach it"
+        )
+    for name in ("chap", "worker"):
+        assert services[name].get("networks") == ["default", BACKEND_NETWORK], (
+            f"{compose_file}: '{name}' must join both networks to serve model services and reach the broker"
+        )
+
+
+@pytest.mark.parametrize("compose_file", MODEL_OVERLAY_FILES + ["compose.override.yml.example"])
+def test_model_services_stay_on_default_network(compose_file):
+    """A model service that declares no networks is isolated automatically; opting into backend defeats that."""
+    for service_name, service in _services(compose_file).items():
+        assert BACKEND_NETWORK not in (service.get("networks") or []), (
+            f"{compose_file}: service '{service_name}' joins '{BACKEND_NETWORK}', so it shares a network "
+            f"with the Celery broker and can enqueue tasks the worker executes"
+        )


### PR DESCRIPTION
## Problem

The compose stack runs valkey with no authentication and no compose file declares networks, so every service shares the project's default bridge and can reach `redis:6379`. Valkey is never published to the host, so the exposure is between containers: `compose.chapkit.yml` and any user `compose.override.yml` add third-party model images onto that same network. Redis is the Celery broker, so anything that can write to it can enqueue tasks the worker executes. The Kubernetes chart already requires a valkey password; compose is the odd one out.

CLIM-977 offers two remedies: authenticate valkey, or isolate model services from the broker. This PR does the isolation half. Authentication interacts with `.env.example`, host-side tests and the CI job that copies `.env.example`, and stays open on the ticket.

## Summary

- `compose.yml` and `compose.ghcr.yml` declare a `backend` network; `redis` and `postgres` sit on it only, `chap` and `worker` join it alongside `default`
- Model overlays need no `networks` key at all: a service that declares none lands on `default`, which reaches `chap` and `worker` but not the broker or the database, so models added from outside are isolated by default
- Test overlays keep working for the same reason; they only need `chap`
- Docs for writing your own model overlay explain the layout
- `tests/test_compose_deployment.py` locks in the attachments for base files and checks no shipped model overlay opts into `backend`

## Verification

- `docker compose config` passes for every documented stacking: dev, test, integration, r-model integration and the override template
- Runtime with `compose.yml` + `compose.chapkit.yml`: `ewars` cannot resolve `redis` or `postgres`, resolves `chap`; `chap` and `worker` reach the model at its registered URL (`/health` 200); worker reaches healthy through the broker; ewars registers as before
- `make lint`, `make test` (1464 passed)
