### PR TITLE
feat(thresholds): add geometric endemic channel strategy

### DIFF
--- a/chap_core/assessment/thresholds/__init__.py
+++ b/chap_core/assessment/thresholds/__init__.py
@@ -73,6 +73,7 @@ def list_threshold_strategies() -> list[dict]:
 
 def _discover_strategies():
     from chap_core.assessment.thresholds import (
+        geometric,
         percentile,
         seasonal,
     )

--- a/chap_core/assessment/thresholds/geometric.py
+++ b/chap_core/assessment/thresholds/geometric.py
@@ -1,0 +1,87 @@
+"""Geometric threshold strategy: the endemic channel on a log1p scale.
+
+Case counts are strongly right-skewed, so an arithmetic mean is pulled up by single
+epidemic years. This channel takes the mean and standard deviation of ``log1p(cases)``
+instead and back-transforms with ``expm1``, giving a multiplicative channel: each line is
+the geometric mean times the geometric standard deviation raised to the requested power.
+Working on a ``x + 1`` scale keeps zero counts, which a plain geometric mean cannot
+represent.
+
+The centre of the channel is the geometric mean, which AM-GM puts at or below the
+arithmetic mean for any non-constant history, so an epidemic year moves it far less. The
+*width* is a different matter and is not uniformly tighter than mean + k*std: the log-scale
+standard deviation is a relative spread, so on a short baseline a single extreme year can
+make the back-transformed band wider than the arithmetic one. With a longer baseline
+(roughly eight years or more for one 20x spike) the geometric band is the tighter of the
+two.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from chap_core.assessment.thresholds import threshold
+from chap_core.assessment.thresholds.base import ThresholdStrategyBase, align_seasonal_to_periods
+from chap_core.assessment.thresholds.params import GeometricParams
+from chap_core.time_period.vectorized import season_column
+
+
+def log_seasonal_stats(historical_observations: pd.DataFrame) -> tuple[str, pd.DataFrame]:
+    """Per-(location, season) mean and std of ``log1p(disease_cases)``.
+
+    Returns:
+        The season column name ("month" or "week") and a DataFrame with columns
+        ``[location, month|week, mean, std]``, both on the log1p scale.
+    """
+    df = historical_observations.assign(disease_cases=np.log1p(historical_observations["disease_cases"]))
+    season, buckets = season_column(df["time_period"])
+    df[season] = buckets
+    grouped = df.groupby(["location", season])["disease_cases"].agg(["mean", "std"]).reset_index()
+    return season, grouped
+
+
+def compute_geometric_thresholds(historical_observations: pd.DataFrame, k: float = 2.0) -> pd.DataFrame:
+    """Compute geometric (log1p) outbreak thresholds from historical observations.
+
+    Args:
+        historical_observations: DataFrame with columns [location, time_period, disease_cases]
+        k: Number of geometric standard deviations above the geometric mean (default 2.0).
+
+    Returns:
+        DataFrame with columns [location, month, threshold] for monthly data,
+        or [location, week, threshold] for weekly data.
+    """
+    season, stats = log_seasonal_stats(historical_observations)
+    stats["threshold"] = np.expm1(stats["mean"] + k * stats["std"])
+    return stats[["location", season, "threshold"]]
+
+
+@threshold(
+    "geometric",
+    "Seasonal geometric mean + k*geometric SD",
+    GeometricParams,
+    "Outbreak threshold as expm1(mean(log1p(cases)) + k*std(log1p(cases))) over historical same-month "
+    "(or same-week) values: the geometric mean times the geometric standard deviation to the power k. "
+    "Centred on the geometric mean, which a past epidemic year moves far less than the arithmetic mean, "
+    "and defined for zero counts. The band is multiplicative, so on a short baseline it can be wider than "
+    "mean + k*std.",
+)
+class GeometricThresholdStrategy(ThresholdStrategyBase[GeometricParams]):
+    """Registered strategy computing one line per requested std multiplier from shared log-scale stats."""
+
+    def compute(
+        self,
+        historical_observations: pd.DataFrame,
+        period_ids: list[str],
+        params: GeometricParams,
+    ) -> pd.DataFrame:
+        season, stats = log_seasonal_stats(historical_observations)
+        lines = []
+        for i, multiplier in enumerate(params.lines):
+            line = stats[["location", season]].copy()
+            line["line"] = i
+            line["threshold"] = np.expm1(stats["mean"] + multiplier * stats["std"])
+            lines.append(line)
+        per_season = pd.concat(lines, ignore_index=True)
+        return align_seasonal_to_periods(per_season, period_ids)

--- a/chap_core/assessment/thresholds/params.py
+++ b/chap_core/assessment/thresholds/params.py
@@ -51,6 +51,21 @@ class SeasonalParams(ThresholdParamsBase):
         return line_values(self.std_multiplier)
 
 
+class GeometricParams(ThresholdParamsBase):
+    """Parameters for the seasonal geometric mean + k*geometric SD strategy."""
+
+    type: Literal["geometric"]
+    std_multiplier: float | Annotated[list[float], Field(min_length=1)] = Field(
+        2.0,
+        description="Number of geometric standard deviations above the seasonal geometric mean, "
+        "applied on a log1p scale. A list produces one threshold line per entry.",
+    )
+
+    @property
+    def lines(self) -> list[float]:
+        return line_values(self.std_multiplier)
+
+
 class PercentileParams(ThresholdParamsBase):
     """Parameters for the seasonal percentile (WHO endemic channel) strategy."""
 
@@ -72,7 +87,7 @@ class PercentileParams(ThresholdParamsBase):
         return line_values(self.quantile)
 
 
-ThresholdParams = Annotated[SeasonalParams | PercentileParams, Field(discriminator="type")]
+ThresholdParams = Annotated[SeasonalParams | GeometricParams | PercentileParams, Field(discriminator="type")]
 
 
 def line_values(scalar_or_list: float | list[float]) -> list[float]:

--- a/docs/contributor/creating_custom_threshold_strategies.md
+++ b/docs/contributor/creating_custom_threshold_strategies.md
@@ -40,6 +40,24 @@ Each strategy:
 | `line` | int | Zero-based index into the requested line parameter list |
 | `threshold` | float | Computed threshold value |
 
+## Built-in strategies
+
+| Id | Line parameter | Threshold |
+|----|----------------|-----------|
+| `seasonal` | `std_multiplier` (2.0) | `mean + k*std` of historical same-season values |
+| `geometric` | `std_multiplier` (2.0) | `expm1(mean(log1p(x)) + k*std(log1p(x)))` — the geometric mean times the geometric standard deviation to the power k, on a `x + 1` scale so zero counts are kept |
+| `percentile` | `quantile` (0.75) | percentile of historical same-season values over a baseline window of complete years |
+
+All three bucket the history by season — month-of-year for monthly data, week-of-year for
+weekly data — and all accept their line parameter as a list to return several lines at once.
+
+Picking between them comes down to how the baseline should treat a past epidemic year.
+`seasonal` lets it pull the line up through both the mean and the standard deviation.
+`percentile` is an order statistic over the data as they are, so the epidemic shifts the line
+only as far as its rank. `geometric` is centred on the geometric mean, which AM-GM keeps at or
+below the arithmetic mean, though its band is multiplicative and on a short baseline can come
+out wider than `seasonal`'s.
+
 ## Writing a strategy
 
 Declare a params model with a `type` literal matching the strategy id, subclass
@@ -107,6 +125,7 @@ imported. For Chap to discover the strategy at startup, import your module in
 ```python
 def _discover_strategies():
     from chap_core.assessment.thresholds import (  # noqa: F401
+        geometric,
         historical_percentile,
         percentile,
         seasonal,

--- a/tests/integration/rest_api/conftest.py
+++ b/tests/integration/rest_api/conftest.py
@@ -89,6 +89,17 @@ def endemic_channel_observations() -> pd.DataFrame:
 
 
 @pytest.fixture
+def endemic_channel_observations_with_epidemic(endemic_channel_observations) -> pd.DataFrame:
+    """The endemic channel data with one epidemic January, for separating robust from mean-based channels."""
+    epidemic = endemic_channel_observations["time_period"] == "2021-01"
+    return endemic_channel_observations.assign(
+        disease_cases=endemic_channel_observations["disease_cases"].where(
+            ~epidemic, endemic_channel_observations["disease_cases"] * 20
+        )
+    )
+
+
+@pytest.fixture
 def endemic_channel_observations_partial_year(endemic_channel_observations) -> pd.DataFrame:
     """The endemic channel data plus an in-progress final year with only January and February."""
     partial = endemic_channel_observations[endemic_channel_observations["time_period"].isin(["2022-01", "2022-02"])]

--- a/tests/integration/rest_api/test_from_seeded_engine.py
+++ b/tests/integration/rest_api/test_from_seeded_engine.py
@@ -121,7 +121,7 @@ def test_backtest_plot(override_session, tmp_path):
 def test_threshold_strategies_discovery(override_session):
     strategies = client.get_json("/v1/analytics/thresholds/strategies")
     ids = {s["id"] for s in strategies}
-    assert {"seasonal", "percentile"}.issubset(ids)
+    assert {"seasonal", "percentile", "geometric"}.issubset(ids)
     seasonal = next(s for s in strategies if s["id"] == "seasonal")
     assert seasonal["displayName"]
     assert seasonal["description"]
@@ -135,7 +135,7 @@ def test_threshold_params_schema_is_discriminated_union():
         assert "oneOf" in params, params
         assert params["discriminator"]["propertyName"] == "type"
         mapping = params["discriminator"]["mapping"]
-        assert set(mapping) == {"seasonal", "percentile"}
+        assert set(mapping) == {"seasonal", "percentile", "geometric"}
         # the discriminator must be required, or generated clients get `type?: string` and cannot narrow the union
         for ref in mapping.values():
             member = schema["components"]["schemas"][ref.rsplit("/", 1)[-1]]
@@ -167,6 +167,26 @@ def test_compute_thresholds(override_session):
     assert {e["period"] for e in entries} == {"2023-01", "2023-02"}
     assert {e["location"] for e in entries} == {"loc_1", "loc_2", "loc_3"}
     assert all(len(e["values"]) == 1 and e["values"][0] is not None for e in entries)
+
+
+@pytest.mark.parametrize(
+    "params, expected_lines",
+    [
+        ({"type": "geometric"}, [2.0]),
+        ({"type": "geometric", "stdMultiplier": [1.0, 2.0]}, [1.0, 2.0]),
+    ],
+)
+def test_compute_thresholds_geometric(override_session, params, expected_lines):
+    body = {"dataset_id": 1, "period_ids": ["2023-01"], "params": params}
+    response = client.post("/v1/analytics/thresholds", json=body)
+    assert response.status_code == 200, response.json()
+    result = response.json()
+    assert result["lines"] == expected_lines
+    entries = result["entries"]
+    assert {e["location"] for e in entries} == {"loc_1", "loc_2", "loc_3"}
+    for entry in entries:
+        assert len(entry["values"]) == len(expected_lines)
+        assert all(v is not None for v in entry["values"])
 
 
 def test_compute_thresholds_multi_line(override_session):

--- a/tests/integration/rest_api/test_threshold_strategies.py
+++ b/tests/integration/rest_api/test_threshold_strategies.py
@@ -1,7 +1,8 @@
-"""Tests for the threshold strategy registry and the seasonal and percentile strategies."""
+"""Tests for the threshold strategy registry and the built-in endemic channel strategies."""
 
 from typing import get_args
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -12,7 +13,13 @@ from chap_core.assessment.thresholds import (
     threshold,
 )
 from chap_core.assessment.thresholds.base import ThresholdStrategyBase
-from chap_core.assessment.thresholds.params import PercentileParams, SeasonalParams, ThresholdParams
+from chap_core.assessment.thresholds.geometric import compute_geometric_thresholds
+from chap_core.assessment.thresholds.params import (
+    GeometricParams,
+    PercentileParams,
+    SeasonalParams,
+    ThresholdParams,
+)
 from chap_core.assessment.thresholds.seasonal import compute_seasonal_thresholds
 from chap_core.spatio_temporal_data.converters import observations_to_dataframe
 
@@ -31,7 +38,7 @@ def _strategy(strategy_id):
 
 def test_strategies_are_registered():
     ids = {s["id"] for s in list_threshold_strategies()}
-    assert {"seasonal", "percentile"}.issubset(ids)
+    assert {"seasonal", "percentile", "geometric"}.issubset(ids)
 
 
 def test_unknown_strategy_returns_none():
@@ -247,3 +254,93 @@ def test_percentile_params_validation():
         PercentileParams(type="percentile", quantile=[])
     with pytest.raises(ValueError):
         PercentileParams(type="percentile", baseline_years=0)
+
+
+def test_geometric_strategy_shape(dataset_observations, org_units):
+    df = _disease_cases_df(dataset_observations)
+    period_ids = ["2023-01", "2023-02"]
+    result = _strategy("geometric").compute(df, period_ids, GeometricParams(type="geometric"))
+    assert set(result.columns) == {"period_id", "location", "line", "threshold"}
+    assert len(result) == len(period_ids) * len(org_units)
+    assert set(result["period_id"]) == set(period_ids)
+    assert set(result["location"]) == set(org_units)
+    assert set(result["line"]) == {0}
+
+
+def test_geometric_strategy_weekly(dataset_observations_weekly, org_units):
+    df = _disease_cases_df(dataset_observations_weekly)
+    period_ids = ["2023W01", "2023W02"]
+    result = _strategy("geometric").compute(df, period_ids, GeometricParams(type="geometric"))
+    assert len(result) == len(period_ids) * len(org_units)
+    assert result["threshold"].notna().all()
+
+
+def test_geometric_strategy_frequency_mismatch_raises(dataset_observations_weekly):
+    df = _disease_cases_df(dataset_observations_weekly)
+    with pytest.raises(ValueError, match="frequency"):
+        _strategy("geometric").compute(df, ["2023-01"], GeometricParams(type="geometric"))
+
+
+def test_geometric_strategy_values(endemic_channel_observations):
+    result = _strategy("geometric").compute(
+        endemic_channel_observations, ["2023-01"], GeometricParams(type="geometric")
+    )
+    january = endemic_channel_observations[endemic_channel_observations["time_period"].str.endswith("-01")]
+    for row in result.itertuples():
+        logged = np.log1p(january[january["location"] == row.location]["disease_cases"])
+        expected = np.expm1(logged.mean() + 2.0 * logged.std(ddof=1))
+        assert row.threshold == pytest.approx(expected)
+
+
+def test_geometric_strategy_parity_with_compute_geometric_thresholds(endemic_channel_observations):
+    result = _strategy("geometric").compute(
+        endemic_channel_observations, ["2023-01"], GeometricParams(type="geometric")
+    )
+    per_month = compute_geometric_thresholds(endemic_channel_observations)
+    january = per_month[per_month["month"] == 1]
+    for row in result.itertuples():
+        assert row.threshold == january[january["location"] == row.location]["threshold"].iloc[0]
+
+
+def test_geometric_strategy_handles_zero_counts(endemic_channel_observations):
+    """log1p keeps zero counts, so an all-zero season gives a finite threshold of zero."""
+    zeroed = endemic_channel_observations.assign(disease_cases=0.0)
+    result = _strategy("geometric").compute(zeroed, ["2023-01"], GeometricParams(type="geometric"))
+    assert np.isfinite(result["threshold"]).all()
+    assert result["threshold"].eq(0.0).all()
+
+
+def test_geometric_centre_is_below_arithmetic_after_epidemic_year(endemic_channel_observations_with_epidemic):
+    """With no spread term the channel is the geometric mean, which AM-GM keeps below the arithmetic mean.
+
+    Only the centre is guaranteed to be lower. The k=2 band is not: the log-scale standard
+    deviation is a relative spread, so on this five-year baseline one epidemic January makes
+    the back-transformed band wider than mean + 2*std rather than tighter.
+    """
+    geometric = _strategy("geometric").compute(
+        endemic_channel_observations_with_epidemic, ["2023-01"], GeometricParams(type="geometric", std_multiplier=0.0)
+    )
+    arithmetic = _strategy("seasonal").compute(
+        endemic_channel_observations_with_epidemic, ["2023-01"], SeasonalParams(type="seasonal", std_multiplier=0.0)
+    )
+    assert (geometric.set_index("location")["threshold"] < arithmetic.set_index("location")["threshold"]).all()
+
+
+def test_geometric_strategy_multi_line(endemic_channel_observations):
+    result = _strategy("geometric").compute(
+        endemic_channel_observations, ["2023-01"], GeometricParams(type="geometric", std_multiplier=[1.0, 3.0])
+    )
+    assert set(result["line"]) == {0, 1}
+    for location in ("loc_1", "loc_2"):
+        rows = result[result["location"] == location].set_index("line")["threshold"]
+        assert rows[0] < rows[1]
+
+
+def test_geometric_params_lines_follow_request_order():
+    assert GeometricParams(type="geometric").lines == [2.0]
+    assert GeometricParams(type="geometric", std_multiplier=[3.0, 1.0]).lines == [3.0, 1.0]
+
+
+def test_geometric_params_reject_empty_line_list():
+    with pytest.raises(ValueError):
+        GeometricParams(type="geometric", std_multiplier=[])


### PR DESCRIPTION
## What

Adds a `geometric` endemic channel strategy alongside the existing `seasonal` and `percentile` ones:

```
threshold = expm1(mean(log1p(cases)) + k * std(log1p(cases)))
```

over historical same-month (or same-week) values — the geometric mean times the geometric standard deviation raised to the power `k`. `std_multiplier` takes a scalar or a list, so one request can return several lines.

## Why

Case counts are strongly right-skewed, and `seasonal`'s arithmetic mean is pulled up by single epidemic years. Working on a log scale centres the channel on the geometric mean instead, which AM-GM keeps at or below the arithmetic mean for any non-constant history.

Computing on `log1p`/`expm1` rather than a plain geometric mean is deliberate: it keeps zero counts, which a plain geometric mean cannot represent, and an all-zero season yields a finite threshold of 0 rather than dropping the rows.

## Caveat, stated in the strategy description

Only the *centre* is guaranteed lower than the arithmetic channel. The band is multiplicative, so the log-scale standard deviation is a relative spread, and on a short baseline a single extreme year can make the back-transformed band **wider** than `mean + k*std`:

| baseline (one 20x spike) | `seasonal` | `geometric` |
|---|---|---|
| n=5 | 2179 | **2652** (wider) |
| n=8 | 1681 | 1211 |
| n=20 | 1045 | 445 |

That matters because `percentile` defaults to a 5-year baseline, which is exactly where the effect reverses. The registry description, module docstring and contributor guide all say this, and the test asserts the guaranteed property (`k=0`, AM-GM) rather than the data-dependent inequality.

## Notes

- No endpoint changes — registration through `@threshold` plus membership in the `ThresholdParams` union is enough.
- Contributor guide gains a built-in strategy table covering all three strategies and when to reach for each.
- An earlier revision of this branch also added a `median_iqr` (Tukey fence) strategy; it was dropped as redundant next to `percentile`.

## Testing

- `make lint` clean (ruff, mypy, pyright)
- Full suite: 1501 passed, 122 skipped, 4 xfailed
- New tests cover values, parity with the module-level helper, zero counts, the AM-GM centre against an epidemic-year baseline, multi-line output, weekly data, frequency mismatch, and params validation, plus an end-to-end endpoint test
