### PR TITLE
feat: stream model output to the debug log as it arrives

### DIFF
--- a/chap_core/runners/command_line_runner.py
+++ b/chap_core/runners/command_line_runner.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 from pathlib import Path
 
@@ -31,17 +32,42 @@ def run_command(command: str, working_directory=Path("."), env: dict | None = No
         The directory to run the command in
     env : dict, optional
         Environment variables to use. If None, uses the current environment.
+
+    Notes
+    -----
+    The command's output is logged line by line at debug level as it arrives, so
+    a long-running model reports progress instead of going silent until it
+    exits. It is still returned in full, and still included in the exception
+    raised on failure.
     """
     logging.debug(f"Running command: {command}")
+    env = dict(os.environ if env is None else env)
+    # Python block-buffers stdout when it is not a terminal, which would hold a
+    # model's output until it exits and defeat the line-by-line logging below.
+    env.setdefault("PYTHONUNBUFFERED", "1")
     process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=working_directory, shell=True, env=env
+        command,
+        stdout=subprocess.PIPE,
+        # Merged so the two streams stay in the order the model produced them;
+        # they were concatenated into one string here anyway.
+        stderr=subprocess.STDOUT,
+        cwd=working_directory,
+        shell=True,
+        env=env,
+        text=True,
+        # Model output is not guaranteed to be valid UTF-8 (locale-dependent R
+        # warnings, for instance); a failed model must still produce a readable
+        # error message rather than a UnicodeDecodeError.
+        errors="replace",
+        bufsize=1,
     )
-    stdout, stderr = process.communicate()
-    # Model output is not guaranteed to be valid UTF-8 (locale-dependent R
-    # warnings, for instance); a failed model must still produce a readable
-    # error message rather than a UnicodeDecodeError.
-    output = stdout.decode(errors="replace") + "\n" + stderr.decode(errors="replace")
-    return_code = process.returncode
+    assert process.stdout is not None  # guaranteed by stdout=PIPE, but not to mypy
+    lines = []
+    for line in process.stdout:
+        logger.debug("[model] %s", line.rstrip())
+        lines.append(line)
+    output = "".join(lines)
+    return_code = process.wait()
 
     if return_code != 0:
         message = (

--- a/tests/runners/test_runners.py
+++ b/tests/runners/test_runners.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from unittest.mock import patch, MagicMock, ANY
 
@@ -44,6 +45,21 @@ def test_run_command():
     command = "echo 'test2' >&2"
     output = CommandLineRunner("./").run_command(command)
     assert "test2" in output, "Output from command not as expected, output is: " + output
+
+
+def test_run_command_streams_output_to_debug_log(caplog):
+    """Output is logged as it arrives, not only returned at the end."""
+    with caplog.at_level(logging.DEBUG, logger="chap_core.runners.command_line_runner"):
+        CommandLineRunner("./").run_command("echo 'first'; echo 'second' >&2; echo 'third'")
+
+    streamed = [r.getMessage() for r in caplog.records if r.getMessage().startswith("[model] ")]
+    assert streamed == ["[model] first", "[model] second", "[model] third"]
+
+
+def test_run_command_unbuffers_subprocess_python():
+    """PYTHONUNBUFFERED reaches the subprocess, so its output is not held back."""
+    output = CommandLineRunner("./").run_command('echo "$PYTHONUNBUFFERED"')
+    assert output.strip() == "1"
 
 
 def test_run_command_failure_reports_output_as_text():


### PR DESCRIPTION
## What

`run_command` captured a model's stdout and stderr with `communicate()`, which blocks until the process exits, and `ExternalModel.train()` / `.predict()` discard the returned string on success. A model that ran for minutes was silent the whole time, and anything it logged was visible only if it failed.

This reads the pipe line by line and logs each line at **debug** level with a `[model]` prefix, so a long backtest reports progress as it goes.

## Why it needs both halves

Streaming on this side is necessary but not sufficient: Python block-buffers stdout when it is not a terminal, so a model's log lines would still arrive in 4-8KB lumps, or all at once at exit. `PYTHONUNBUFFERED` is now set in the subprocess environment too. Either change alone leaves the output effectively unstreamed.

## Behaviour preserved

- The full output is still returned.
- It is still embedded in the `CommandLineException` raised on a non-zero exit, so failures read exactly as before.
- `stderr` is merged into `stdout` so the two streams keep the order the model produced them. They were concatenated into a single string here anyway, so nothing is lost; what improves is that interleaved output is no longer reordered into "all stdout, then all stderr".

## Scope

Every runner that shells out goes through `Runner._execute` and so through this function, which covers uv, conda and renv. The docker path captures its logs separately (`container.wait()` then `container.logs()`) and is unchanged; it would need the equivalent `stream=True` treatment as a follow-up.

Debug level rather than info is deliberate: a 12-split backtest at `n_iter 500` produces a lot of per-epoch output, which would bury chap's own logging if it were on by default. `--run-config.debug` opts in.

## Tests

- `test_run_command_streams_output_to_debug_log` asserts the lines are logged individually and in the order produced, across both streams.
- `test_run_command_unbuffers_subprocess_python` asserts `PYTHONUNBUFFERED` actually reaches the subprocess.

`make lint`, `make check` and `make test` all pass (1462 passed, 122 skipped, 4 xfailed, 1 xpassed).