### PR TITLE
fix: record the train cutoff and honour n_retrain in dry runs

### DIFF
--- a/chap_core/cli_endpoints/evaluate.py
+++ b/chap_core/cli_endpoints/evaluate.py
@@ -298,6 +298,7 @@ def _run_eval(
                 train_set=train_set,
                 test_generator=test_generator,
                 n_test_sets=backtest_params.n_splits,
+                n_retrain=backtest_params.n_retrain,
             ):
                 pass
             return

--- a/chap_core/rest_api/db_worker_functions.py
+++ b/chap_core/rest_api/db_worker_functions.py
@@ -155,7 +155,9 @@ def run_backtest(
         n_test_sets=n_splits,
         n_retrain=n_retrain,
     )
-    last_train_period = dataset.period_range[-1]
+    # The last period the model was trained on, not the last period in the dataset:
+    # the tail of `dataset` is the held-out test window the splits forecast.
+    last_train_period = train_set.period_range[-1]
     evaluation = Evaluation.from_samples_with_truth(
         predictions_list, last_train_period, configured_model, info=info, specification=specification
     )

--- a/tests/integration/rest_api/test_db_endpoints.py
+++ b/tests/integration/rest_api/test_db_endpoints.py
@@ -38,6 +38,7 @@ from chap_core.rest_api.data_models import (
 from chap_core.rest_api.app import app
 from chap_core.spatio_temporal_data.converters import observations_to_dataset
 from chap_core.rest_api.db_worker_functions import harmonize_and_add_dataset, run_backtest
+from chap_core.time_period import TimePeriod
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -573,6 +574,20 @@ def _run(session, name, dataset_id, **params):
     return run_backtest(
         BacktestCreate(name=name, dataset_id=dataset_id, model_id="naive_model"), session=session, **params
     )
+
+
+def test_run_backtest_records_the_train_cutoff_not_the_dataset_end(p_seeded_engine):
+    """`last_train_period` is the end of the training window, so it must precede every
+    period forecast from it. Using the end of the full dataset instead puts the cutoff
+    after the held-out window and makes horizon distances come out wrong."""
+    with SessionWrapper(p_seeded_engine) as session:
+        dataset_id = session.session.exec(select(DataSet.id)).first()
+        backtest_id = _run(session, "cutoff", dataset_id, n_periods=3, n_splits=2, stride=1)
+        forecasts = session.session.get(Backtest, backtest_id).forecasts
+        assert forecasts
+        assert all(TimePeriod.parse(f.last_train_period) < TimePeriod.parse(f.period) for f in forecasts), (
+            "last_train_period must be before the forecast period"
+        )
 
 
 def test_backtests_with_the_same_parameters_share_one_specification(p_seeded_engine):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,12 +55,13 @@ def _make_fake_estimator(min_prediction_periods, max_prediction_periods):
     return estimator
 
 
-def _patched_eval_chain(fake_estimator, patch_filter=True):
+def _patched_eval_chain(fake_estimator, patch_filter=True, dataset=None):
     """Stack mocks for the parts of eval_cmd that aren't under test, returning
     the Evaluation mock so the caller can inspect ``Evaluation.create`` calls.
 
     By default the pre-backtest region filter is patched to a passthrough so the
     MagicMock dataset survives; tests exercising the filter pass ``patch_filter=False``.
+    Tests that need the backtest to actually run pass a real ``dataset``.
     """
     template_cm = MagicMock(name="ModelTemplate")
     template_cm.__enter__.return_value = template_cm
@@ -79,7 +80,7 @@ def _patched_eval_chain(fake_estimator, patch_filter=True):
     stack.enter_context(
         patch(
             "chap_core.cli_endpoints.evaluate.load_dataset_from_csv",
-            return_value=MagicMock(name="DataSet"),
+            return_value=MagicMock(name="DataSet") if dataset is None else dataset,
         )
     )
     if patch_filter:
@@ -107,6 +108,38 @@ def _patched_eval_chain(fake_estimator, patch_filter=True):
     eval_mock = stack.enter_context(patch("chap_core.assessment.evaluation.Evaluation"))
     eval_mock.create.return_value = MagicMock(name="EvaluationInstance")
     return stack, eval_mock
+
+
+def test_eval_cmd_dry_run_retrains_n_retrain_times(tmp_path, weekly_full_data):
+    """A dry run has to follow the same retrain schedule as the real run. Training once
+    when n_retrain is 2 leaves the retrain-on-historic-data path unexercised, which is
+    exactly the failure a dry run is supposed to surface before the real run."""
+    from chap_core.api_types import BacktestParams, RunConfig
+    from chap_core.predictor.naive_estimator import NaiveEstimator
+
+    class _CountingEstimator:
+        def __init__(self):
+            self.inner = NaiveEstimator()
+            self.train_calls = 0
+            self.model_information = _make_fake_estimator(None, None).model_information
+
+        def train(self, data):
+            self.train_calls += 1
+            return self.inner.train(data)
+
+    estimator = _CountingEstimator()
+    stack, _ = _patched_eval_chain(estimator, dataset=weekly_full_data)
+    with stack:
+        eval_cmd(
+            model_name="dummy",
+            dataset_csv="dummy.csv",
+            output_file=tmp_path / "out.nc",
+            backtest_params=BacktestParams(n_periods=3, n_splits=4, stride=1, n_retrain=2),
+            run_config=RunConfig(),
+            dry_run=True,
+        )
+
+    assert estimator.train_calls == 2
 
 
 def test_eval_cmd_raises_when_n_periods_below_min_prediction_periods(tmp_path):


### PR DESCRIPTION
Two bugs found while reviewing #554. Both predate that PR, which only brought them into view; both are still on master.

## `last_train_period` recorded the dataset end, not the train cutoff

`run_backtest` set `last_train_period = dataset.period_range[-1]`, but the tail of that dataset is precisely the held-out window the splits forecast. On a 20-period dataset with `n_periods=3, n_splits=2, stride=1` the splits forecast periods 16-19 while every `BacktestForecast` row was stamped with period 19 — a training cutoff *after* the periods predicted from it. `horizon_distance` in `Evaluation.to_flat` is derived from this field, so it came out wrong for every REST-created backtest.

`Evaluation.create` already uses `train_set.period_range[-1]`; the REST path now matches, so the two entry points agree.

## `chap eval --dry-run` ignored `n_retrain`

The dry-run branch called `backtest(...)` without `n_retrain`, so it always trained once regardless of `--backtest-params.n-retrain`. A dry run with `n_retrain=2` reported a clean smoke test having never touched the retrain-on-`historic_data` path the real run takes — which is the kind of failure a dry run exists to surface.

## Tests

Both tests fail on master and pass with the fix:

- `test_run_backtest_records_the_train_cutoff_not_the_dataset_end` asserts the invariant directly: `last_train_period` must precede every period forecast from it. On master it fails for every row.
- `test_eval_cmd_dry_run_retrains_n_retrain_times` counts `train` calls through a dry run with `n_retrain=2`; on master the count is 1.

Both reuse existing fixtures (`p_seeded_engine`, `weekly_full_data`) and the existing `_patched_eval_chain` helper, which gains an optional `dataset` argument so a test can run the backtest against real data instead of a `MagicMock`.

`make lint` and `make test` are green (1487 passed, 122 skipped, 4 xfailed, 1 xpassed).
