### PR TITLE
fix: describe MAPE as a percentage error, not Mean Absolute Error (CLIM-1087)

### DIFF
--- a/chap_core/assessment/metrics/mape.py
+++ b/chap_core/assessment/metrics/mape.py
@@ -32,7 +32,7 @@ class MAPEMetric(DeterministicMetric):
         metric_id="mape",
         metric_name="MAPE",
         aggregation_op=AggregationOp.MEAN,
-        description="Mean Absolute Percentage Error - average absolute prediction error as a percentage of the observed value",
+        description="Mean Absolute Percentage Error - average absolute error as percent of observed",
         optimization_direction=OptimizationDirection.MINIMIZE,
     )
 

--- a/chap_core/assessment/metrics/mape.py
+++ b/chap_core/assessment/metrics/mape.py
@@ -18,8 +18,8 @@ class MAPEMetric(DeterministicMetric):
     """
     Mean Absolute Percentage Error metric.
 
-    Computes the average of the absolute error for each entry. When aggregated using
-    MEAN, this produces the MAPE (mean of absolute percentage error).
+    Computes the absolute percentage error at the detailed level. When aggregated
+    using MEAN, this produces the MAPE (mean of absolute percentage errors).
 
     Usage:
         mape = MAPEMetric()
@@ -32,12 +32,12 @@ class MAPEMetric(DeterministicMetric):
         metric_id="mape",
         metric_name="MAPE",
         aggregation_op=AggregationOp.MEAN,
-        description="Mean Absolute Percentage Error - measures average absolute prediction error",
+        description="Mean Absolute Percentage Error - average absolute prediction error as a percentage of the observed value",
         optimization_direction=OptimizationDirection.MINIMIZE,
     )
 
     def compute_point_metric(self, forecast: float, observed: float) -> float:
-        """Compute absolute error for a single forecast/observation pair."""
+        """Compute absolute percentage error for a single forecast/observation pair."""
         if observed == 0.0:
             return np.nan
         return abs(observed - forecast) / abs(observed) * 100.0

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -324,6 +324,13 @@ def test_read_example_weekly_predictions(data_path):
     print(type(samples.time_period))
 
 
+def test_mape_description_is_about_percentage_error():
+    """MAPE must not be described as plain Mean Absolute Error."""
+    description = MAPEMetric.spec.description
+    assert "percentage" in description.lower()
+    assert description != MAEMetric.spec.description
+
+
 def test_mape_uses_median_of_samples(flat_forecasts_multiple_samples, flat_observations):
     """Test that MAPEMetric computes errors from median of samples."""
     mape = MAPEMetric()

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -324,13 +324,6 @@ def test_read_example_weekly_predictions(data_path):
     print(type(samples.time_period))
 
 
-def test_mape_description_is_about_percentage_error():
-    """MAPE must not be described as plain Mean Absolute Error."""
-    description = MAPEMetric.spec.description
-    assert "percentage" in description.lower()
-    assert description != MAEMetric.spec.description
-
-
 def test_mape_uses_median_of_samples(flat_forecasts_multiple_samples, flat_observations):
     """Test that MAPEMetric computes errors from median of samples."""
     mape = MAPEMetric()


### PR DESCRIPTION
The `mape` metric description and docstrings were copied from MAE and read "measures average absolute prediction error", with no mention of percentages, so users saw MAPE described as Mean Absolute Error.

- description now says the error is a percentage of the observed value
- class and method docstrings corrected to match