### PR TITLE
feat(cli): install, update and uninstall marketplace models

### DIFF
--- a/chap_core/cli.py
+++ b/chap_core/cli.py
@@ -19,6 +19,7 @@ from chap_core.cli_endpoints import (
     explain,
     forecast,
     generate_modelcard,
+    marketplace,
     model,
     preference_learn,
     report,
@@ -42,6 +43,7 @@ evaluate.register_commands(app)
 explain.register_commands(app)
 forecast.register_commands(app)
 model.register_commands(app)
+marketplace.register_commands(app)
 preference_learn.register_commands(app)
 report.register_commands(app)
 utils.register_commands(app)

--- a/chap_core/cli_endpoints/marketplace.py
+++ b/chap_core/cli_endpoints/marketplace.py
@@ -1,0 +1,193 @@
+"""Install and update chapkit model services in a CHAP Compose deployment."""
+
+import logging
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Annotated
+
+from cyclopts import Parameter
+
+logger = logging.getLogger(__name__)
+
+ModelArg = Annotated[str, Parameter(help="Marketplace model ID, or a name for a custom chapkit model.")]
+ComposeArg = Annotated[
+    tuple[Path, ...],
+    Parameter(help="Base Compose files in deployment order. Defaults to compose.yml."),
+]
+ImageArg = Annotated[str | None, Parameter(help="Custom chapkit container image (requires --accept-risk).")]
+RiskArg = Annotated[
+    bool,
+    Parameter(help="Accept responsibility for running unreviewed custom model code and using its forecasts."),
+]
+LocalArg = Annotated[
+    bool, Parameter(help="Run a standalone local service for CLI evaluations (no CHAP server needed).")
+]
+PlatformArg = Annotated[str | None, Parameter(help="Container platform, e.g. linux/amd64 for R-INLA on Apple Silicon.")]
+
+
+def install(
+    model: ModelArg,
+    *,
+    compose_file: ComposeArg = (Path("compose.yml"),),
+    image: ImageArg = None,
+    accept_risk: RiskArg = False,
+    local: LocalArg = False,
+    platform: PlatformArg = None,
+) -> None:
+    """Install a marketplace model's verified stable version into CHAP.
+
+    Run from your CHAP Docker Compose deployment directory. Custom chapkit images
+    can be installed with --image IMAGE --accept-risk. Docker Compose is required.
+    """
+    _deploy(model, compose_file, image, accept_risk, local, platform, updating=False)
+
+
+def update(
+    model: ModelArg,
+    *,
+    compose_file: ComposeArg = (Path("compose.yml"),),
+    image: ImageArg = None,
+    accept_risk: RiskArg = False,
+    local: LocalArg = False,
+    platform: PlatformArg = None,
+) -> None:
+    """Update an installed model to the marketplace's verified stable version.
+
+    Custom models require --accept-risk again. Use --image to select a new custom
+    image, or omit it to pull the previously installed custom image reference.
+    """
+    _deploy(model, compose_file, image, accept_risk, local, platform, updating=True)
+
+
+def _deploy(
+    model: str,
+    compose_files: tuple[Path, ...],
+    image: str | None,
+    accept_risk: bool,
+    local: bool,
+    platform: str | None,
+    updating: bool,
+) -> None:
+    import httpx
+    import yaml
+
+    from chap_core.log_config import initialize_logging
+    from chap_core.services.model_marketplace import resolve_model
+
+    initialize_logging()
+    try:
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_]*", model):
+            raise ValueError("Model names must contain only lowercase letters, digits and underscores.")
+        if not local and (not compose_files or any(not path.is_file() for path in compose_files)):
+            raise ValueError("Run from a CHAP deployment directory or pass its base files with --compose-file.")
+        if local:
+            overlay = Path.home() / ".chap" / "compose.models.yml"
+            overlay.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            overlay = compose_files[0].resolve().parent / "compose.marketplace.yml"
+        config = yaml.safe_load(overlay.read_text()) if overlay.exists() else {"services": {}, "volumes": {}}
+        if not isinstance(config, dict) or not isinstance(config.get("services"), dict):
+            raise ValueError(f"Invalid model Compose file: {overlay}")
+        config.setdefault("volumes", {})
+        service_name = f"marketplace-{model.replace('_', '-')}"
+        services = config["services"]
+        previous = services.get(service_name)
+        if updating and previous is None:
+            raise ValueError(f"Model '{model}' is not installed. Run 'chap install {model}' first.")
+        if not updating and previous is not None:
+            raise ValueError(f"Model '{model}' is already installed. Run 'chap update {model}' instead.")
+
+        custom = image is not None or (previous is not None and previous.get("x-chap-custom", False))
+        if custom:
+            warning = (
+                "Custom models are not reviewed by the CHAP marketplace. You accept responsibility "
+                "for running their code, sharing data with them, and using their forecasts."
+            )
+            if not accept_risk:
+                raise ValueError(f"{warning} Pass --accept-risk to continue.")
+            logger.warning(warning)
+            image = image if image is not None else previous["image"]
+            if not image or any(character.isspace() for character in image) or "$" in image:
+                raise ValueError("Provide a valid custom container image reference.")
+            version = "custom"
+        else:
+            pin = resolve_model(model)
+            image, version = pin.image, pin.version
+
+        # Retain operator settings and the data volume when updating a model.
+        if previous is not None:
+            service = dict(previous)
+        else:
+            service = {
+                "restart": "unless-stopped",
+                "init": True,
+                "read_only": True,
+                "security_opt": ["no-new-privileges:true"],
+                "cap_drop": ["ALL"],
+                "environment": {
+                    "SERVICEKIT_ORCHESTRATOR_URL": "http://chap:8000/v2/services/$$register",
+                    "SERVICEKIT_REGISTRATION_KEY": "${SERVICEKIT_REGISTRATION_KEY:-}",
+                    "SERVICEKIT_HOST": service_name,
+                },
+                "volumes": [f"{service_name}-data:/app/data", {"type": "tmpfs", "target": "/tmp"}],
+                "depends_on": {"chap": {"condition": "service_healthy"}},
+            }
+            config["volumes"][f"{service_name}-data"] = {}
+            if local:
+                del service["environment"]
+                del service["depends_on"]
+                service["ports"] = [{"target": 8000, "host_ip": "127.0.0.1"}]
+        service.update({"image": image, "x-chap-custom": bool(custom), "x-chap-version": version})
+        if platform is not None:
+            service["platform"] = platform
+        services[service_name] = service
+
+        command = ["docker", "compose"]
+        if local:
+            command.extend(["--project-name", "chap-local-models"])
+        else:
+            for path in compose_files:
+                command.extend(["-f", str(path.resolve())])
+        # Publish the new pin only after Docker has pulled and started it successfully.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", dir=overlay.parent, delete=False) as temporary:
+            pending = Path(temporary.name)
+            yaml.safe_dump(config, temporary, sort_keys=False)
+        try:
+            pending_command = [*command, "-f", str(pending)]
+            subprocess.run([*pending_command, "pull", service_name], check=True)
+            up = ["up", "-d", "--no-deps", "--wait", "--wait-timeout", "120", service_name]
+            try:
+                subprocess.run([*pending_command, *up], check=True)
+            except subprocess.CalledProcessError:
+                if previous is not None:
+                    logger.warning("Update failed; restoring the previous model service.")
+                    subprocess.run([*command, "-f", str(overlay), *up], check=True)
+                else:
+                    subprocess.run([*pending_command, "rm", "--stop", "--force", service_name], check=True)
+                raise
+            pending.replace(overlay)
+        finally:
+            pending.unlink(missing_ok=True)
+        logger.info("%s %s (%s): %s", "Updated" if updating else "Installed", model, version, image)
+        if local:
+            result = subprocess.run(
+                [*command, "-f", str(overlay), "port", service_name, "8000"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            logger.info(
+                "Use with chap eval --model-name http://%s --run-config.is-chapkit-model", result.stdout.strip()
+            )
+        else:
+            logger.info("Include -f %s in future Docker Compose commands for this deployment.", overlay)
+    except (ValueError, OSError, httpx.HTTPError, yaml.YAMLError, subprocess.CalledProcessError) as error:
+        logger.error("%s", error)
+        raise SystemExit(1) from error
+
+
+def register_commands(app):
+    app.command()(install)
+    app.command()(update)

--- a/chap_core/services/model_marketplace.py
+++ b/chap_core/services/model_marketplace.py
@@ -1,0 +1,70 @@
+"""Resolve reviewed chapkit image pins from the CHAP model marketplace."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+import httpx
+import yaml
+from pydantic import BaseModel, Field
+
+REGISTRY_URL = "https://raw.githubusercontent.com/dhis2-chap/model-marketplace/main"
+
+
+class Registry(BaseModel):
+    schema_version: Literal[2]
+    models: list[str]
+
+
+class ModelVersion(BaseModel):
+    version: str
+    commit: str = Field(pattern=r"^[0-9a-f]{40}$")
+    image_tag: str = Field(pattern=r"^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$")
+    status: str
+
+
+class ModelSource(BaseModel):
+    image: str = Field(pattern=r"^[a-z0-9][a-z0-9._/\-]*$")
+
+
+class MarketplaceModel(BaseModel):
+    schema_version: Literal[2]
+    id: str
+    service_id: str
+    kind: Literal["model", "template"]
+    source: ModelSource
+    channels: dict[str, str]
+    versions: list[ModelVersion]
+
+
+@dataclass(frozen=True)
+class ModelPin:
+    image: str
+    version: str
+
+
+def resolve_model(model: str) -> ModelPin:
+    """Return only the registry's verified stable pin, never the latest channel."""
+    with httpx.Client(timeout=30, follow_redirects=True) as client:
+        response = client.get(f"{REGISTRY_URL}/registry.yaml")
+        response.raise_for_status()
+        registry = Registry.model_validate(yaml.safe_load(response.text))
+        model_file = f"models/{model}.yaml"
+        if model_file not in registry.models:
+            raise ValueError(f"Model '{model}' is not listed in the marketplace.")
+        response = client.get(f"{REGISTRY_URL}/{model_file}")
+        response.raise_for_status()
+        entry = MarketplaceModel.model_validate(yaml.safe_load(response.text))
+
+    if entry.id != model or entry.service_id != model.replace("_", "-"):
+        raise ValueError(f"Marketplace identity does not match '{model}'.")
+    if entry.kind != "model":
+        raise ValueError(f"'{model}' is a template for model authors, not a forecasting model.")
+    stable = entry.channels.get("stable")
+    version = next((version for version in entry.versions if version.version == stable), None)
+    if version is None or version.status != "verified":
+        raise ValueError(f"Model '{model}' has no verified stable version.")
+    if version.image_tag == "latest" or (
+        version.image_tag.startswith("sha-") and version.image_tag != f"sha-{version.commit[:7]}"
+    ):
+        raise ValueError(f"Model '{model}' has an invalid stable image pin.")
+    return ModelPin(image=f"{entry.source.image}:{version.image_tag}", version=version.version)

--- a/docs/chap-cli/chap-core-cli-setup.md
+++ b/docs/chap-cli/chap-core-cli-setup.md
@@ -14,6 +14,80 @@ uv tool install chap-core --python 3.13
 
 This installs the `chap` command-line tool globally, making it available from any directory.
 
+## Installing and updating models
+
+With Docker and Docker Compose v2 installed, use a model ID from the
+[CHAP Model Marketplace](https://github.com/dhis2-chap/model-marketplace).
+Both commands select `channels.stable` and require that version to be `verified`.
+They do not select the `latest` channel or an unreviewed version. Marketplace
+verification checks the model revision and chapkit service, not forecast quality.
+Templates for model authors cannot be installed as forecasting models.
+
+### For CLI evaluations
+
+```bash
+chap install chapkit_simple_multistep_model --local
+chap update chapkit_simple_multistep_model --local
+```
+
+The model runs in a background container with a port bound to `127.0.0.1`.
+The command prints its URL and an example `chap eval --model-name` argument;
+use that URL with your dataset. No CHAP server is needed. The port may change
+after an update, so use the URL printed by the latest command.
+Local model settings are stored in `~/.chap/compose.models.yml`.
+
+To stop local models:
+
+```bash
+docker compose -p chap-local-models -f ~/.chap/compose.models.yml stop
+```
+
+### For a CHAP deployment and the Modeling App
+
+From the directory containing your running CHAP Compose deployment:
+
+```bash
+chap install chapkit_simple_multistep_model
+chap update chapkit_simple_multistep_model
+```
+
+The service joins the deployment network and self-registers with CHAP, making it
+available to the Modeling App. CHAP must already be running. If your deployment
+uses different base files, supply them in the same order as when starting CHAP:
+
+```bash
+chap install chapkit_simple_multistep_model --compose-file compose.yml --compose-file compose.ghcr.yml
+```
+
+The commands create `compose.marketplace.yml` beside the first base file. Include
+it in subsequent Docker Compose commands, for example
+`docker compose -f compose.yml -f compose.marketplace.yml up -d`.
+Continue using your deployment's existing `COMPOSE_PROJECT_NAME` and environment
+settings. `SERVICEKIT_REGISTRATION_KEY` is forwarded when set in the environment
+or deployment's `.env` file.
+
+Only the selected model is pulled and started. Updates preserve its data volume
+and Compose settings; failed updates attempt to restart the previous image.
+Use `--platform linux/amd64` for models that only publish AMD64 images, such as
+R-INLA models on Apple Silicon. The platform is retained for subsequent updates.
+
+### Custom chapkit models
+
+Custom images must implement the chapkit service API on port 8000 and, for a CHAP
+deployment, support chapkit self-registration. They are not marketplace-reviewed.
+You accept responsibility for running their code, sharing data with them, and
+using their forecasts. Both installation and updates require `--accept-risk`:
+
+```bash
+chap install my_model --local --image ghcr.io/my-org/my-model:v1 --accept-risk
+chap update my_model --local --image ghcr.io/my-org/my-model:v2 --accept-risk
+```
+
+Omit `--local` to add the custom service to your CHAP deployment. Updating a custom
+model without `--image` pulls its existing image reference again; it never
+switches to a marketplace model automatically. Prefer version tags or digests
+for reproducible custom installations.
+
 ## Exercise
 
 ### Verify your installation

--- a/tests/cli_endpoints/conftest.py
+++ b/tests/cli_endpoints/conftest.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import yaml
+
+
+@pytest.fixture
+def marketplace_model():
+    # Registry schema v2 example from dhis2-chap/model-marketplace.
+    path = Path(__file__).parents[1] / "fixtures/marketplace/chapkit_simple_multistep_model.yaml"
+    return yaml.safe_load(path.read_text())
+
+
+@pytest.fixture
+def marketplace_http(monkeypatch, marketplace_model):
+    requests = []
+
+    def respond(request):
+        requests.append(str(request.url))
+        if request.url.path.endswith("/registry.yaml"):
+            content = {"schema_version": 2, "models": [f"models/{marketplace_model['id']}.yaml"]}
+        else:
+            content = marketplace_model
+        return httpx.Response(200, text=yaml.safe_dump(content))
+
+    client = httpx.Client
+    monkeypatch.setattr(httpx, "Client", lambda **kwargs: client(transport=httpx.MockTransport(respond), **kwargs))
+    return requests
+
+
+@pytest.fixture
+def model_deployment(tmp_path, monkeypatch, mocker):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services:\n  chap:\n    image: chap:test\n")
+    deployments = []
+
+    def run(command, **kwargs):
+        overlay = [Path(command[index + 1]) for index, value in enumerate(command) if value == "-f"][-1]
+        deployments.append(yaml.safe_load(overlay.read_text()))
+        return SimpleNamespace(stdout="127.0.0.1:54321\n")
+
+    runner = mocker.patch("chap_core.cli_endpoints.marketplace.subprocess.run", side_effect=run)
+    return SimpleNamespace(
+        overlay=tmp_path / "compose.marketplace.yml",
+        local_overlay=tmp_path / ".chap/compose.models.yml",
+        runner=runner,
+        deployments=deployments,
+    )

--- a/tests/cli_endpoints/test_marketplace.py
+++ b/tests/cli_endpoints/test_marketplace.py
@@ -1,0 +1,191 @@
+import logging
+import subprocess
+
+import pytest
+import yaml
+
+from chap_core.cli import app
+from chap_core.cli_endpoints.marketplace import install, update
+from chap_core.services.model_marketplace import resolve_model
+
+
+def test_resolves_stable_not_latest(marketplace_model, marketplace_http):
+    marketplace_model["channels"]["latest"] = "99.0.0"
+    marketplace_model["versions"].insert(
+        0, {**marketplace_model["versions"][0], "version": "99.0.0", "status": "unstable"}
+    )
+    pin = resolve_model(marketplace_model["id"])
+    assert pin.version == "0.1.0"
+    assert pin.image == f"{marketplace_model['source']['image']}:sha-57eeb78"
+    assert len(marketplace_http) == 2
+
+
+@pytest.mark.parametrize("status", ["unstable", "deprecated", "yanked"])
+def test_refuses_unverified_stable(marketplace_model, marketplace_http, status):
+    marketplace_model["versions"][0]["status"] = status
+    with pytest.raises(ValueError, match="no verified stable"):
+        resolve_model(marketplace_model["id"])
+
+
+def test_refuses_missing_stable(marketplace_model, marketplace_http):
+    marketplace_model["channels"]["stable"] = "missing"
+    with pytest.raises(ValueError, match="no verified stable"):
+        resolve_model(marketplace_model["id"])
+
+
+@pytest.mark.parametrize("tag", ["latest", "sha-0000000"])
+def test_refuses_invalid_pin(marketplace_model, marketplace_http, tag):
+    marketplace_model["versions"][0]["image_tag"] = tag
+    with pytest.raises(ValueError, match="invalid stable image pin"):
+        resolve_model(marketplace_model["id"])
+
+
+def test_refuses_template(marketplace_model, marketplace_http):
+    marketplace_model["kind"] = "template"
+    with pytest.raises(ValueError, match="template"):
+        resolve_model(marketplace_model["id"])
+
+
+def test_unknown_model_never_fetches_arbitrary_path(marketplace_http):
+    with pytest.raises(ValueError, match="not listed"):
+        resolve_model("../../custom")
+    assert len(marketplace_http) == 1
+
+
+def test_install_and_update_preserve_settings_and_data(marketplace_model, marketplace_http, model_deployment):
+    model = marketplace_model["id"]
+    app(["install", model], result_action="return_value")
+    installed = yaml.safe_load(model_deployment.overlay.read_text())
+    service_name = f"marketplace-{marketplace_model['service_id']}"
+    service = installed["services"][service_name]
+    assert service["image"].endswith(":sha-57eeb78")
+    assert service["environment"]["SERVICEKIT_ORCHESTRATOR_URL"].endswith("/$$register")
+    assert service["environment"]["SERVICEKIT_HOST"] == service_name
+    assert "ports" not in service
+    service["cpus"] = 2
+    model_deployment.overlay.write_text(yaml.safe_dump(installed))
+
+    marketplace_model["versions"][0].update(version="0.2.0", commit="a" * 40, image_tag="sha-aaaaaaa")
+    marketplace_model["channels"]["stable"] = "0.2.0"
+    app(["update", model], result_action="return_value")
+    updated = yaml.safe_load(model_deployment.overlay.read_text())
+    assert updated["services"][service_name]["image"].endswith(":sha-aaaaaaa")
+    assert updated["services"][service_name]["cpus"] == 2
+    assert updated["services"][service_name]["volumes"] == service["volumes"]
+    assert updated["volumes"] == installed["volumes"]
+    assert model_deployment.runner.call_count == 4
+    assert "--no-deps" in model_deployment.runner.call_args.args[0]
+
+
+def test_install_local_and_update_print_url(marketplace_model, marketplace_http, model_deployment, caplog):
+    model = marketplace_model["id"]
+    with caplog.at_level(logging.INFO):
+        app(["install", model, "--local"], result_action="return_value")
+        app(["update", model, "--local"], result_action="return_value")
+    config = yaml.safe_load(model_deployment.local_overlay.read_text())
+    service = next(iter(config["services"].values()))
+    assert service["ports"] == [{"target": 8000, "host_ip": "127.0.0.1"}]
+    assert "environment" not in service
+    assert "depends_on" not in service
+    assert "http://127.0.0.1:54321" in caplog.text
+    assert not model_deployment.overlay.exists()
+
+
+def test_custom_requires_risk_acceptance_each_time(model_deployment, caplog):
+    with pytest.raises(SystemExit):
+        install("custom", image="example/model:v1")
+    model_deployment.runner.assert_not_called()
+    assert "accept responsibility" in caplog.text
+    install("custom", image="example/model:v1", accept_risk=True)
+    model_deployment.runner.reset_mock()
+    with pytest.raises(SystemExit):
+        update("custom")
+    model_deployment.runner.assert_not_called()
+    update("custom", image="example/model:v2", accept_risk=True)
+    update("custom", accept_risk=True)
+    config = yaml.safe_load(model_deployment.overlay.read_text())
+    assert config["services"]["marketplace-custom"]["image"] == "example/model:v2"
+    assert config["services"]["marketplace-custom"]["x-chap-custom"] is True
+
+
+def test_install_existing_and_update_missing_fail(model_deployment):
+    with pytest.raises(SystemExit):
+        update("custom", image="example/model:v1", accept_risk=True)
+    model_deployment.runner.assert_not_called()
+    install("custom", image="example/model:v1", accept_risk=True)
+    model_deployment.runner.reset_mock()
+    with pytest.raises(SystemExit):
+        install("custom", image="example/model:v2", accept_risk=True)
+    model_deployment.runner.assert_not_called()
+
+
+@pytest.mark.parametrize("failure", [FileNotFoundError("docker"), subprocess.CalledProcessError(1, "docker")])
+def test_failed_pull_keeps_previous_install(model_deployment, failure):
+    install("custom", image="example/model:v1", accept_risk=True)
+    previous = model_deployment.overlay.read_text()
+    model_deployment.runner.side_effect = failure
+    with pytest.raises(SystemExit):
+        update("custom", image="example/model:v2", accept_risk=True)
+    assert model_deployment.overlay.read_text() == previous
+    assert sorted(p.name for p in model_deployment.overlay.parent.glob("*.yml")) == [
+        "compose.marketplace.yml",
+        "compose.yml",
+    ]
+
+
+def test_network_failure_does_not_deploy(model_deployment, mocker):
+    import httpx
+
+    mocker.patch("httpx.Client.get", side_effect=httpx.ConnectError("Marketplace unavailable"))
+    with pytest.raises(SystemExit):
+        install("chapkit_simple_multistep_model")
+    model_deployment.runner.assert_not_called()
+
+
+def test_failed_start_restores_previous_image(model_deployment):
+    install("custom", image="example/model:v1", accept_risk=True)
+    previous = model_deployment.overlay.read_text()
+    runner = model_deployment.runner.side_effect
+
+    def fail_start(command, **kwargs):
+        if "up" in command and str(model_deployment.overlay) not in command:
+            raise subprocess.CalledProcessError(1, command)
+        return runner(command, **kwargs)
+
+    model_deployment.runner.side_effect = fail_start
+    with pytest.raises(SystemExit):
+        update("custom", image="example/model:v2", accept_risk=True)
+    assert model_deployment.overlay.read_text() == previous
+    assert model_deployment.deployments[-1]["services"]["marketplace-custom"]["image"] == "example/model:v1"
+    assert "up" in model_deployment.runner.call_args.args[0]
+
+
+def test_multiple_compose_files_and_platform(model_deployment, tmp_path):
+    extra = tmp_path / "compose.extra.yml"
+    extra.write_text("services: {}\n")
+    app(
+        [
+            "install",
+            "custom",
+            "--image",
+            "example/model:v1",
+            "--accept-risk",
+            "--compose-file",
+            str(tmp_path / "compose.yml"),
+            "--compose-file",
+            str(extra),
+            "--platform",
+            "linux/amd64",
+        ],
+        result_action="return_value",
+    )
+    command = model_deployment.runner.call_args.args[0]
+    assert command[:6] == ["docker", "compose", "-f", str(tmp_path / "compose.yml"), "-f", str(extra)]
+    assert model_deployment.deployments[-1]["services"]["marketplace-custom"]["platform"] == "linux/amd64"
+
+
+def test_invalid_registry_never_deploys(marketplace_model, marketplace_http, model_deployment):
+    marketplace_model["schema_version"] = 999
+    with pytest.raises(SystemExit):
+        install(marketplace_model["id"])
+    model_deployment.runner.assert_not_called()

--- a/tests/fixtures/marketplace/chapkit_simple_multistep_model.yaml
+++ b/tests/fixtures/marketplace/chapkit_simple_multistep_model.yaml
@@ -1,0 +1,99 @@
+schema_version: 2
+
+id: chapkit_simple_multistep_model
+service_id: chapkit-simple-multistep-model
+display_name: Simple Multistep
+kind: model
+
+# The author's own chapkit AssessedStatus, copied from the service — not a
+# marketplace verdict. orange = shows promise on limited data, needs careful
+# evaluation. See models/README.md for the full scale.
+assessed_status: orange
+
+summary: >-
+  Recursive multi-step forecaster: a RandomForest wrapped in skpro's
+  ResidualDouble, fed per-location lag features and rolled forward one period
+  at a time. Takes climate covariates but declares none required, so it also
+  runs on lagged case history alone.
+
+source:
+  repository: https://github.com/chap-models/chapkit_simple_multistep_model
+  image: ghcr.io/chap-models/chapkit_simple_multistep_model
+  # Pure Python (scikit-learn + skpro) on the chapkit Python base. Multi-arch.
+  runtime_image: ghcr.io/dhis2-chap/chapkit-py
+
+attribution:
+  author: CHAP team
+  organization: HISP Centre, University of Oslo
+  contact: morten@dhis2.org
+
+# GitHub handles responsible for this listing — backfilled from the source
+# repository's contributors; corrections welcome by PR.
+maintainers:
+  - mortenoh
+  - knutdrand
+  - edvinstava
+
+compatibility:
+  period_types: [monthly]
+  min_prediction_periods: 1
+  max_prediction_periods: 100
+  requires_geo: false
+
+covariates:
+  required: []
+  defaults:
+    - rainfall
+    - mean_temperature
+    - mean_relative_humidity
+  allow_free_additional: true
+
+channels:
+  stable: 0.1.0
+  latest: 0.1.0
+
+versions:
+  - version: 0.1.0
+    commit: 57eeb78791083ee6939a7cc65455cce054ba6bf9
+    image_tag: sha-57eeb78
+    chapkit: ">=2.0.0,<3"
+    status: verified
+    # Verified by the merge gate. Part of the chapkit 2.0.0 seed import.
+    verified_by: []
+    changelog: >-
+      First listed pin: the recursive multistep forecaster as a chapkit 2.0.0
+      service, with GIT_REVISION passed through to the published image.
+    notes: >-
+      Supersedes the MLproject-based knutdrand/mstl_multistep_model listing.
+      This is a different model — a RandomForest + skpro recursive
+      forecaster, not MSTL + ARIMA with a forest correction.
+
+configurations:
+  monthly_climate:
+    description: >-
+      Climate-driven configuration: the service's own default covariates and
+      hyperparameters, at the marketplace's reference three-period horizon
+      (the service itself defaults to twelve). Six target lags give the
+      one-step regressor half a year of history per location.
+    config:
+      prediction_periods: 3
+      n_target_lags: 6
+      n_samples: 100
+      rf_max_depth: 10
+      rf_min_samples_leaf: 5
+      additional_continuous_covariates:
+        - rainfall
+        - mean_temperature
+        - mean_relative_humidity
+  monthly_selfhistory:
+    description: >-
+      Covariate-free variant: lagged case history only. Deliberately a
+      weaker, differently-informed model — useful as a baseline and as an
+      ensemble member on datasets with no usable climate data.
+    config:
+      prediction_periods: 3
+      n_target_lags: 6
+      n_samples: 100
+      rf_max_depth: 10
+      rf_min_samples_leaf: 5
+      additional_continuous_covariates: []


### PR DESCRIPTION
Adds `chap install`, `chap update` and `chap uninstall` for chapkit models from the [model marketplace](https://github.com/dhis2-chap/model-marketplace).

## Decisions

- **Only verified stable versions install.** The `channels.stable` pin must have `status: verified`; `latest`, unverified versions and templates are rejected. A `sha-` tag must be a prefix of the pinned commit.
- **Unreviewed code needs `--accept-risk` every time.** Custom images (`--image`) and models from a non-default registry (`CHAP_MARKETPLACE_URL`) require it on both install and update, with a warning about running their code, sharing data and using forecasts.
- **Models live in a separate Compose overlay.** Deployments get `compose.marketplace.yml` next to the base file; `--local` uses `~/.chap/compose.models.yml` under its own project name and prints a `127.0.0.1` URL for `chap eval`. The overlay is only replaced after the pull and start succeed; a failed update restores the previous image.
- **Updates keep operator settings and data.** The previous service definition and data volume are reused. `DATABASE_URL` is pinned to the mounted volume on install and update so models whose `WORKDIR` is not `/app` start on the read-only filesystem. `--platform` is kept for later updates, and a failed pull suggests `--platform linux/amd64`.
- **Uninstall keeps data unless asked.** The container is removed and the service dropped from the overlay; the data volume stays unless `--delete-data` is passed. The overlay is deleted when the last model goes.

[CLIM-1085](https://dhis2.atlassian.net/browse/CLIM-1085)


[CLIM-1085]: https://dhis2.atlassian.net/browse/CLIM-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ