### PR TITLE
fix(validate): reject non-numeric required covariates and non-finite values

### DIFF
--- a/chap_core/services/dataset_validation.py
+++ b/chap_core/services/dataset_validation.py
@@ -80,21 +80,21 @@ def _check_nan_covariates(dataset: DataSet) -> list[ValidationIssue]:
                     issues.append(
                         ValidationIssue(
                             level="warning",
-                            message=f"Column '{field_name}' is non-numeric and will be ignored by models",
+                            message=f"Column '{field_name}' is non-numeric and is passed to the model as-is",
                         )
                     )
                 continue
             if not np.issubdtype(values.dtype, np.floating):
                 continue
-            isnan = np.isnan(values)
-            if np.any(isnan):
-                nan_periods = [data.time_period[i].to_string() for i in np.flatnonzero(isnan)]
+            invalid = ~np.isfinite(values)
+            if np.any(invalid):
+                invalid_periods = [data.time_period[i].to_string() for i in np.flatnonzero(invalid)]
                 issues.append(
                     ValidationIssue(
                         level="error",
-                        message=f"Missing values in '{field_name}'",
+                        message=f"Missing or non-finite values in '{field_name}'",
                         location=location,
-                        time_periods=nan_periods,
+                        time_periods=invalid_periods,
                     )
                 )
     return issues
@@ -133,6 +133,15 @@ def _check_required_covariates(dataset: DataSet, config: ModelTemplateConfigV2) 
         for covariate in config.required_covariates
         if not covariate.startswith(GEN_PREFIX) and covariate not in dataset_fields
     ]
+    sample = next(iter(dataset.values()))
+    issues.extend(
+        ValidationIssue(
+            level="error",
+            message=f"Required covariate '{covariate}' is non-numeric",
+        )
+        for covariate in config.required_covariates
+        if covariate in dataset_fields and not np.issubdtype(getattr(sample, covariate).dtype, np.number)
+    )
     issues.extend(_check_generated_features(config))
     return issues
 

--- a/tests/test_validate_cli.py
+++ b/tests/test_validate_cli.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -130,6 +131,29 @@ def test_validate_warns_on_non_numeric_field(tmp_path):
     issues = validate_dataset(dataset)
     warnings = [i for i in issues if i.level == "warning"]
     assert any("notes" in w.message and "non-numeric" in w.message for w in warnings)
+
+
+def test_validate_errors_on_non_numeric_required_covariate(tmp_path):
+    raw_df = pd.read_csv(LAOS_SUBSET)
+    raw_df["region_class"] = "urban"
+    csv_path = tmp_path / "with_string_covariate.csv"
+    raw_df.to_csv(csv_path, index=False)
+    dataset = DataSet.from_csv(csv_path)
+    config = ModelTemplateConfigV2(name="test_model", required_covariates=["rainfall", "region_class"])
+    issues = validate_dataset(dataset, model_template_config=config)
+    errors = [i for i in issues if i.level == "error"]
+    assert any("region_class" in e.message and "non-numeric" in e.message for e in errors)
+
+
+def test_validate_errors_on_infinite_covariate(tmp_path):
+    raw_df = pd.read_csv(LAOS_SUBSET)
+    raw_df.loc[0, "rainfall"] = np.inf
+    csv_path = tmp_path / "with_inf.csv"
+    raw_df.to_csv(csv_path, index=False)
+    dataset = DataSet.from_csv(csv_path, FullData)
+    issues = validate_dataset(dataset)
+    errors = [i for i in issues if i.level == "error"]
+    assert any("rainfall" in e.message and e.location is not None for e in errors)
 
 
 def test_validate_accepts_integer_columns(tmp_path):


### PR DESCRIPTION
## Problem

`chap validate` reports success, or only a warning, for datasets that then fail at run time.

- A required covariate that holds strings produces the warning `Column 'x' is non-numeric and will be ignored by models` and no error. The column is not ignored: `DataSet.to_csv` keeps it and the external model runner writes it to `training_data.csv` unchanged, so the model receives text where it expects numbers.
- A covariate containing `inf` or `-inf` produces no issue at all, because the missing-value check only looks for NaN. The climatology weather provider then fails inside sklearn with `Input y contains infinity or a value too large for dtype('float64')`.

Validation is only run by the `chap validate` command, so the point of the command is to catch exactly these cases before a backtest is started.

## Overview

Changes are limited to `chap_core/services/dataset_validation.py`:

- The missing-value check now uses `np.isfinite`, so `inf` and `-inf` are reported as errors alongside NaN, with the same per-location and per-period detail. Message: `Missing or non-finite values in '<field>'`.
- The required-covariate check now also verifies the dtype of each required covariate that is present. A non-numeric one is an error: `Required covariate '<field>' is non-numeric`.
- The non-numeric warning for columns the model does not require now says what actually happens: `Column '<field>' is non-numeric and is passed to the model as-is`. It stays a warning, since a stray text column that the model never reads is not fatal.

## Examples

`example_data/laos_subset.csv` with an added string column `region_class`, validated against a model that requires it:

Before:

```
Warnings (1):
  - Column 'region_class' is non-numeric and will be ignored by models
```

After:

```
Warnings (1):
  - Column 'region_class' is non-numeric and is passed to the model as-is

Errors (1):
  - Required covariate 'region_class' is non-numeric
```

`example_data/laos_subset.csv` with one `rainfall` value set to `inf`:

Before:

```
Validation passed: no issues found.
```

After:

```
Errors (1):
  - Missing or non-finite values in 'rainfall'
    Location: Bokeo
    Time periods: 2010-01
```

## Verification

- New tests in `tests/test_validate_cli.py`: `test_validate_errors_on_non_numeric_required_covariate` and `test_validate_errors_on_infinite_covariate`, both built on the existing `LAOS_SUBSET` fixture pattern.
- The existing `test_validate_warns_on_non_numeric_field` still passes: a string column the model does not require remains a warning.
- `make lint` and `make test` pass (1482 passed, 122 skipped).
