### PR TITLE
feat: expose whether a higher or lower metric score is better (CLIM-1088)

### DIFF
--- a/chap_core/rest_api/v1/routers/visualization.py
+++ b/chap_core/rest_api/v1/routers/visualization.py
@@ -18,6 +18,7 @@ from chap_core.assessment.backtest_plots.db_dimensions import DBFacetDimension, 
 from chap_core.assessment.evaluation import Evaluation
 from chap_core.assessment.metric_plots import get_metric_plots_registry, list_metric_plots
 from chap_core.assessment.metrics import available_metrics
+from chap_core.assessment.metrics.base import OptimizationDirection
 from chap_core.database.base_tables import DBModel
 from chap_core.database.dataset_tables import DataSet
 from chap_core.database.tables import Backtest
@@ -62,6 +63,13 @@ class MetricInfo(DBModel):
     id: str = Field(description="Canonical metric identifier used in URLs and request bodies.")
     display_name: str = Field(description="Human-friendly metric name shown in pickers.")
     description: str = Field(default="", description="Short paragraph explaining what the metric measures.")
+    optimization_direction: OptimizationDirection | None = Field(
+        default=None,
+        description=(
+            "Whether a lower ('minimize') or higher ('maximize') score is better. "
+            "Null for metrics where neither direction is better, such as coverage ratios."
+        ),
+    )
 
 
 @router.get(
@@ -70,7 +78,7 @@ class MetricInfo(DBModel):
     summary="Discover which scoring metrics are available",
 )
 def get_available_metrics(backtest_id: int):
-    """List the metrics you can score a backtest with (CRPS, MAE, ...), with a human-friendly name and description for each.
+    """List the metrics you can score a backtest with (CRPS, MAE, ...), with a human-friendly name, description and optimization direction for each.
 
     Use this to populate a metric picker in a UI before requesting a specific plot. The
     result is the same regardless of ``backtest_id`` — the path takes it for symmetry
@@ -83,6 +91,7 @@ def get_available_metrics(backtest_id: int):
             id=metric_id,
             display_name=metric_factory().get_name(),
             description=metric_factory().get_description(),
+            optimization_direction=metric_factory.spec.optimization_direction,
         )
         for metric_id, metric_factory in available_metrics.items()
     ]

--- a/tests/integration/rest_api/test_python_endpoints.py
+++ b/tests/integration/rest_api/test_python_endpoints.py
@@ -22,6 +22,13 @@ def test_get_available_metrics():
     assert any(metric.id == "rmse" for metric in metrics)
 
 
+def test_available_metrics_expose_optimization_direction():
+    metrics = {metric.id: metric for metric in get_available_metrics(backtest_id=1)}
+    assert metrics["crps"].optimization_direction == "minimize"
+    assert metrics["sensitivity"].optimization_direction == "maximize"
+    assert metrics["coverage_10_90"].optimization_direction is None
+
+
 def all_metric_ids():
     metrics = get_available_metrics(backtest_id=1)
     return [metric.id for metric in metrics]


### PR DESCRIPTION
The metric specs already carry an optimization direction, but `GET /v1/visualization/metrics/{backtest_id}` did not return it, so frontend would have to hardcode which metrics are better when lower.

- `MetricInfo` gains `optimization_direction` (`minimize` / `maximize`, null where neither direction is better, such as coverage ratios)
- populated from the metric spec; no new metadata to maintain
